### PR TITLE
[FEATURE] Activation d'une version (PIX-23865)

### DIFF
--- a/admin/app/adapters/certification-version.js
+++ b/admin/app/adapters/certification-version.js
@@ -3,16 +3,20 @@ import ApplicationAdapter from './application';
 export default class CertificationVersionAdapter extends ApplicationAdapter {
   updateRecord(store, type, snapshot) {
     const certificationVersionId = snapshot.id;
+    const url = `${this.host}/${this.namespace}/certification-versions/${certificationVersionId}`;
 
-    let url = `${this.host}/${this.namespace}/certification-versions/${certificationVersionId}`;
+    if (snapshot.adapterOptions?.activate) {
+      return this.ajax(`${url}/activation`, 'PATCH');
+    }
 
+    let patchUrl = url;
     const changedAttributeKeys = Object.keys(snapshot.changedAttributes());
     if (changedAttributeKeys.length === 1 && changedAttributeKeys.at(0) === 'comments') {
-      url += '/comments';
+      patchUrl += '/comments';
     }
 
     const data = this.serialize(snapshot, { includeId: true });
-    return this.ajax(url, 'PATCH', { data });
+    return this.ajax(patchUrl, 'PATCH', { data });
   }
 
   createRecord(store, type, snapshot) {

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
@@ -1,4 +1,3 @@
-import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -12,10 +11,6 @@ export default class GlobalScoringForm extends Component {
   @service pixToast;
   @service intl;
 
-  get hasError() {
-    return this.globalScoringConfiguration.some(({ bounds }) => bounds.max <= bounds.min);
-  }
-
   get globalScoringConfiguration() {
     const savedConfiguration = this.args.draftVersion.globalScoringConfiguration;
     return savedConfiguration?.length
@@ -25,25 +20,6 @@ export default class GlobalScoringForm extends Component {
 
   get activeVersionConfiguration() {
     return this.args.activeVersion?.globalScoringConfiguration ?? [];
-  }
-
-  @action
-  async saveCapacityByMesh(event) {
-    event.preventDefault();
-    if (this.hasError) return;
-
-    this.args.draftVersion.globalScoringConfiguration = this.globalScoringConfiguration;
-
-    try {
-      await this.args.draftVersion.save();
-      this.pixToast.sendSuccessNotification({
-        message: this.intl.t(
-          'components.certification-frameworks.certification-framework.versions.scoring.success-notification',
-        ),
-      });
-    } catch (error) {
-      this.pixToast.sendErrorNotification({ message: error.errors?.[0].detail });
-    }
   }
 
   @action
@@ -89,7 +65,7 @@ export default class GlobalScoringForm extends Component {
       class="versions-scoring"
       @title={{t "components.certification-frameworks.certification-framework.versions.scoring.title"}}
     >
-      <form id="version-scoring-form" class="versions-scoring__form" {{on "submit" this.saveCapacityByMesh}}>
+      <form id="version-scoring-form" class="versions-scoring__form">
         {{#each this.globalScoringConfiguration as |mesh|}}
           <h3>
 
@@ -100,7 +76,7 @@ export default class GlobalScoringForm extends Component {
           <section>
             <PixInput
               type="number"
-              step="0.01"
+              step="0.0000000001"
               readonly={{this.isNotFirstRow mesh.meshLevel}}
               required={{this.isFirstRow mesh.meshLevel}}
               @requiredLabel={{if (this.isFirstRow mesh.meshLevel) (t "common.forms.mandatory") false}}
@@ -115,7 +91,7 @@ export default class GlobalScoringForm extends Component {
 
             <PixInput
               type="number"
-              step="0.01"
+              step="0.0000000001"
               required={{this.isFirstRow mesh.meshLevel}}
               @requiredLabel={{if (this.isFirstRow mesh.meshLevel) (t "common.forms.mandatory") false}}
               @errorMessage={{t
@@ -132,10 +108,6 @@ export default class GlobalScoringForm extends Component {
             </PixInput>
           </section>
         {{/each}}
-
-        <PixButton @type="submit" form="version-scoring-form" @isDisabled={{this.hasError}} @variant="primary-bis">
-          {{t "components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button"}}
-        </PixButton>
       </form>
     </Card>
   </template>

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
@@ -1,0 +1,42 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class VersionController extends Controller {
+  @service pixToast;
+  @service intl;
+  @service router;
+  @service store;
+
+  @action
+  async activateVersion(draftVersion, calibrationScoringConfiguration) {
+    try {
+      draftVersion.globalScoringConfiguration = draftVersion.globalScoringConfiguration?.length
+        ? [...draftVersion.globalScoringConfiguration]
+        : (calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
+      draftVersion.competencesScoringConfiguration =
+        calibrationScoringConfiguration?.competencesScoringConfiguration ?? [];
+      await draftVersion.save();
+      await draftVersion.save({ adapterOptions: { activate: true } });
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.activate-version.success',
+          {
+            versionId: draftVersion.id,
+          },
+        ),
+      });
+      await this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
+      this.router.refresh('authenticated.certification-frameworks.certification-framework');
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.activate-version.error',
+          {
+            versionId: draftVersion.id,
+          },
+        ),
+      });
+    }
+  }
+}

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
@@ -26,8 +26,8 @@ export default class VersionController extends Controller {
           },
         ),
       });
+      await this.store.findAll('certification-framework', { reload: true });
       await this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
-      this.router.refresh('authenticated.certification-frameworks.certification-framework');
     } catch {
       this.pixToast.sendErrorNotification({
         message: this.intl.t(

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -13,6 +13,14 @@ export default class ScoringController extends Controller {
     this.isConfirmationModalOpen = !this.isConfirmationModalOpen;
   }
 
+  get hasGlobalScoringError() {
+    const draftVersion = this.model.draftVersion;
+    const config = draftVersion.globalScoringConfiguration?.length
+      ? draftVersion.globalScoringConfiguration
+      : (this.model.calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
+    return config.some(({ bounds }) => bounds.max <= bounds.min);
+  }
+
   @action
   activateVersion() {
     return this.versionController.activateVersion(this.model.draftVersion, this.model.calibrationScoringConfiguration);

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -1,0 +1,20 @@
+import Controller from '@ember/controller';
+import { inject as controller } from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ScoringController extends Controller {
+  @controller('authenticated.certification-frameworks.certification-framework.versions.version')
+  versionController;
+  @tracked isConfirmationModalOpen = false;
+
+  @action
+  toggleConfirmationModal() {
+    this.isConfirmationModalOpen = !this.isConfirmationModalOpen;
+  }
+
+  @action
+  activateVersion() {
+    return this.versionController.activateVersion(this.model.draftVersion, this.model.calibrationScoringConfiguration);
+  }
+}

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -21,7 +21,12 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
     <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
       {{t "common.actions.cancel"}}
     </PixButtonLink>
-    <PixButton id="activate-version" @variant="primary-bis" @triggerAction={{@controller.toggleConfirmationModal}}>
+    <PixButton
+      id="activate-version"
+      @variant="primary-bis"
+      @isDisabled={{@controller.hasGlobalScoringError}}
+      @triggerAction={{@controller.toggleConfirmationModal}}
+    >
       {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
     </PixButton>
   </section>

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -1,4 +1,6 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { t } from 'ember-intl';
 import CompetencesScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-competences-scoring-form';
 import GlobalScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form';
@@ -19,5 +21,32 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
     <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
       {{t "common.actions.cancel"}}
     </PixButtonLink>
+    <PixButton id="activate-version" @variant="primary-bis" @triggerAction={{@controller.toggleConfirmationModal}}>
+      {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
+    </PixButton>
   </section>
+
+  {{#if @controller.isConfirmationModalOpen}}
+    <PixModal
+      @title={{t
+        "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.title"
+      }}
+      @showModal={{@controller.isConfirmationModalOpen}}
+      @onCloseButtonClick={{@controller.toggleConfirmationModal}}
+    >
+      <:content>
+        <p>{{t
+            "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.content"
+          }}</p>
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{@controller.toggleConfirmationModal}} @size="small" @variant="secondary">
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @triggerAction={{@controller.activateVersion}} @size="small">
+          {{t "common.actions.confirm"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  {{/if}}
 </template>

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -139,25 +139,6 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
           assert.dom(screen.getByDisplayValue('-4.67')).exists();
           assert.dom(screen.getByDisplayValue('0.6')).exists();
         });
-
-        test('persists the calibration bounds when submitting without editing them', async function (assert) {
-          let patchedAttributes;
-          server.patch('/admin/certification-versions/:id', (schema, request) => {
-            patchedAttributes = JSON.parse(request.requestBody).data.attributes;
-            return schema.certificationVersions.find(request.params.id);
-          });
-          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-
-          await visit(`/certification-frameworks/CORE/versions/14/scoring`);
-          await clickByName(
-            t('components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button'),
-          );
-
-          assert.deepEqual(patchedAttributes['global-scoring-configuration'], [
-            { bounds: { min: -4.67, max: -1.4 }, meshLevel: 0 },
-            { bounds: { min: -1.4, max: 0.6 }, meshLevel: 1 },
-          ]);
-        });
       });
     });
 

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form-test.gjs
@@ -1,13 +1,11 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click, fillIn } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import GlobalScoringForm from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest, { t } from '../../../../../helpers/setup-intl-rendering';
 
-const SUBMIT_BUTTON_LABEL =
-  'components.certification-frameworks.certification-framework.versions.scoring.capacity-submit-button';
 const LEVEL_KEY = 'components.certification-frameworks.certification-framework.versions.scoring.level';
 const CAPACITY_LABEL =
   'components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity';
@@ -229,80 +227,6 @@ module(
       });
     });
 
-    module('submit button state', function () {
-      test('it enables the submit button when all bounds are valid', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const draftVersion = store.createRecord('certification-version', {
-          id: '1',
-          status: 'draft',
-          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
-        });
-        const calibrationScoringConfiguration = createCalibrationProposal(store);
-
-        // when
-        const screen = await render(
-          <template>
-            <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) })).doesNotHaveAttribute('aria-disabled');
-      });
-
-      test('it disables the submit button when max is lower than min on page load', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const draftVersion = store.createRecord('certification-version', {
-          id: '1',
-          status: 'draft',
-          globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
-        });
-        const calibrationScoringConfiguration = createCalibrationProposal(store);
-
-        // when
-        const screen = await render(
-          <template>
-            <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) })).hasAttribute('aria-disabled');
-      });
-
-      test('it disables the submit button when max equals min on page load', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const draftVersion = store.createRecord('certification-version', {
-          id: '1',
-          status: 'draft',
-          globalScoringConfiguration: [{ bounds: { min: 3, max: 3 }, meshLevel: 0 }],
-        });
-        const calibrationScoringConfiguration = createCalibrationProposal(store);
-
-        // when
-        const screen = await render(
-          <template>
-            <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
-            />
-          </template>,
-        );
-
-        // then
-        assert.dom(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) })).hasAttribute('aria-disabled');
-      });
-    });
-
     module('error message', function () {
       test('it displays an error message when max is lower than min on page load', async function (assert) {
         // given
@@ -363,95 +287,6 @@ module(
 
         // then
         assert.dom(getBoundsInputs(screen).min[1]).hasValue('10');
-      });
-    });
-
-    module('save notifications', function () {
-      test('it shows a success notification when save succeeds', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const draftVersion = store.createRecord('certification-version', {
-          id: '1',
-          status: 'draft',
-          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
-        });
-        sinon.stub(draftVersion, 'save').resolves();
-        const calibrationScoringConfiguration = createCalibrationProposal(store);
-
-        const screen = await render(
-          <template>
-            <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
-            />
-          </template>,
-        );
-
-        // when
-        await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
-
-        // then
-        assert.ok(
-          pixToast.sendSuccessNotification.calledOnceWith({
-            message: t(
-              'components.certification-frameworks.certification-framework.versions.scoring.success-notification',
-            ),
-          }),
-        );
-      });
-
-      test('it shows an error notification when save fails', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const draftVersion = store.createRecord('certification-version', {
-          id: '1',
-          status: 'draft',
-          globalScoringConfiguration: [{ bounds: { min: 1, max: 8 }, meshLevel: 0 }],
-        });
-        sinon.stub(draftVersion, 'save').rejects({ errors: [{ detail: 'Erreur serveur' }] });
-        const calibrationScoringConfiguration = createCalibrationProposal(store);
-
-        const screen = await render(
-          <template>
-            <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
-            />
-          </template>,
-        );
-
-        // when
-        await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
-
-        // then
-        assert.ok(pixToast.sendErrorNotification.calledOnceWith({ message: 'Erreur serveur' }));
-      });
-
-      test('it does not save when bounds are invalid', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const draftVersion = store.createRecord('certification-version', {
-          id: '1',
-          status: 'draft',
-          globalScoringConfiguration: [{ bounds: { min: 5, max: 2 }, meshLevel: 0 }],
-        });
-        sinon.stub(draftVersion, 'save').resolves();
-        const calibrationScoringConfiguration = createCalibrationProposal(store);
-
-        const screen = await render(
-          <template>
-            <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
-            />
-          </template>,
-        );
-
-        // when
-        await click(screen.getByRole('button', { name: t(SUBMIT_BUTTON_LABEL) }));
-
-        // then
-        assert.ok(draftVersion.save.notCalled);
       });
     });
   },

--- a/admin/tests/unit/adapters/certification-version-test.js
+++ b/admin/tests/unit/adapters/certification-version-test.js
@@ -6,31 +6,61 @@ import sinon from 'sinon';
 module('Unit | Adapters | certification-version', function (hooks) {
   setupTest(hooks);
 
-  test('should call PATCH with certification version id and serialized data', async function (assert) {
-    const adapter = this.owner.lookup('adapter:certification-version');
-    const snapshot = {
-      id: '456',
-      changedAttributes: sinon.stub().resolves([]),
-    };
-    const serializedData = {
-      data: {
-        type: 'certification-versions',
-        id: '456',
-        attributes: {
-          'challenges-configuration': {
-            maximumAssessmentLength: 40,
-          },
-        },
-      },
-    };
+  let adapter;
 
-    sinon.stub(adapter, 'serialize').returns(serializedData);
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:certification-version');
     sinon.stub(adapter, 'ajax').resolves({});
+  });
 
-    await adapter.updateRecord(null, null, snapshot);
+  module('#updateRecord', function () {
+    module('when no special adapterOptions', function () {
+      test('calls PATCH with serialized data on the base url', async function (assert) {
+        const serializedData = {
+          data: {
+            type: 'certification-versions',
+            id: '456',
+            attributes: { 'challenges-configuration': { maximumAssessmentLength: 40 } },
+          },
+        };
+        sinon.stub(adapter, 'serialize').returns(serializedData);
+        const snapshot = { id: '456', adapterOptions: {}, changedAttributes: sinon.stub().returns({}) };
 
-    const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-versions/456`;
-    sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH', { data: serializedData });
-    assert.ok(adapter);
+        await adapter.updateRecord(null, null, snapshot);
+
+        const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-versions/456`;
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH', { data: serializedData });
+        assert.ok(true);
+      });
+    });
+
+    module('when only the comments attribute has changed', function () {
+      test('calls PATCH on the /comments sub-route', async function (assert) {
+        sinon.stub(adapter, 'serialize').returns({});
+        const snapshot = {
+          id: '456',
+          adapterOptions: {},
+          changedAttributes: sinon.stub().returns({ comments: ['old', 'new'] }),
+        };
+
+        await adapter.updateRecord(null, null, snapshot);
+
+        const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-versions/456/comments`;
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH');
+        assert.ok(true);
+      });
+    });
+
+    module('when the activate adapterOption is set', function () {
+      test('calls PATCH on the /activation sub-route with no payload', async function (assert) {
+        const snapshot = { id: '456', adapterOptions: { activate: true } };
+
+        await adapter.updateRecord(null, null, snapshot);
+
+        const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-versions/456/activation`;
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH');
+        assert.ok(true);
+      });
+    });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
@@ -20,7 +20,9 @@ module(
       };
       controller.router = {
         transitionTo: sinon.stub().resolves(),
-        refresh: sinon.stub(),
+      };
+      controller.store = {
+        findAll: sinon.stub().resolves(),
       };
     });
 
@@ -48,7 +50,6 @@ module(
         };
 
         await controller.activateVersion(draftVersion, null);
-
         sinon.assert.calledOnce(controller.pixToast.sendSuccessNotification);
         sinon.assert.calledWith(
           controller.router.transitionTo,

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
@@ -1,0 +1,76 @@
+import setupIntlRenderingTest from 'pix-admin/tests/helpers/setup-intl-rendering';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Unit | Controller | authenticated/certification-frameworks/certification-framework/versions/version',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    let controller;
+
+    hooks.beforeEach(function () {
+      controller = this.owner.lookup(
+        'controller:authenticated/certification-frameworks/certification-framework/versions/version',
+      );
+
+      controller.pixToast = {
+        sendSuccessNotification: sinon.stub(),
+        sendErrorNotification: sinon.stub(),
+      };
+      controller.router = {
+        transitionTo: sinon.stub().resolves(),
+        refresh: sinon.stub(),
+      };
+    });
+
+    module('#activateVersion', function () {
+      test('saves the draft version data and activates the version', async function (assert) {
+        const draftVersion = {
+          id: 42,
+          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -2 } }],
+          competencesScoringConfiguration: null,
+          save: sinon.stub().resolves(),
+        };
+
+        await controller.activateVersion(draftVersion, null);
+
+        assert.strictEqual(draftVersion.save.callCount, 2);
+        sinon.assert.calledWith(draftVersion.save.secondCall, { adapterOptions: { activate: true } });
+      });
+
+      test('shows a success notification and redirects after activation', async function (assert) {
+        const draftVersion = {
+          id: 42,
+          globalScoringConfiguration: [],
+          competencesScoringConfiguration: null,
+          save: sinon.stub().resolves(),
+        };
+
+        await controller.activateVersion(draftVersion, null);
+
+        sinon.assert.calledOnce(controller.pixToast.sendSuccessNotification);
+        sinon.assert.calledWith(
+          controller.router.transitionTo,
+          'authenticated.certification-frameworks.certification-framework',
+        );
+        assert.ok(true);
+      });
+
+      test('shows an error notification when the save fails', async function (assert) {
+        const draftVersion = {
+          id: 42,
+          globalScoringConfiguration: [],
+          competencesScoringConfiguration: null,
+          save: sinon.stub().rejects(new Error('network error')),
+        };
+
+        await controller.activateVersion(draftVersion, null);
+
+        sinon.assert.calledOnce(controller.pixToast.sendErrorNotification);
+        sinon.assert.notCalled(controller.router.transitionTo);
+        assert.ok(true);
+      });
+    });
+  },
+);

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
@@ -32,6 +32,47 @@ module(
       });
     });
 
+    module('#hasGlobalScoringError', function () {
+      test('returns false when all bounds are valid', function (assert) {
+        controller.model = {
+          draftVersion: {
+            globalScoringConfiguration: [
+              { meshLevel: 0, bounds: { min: -4, max: -1 } },
+              { meshLevel: 1, bounds: { min: -1, max: 2 } },
+            ],
+          },
+          calibrationScoringConfiguration: null,
+        };
+
+        assert.false(controller.hasGlobalScoringError);
+      });
+
+      test('returns true when at least one bound has max <= min', function (assert) {
+        controller.model = {
+          draftVersion: {
+            globalScoringConfiguration: [
+              { meshLevel: 0, bounds: { min: -4, max: -1 } },
+              { meshLevel: 1, bounds: { min: 2, max: 1 } },
+            ],
+          },
+          calibrationScoringConfiguration: null,
+        };
+
+        assert.true(controller.hasGlobalScoringError);
+      });
+
+      test('falls back to calibrationScoringConfiguration when draftVersion has no configuration', function (assert) {
+        controller.model = {
+          draftVersion: { globalScoringConfiguration: null },
+          calibrationScoringConfiguration: {
+            globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 1, max: 0 } }],
+          },
+        };
+
+        assert.true(controller.hasGlobalScoringError);
+      });
+    });
+
     module('#activateVersion', function () {
       test('delegates to versionController.activateVersion with draftVersion and calibrationScoringConfiguration', function (assert) {
         const draftVersion = { id: 1 };

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
@@ -1,0 +1,51 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Unit | Controller | authenticated/certification-frameworks/certification-framework/versions/version/scoring',
+  function (hooks) {
+    setupTest(hooks);
+
+    let controller;
+
+    hooks.beforeEach(function () {
+      controller = this.owner.lookup(
+        'controller:authenticated/certification-frameworks/certification-framework/versions/version/scoring',
+      );
+    });
+
+    module('#toggleConfirmationModal', function () {
+      test('opens the modal when called once', function (assert) {
+        assert.false(controller.isConfirmationModalOpen);
+
+        controller.toggleConfirmationModal();
+
+        assert.true(controller.isConfirmationModalOpen);
+      });
+
+      test('closes the modal when called twice', function (assert) {
+        controller.toggleConfirmationModal();
+        controller.toggleConfirmationModal();
+
+        assert.false(controller.isConfirmationModalOpen);
+      });
+    });
+
+    module('#activateVersion', function () {
+      test('delegates to versionController.activateVersion with draftVersion and calibrationScoringConfiguration', function (assert) {
+        const draftVersion = { id: 1 };
+        const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
+        controller.model = { draftVersion, calibrationScoringConfiguration };
+
+        const activateVersionStub = sinon.stub();
+        controller.versionController = { activateVersion: activateVersionStub };
+
+        controller.activateVersion();
+
+        sinon.assert.calledWithExactly(activateVersionStub, draftVersion, calibrationScoringConfiguration);
+        assert.ok(true);
+      });
+    });
+  },
+);

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -645,7 +645,6 @@
           "page-title": "Creation of a new version of the certification in {scope} framework",
           "scoring": {
             "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
-            "capacity-submit-button": "Save capacities by mesh",
             "competences": {
               "level": "Level",
               "maximum-input-label": "Maximal capacity ",

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -579,6 +579,15 @@
           "status": "Status:"
         },
         "versions": {
+          "activate-version": {
+            "button-label": "Activate version",
+            "confirmation-modal": {
+              "content": "This action cannot be undone. Activating this version will cause the previous version to be archived. The scoring configurations will be saved, and the retrieval of calibrated challenges will be triggered.",
+              "title": "Are you sure you want to enable this version?"
+            },
+            "error": "An error occurred :  version {versionId} has not been activated.",
+            "success": "Version {versionId} is now active."
+          },
           "calibration": {
             "label-for-CALIBRATED_CHALLENGE_COUNT": "Count of calibrated challenges",
             "label-for-CALIBRATION_SCOPE": "Target scope",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -590,7 +590,7 @@
           "activate-version": {
             "button-label": "Activer la version",
             "confirmation-modal": {
-              "content": "Cette action est irreversible. L'activation de cette version va provoquer l'archivage de la version précédente. Les configurations de scoring vont être enregistrées et la récuppération des challenges calibrés va être déclenchée.",
+              "content": "Cette action est irreversible. L'activation de cette version va provoquer l'archivage de la version précédente. Les configurations de scoring vont être enregistrées et la récupération des challenges calibrés va être déclenchée.",
               "title": "Êtes-vous sûr·e de vouloir activer cette version ?"
             },
             "error": "Une erreur est survenue : la version {versionId} n'a pas pu être activée.",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -653,7 +653,6 @@
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
           "scoring": {
             "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
-            "capacity-submit-button": "Sauvegarder les capacités par mailles",
             "competences": {
               "level": "Niveau",
               "title": "Bornes de capacités par compétences"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -587,6 +587,15 @@
           "status": "Statut :"
         },
         "versions": {
+          "activate-version": {
+            "button-label": "Activer la version",
+            "confirmation-modal": {
+              "content": "Cette action est irreversible. L'activation de cette version va provoquer l'archivage de la version précédente. Les configurations de scoring vont être enregistrées et la récuppération des challenges calibrés va être déclenchée.",
+              "title": "Êtes-vous sûr·e de vouloir activer cette version ?"
+            },
+            "error": "Une erreur est survenue : la version {versionId} n'a pas pu être activée.",
+            "success": "La version {versionId} est maintenant active."
+          },
           "calibration": {
             "label-for-CALIBRATED_CHALLENGE_COUNT": "Nombre d'épreuves calibrées",
             "label-for-CALIBRATION_SCOPE": "Prévue pour le référentiel",

--- a/api/db/database-builder/factory/build-certification-version.js
+++ b/api/db/database-builder/factory/build-certification-version.js
@@ -144,6 +144,7 @@ export function buildCertificationVersion({
   competencesScoringConfiguration,
   challengesConfiguration,
   minimumAnswersRequiredToValidateACertification,
+  externalCalibrationId = null,
   status,
   comments,
 } = {}) {
@@ -159,6 +160,7 @@ export function buildCertificationVersion({
       competencesScoringConfiguration: JSON.stringify(competencesScoringConfiguration),
       challengesConfiguration: JSON.stringify(challengesConfiguration),
       minimumAnswersRequiredToValidateACertification,
+      externalCalibrationId,
       status,
       comments,
     },

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -68,6 +68,12 @@ async function getCalibrationScoringConfiguration(request, h) {
   return h.response(calibrationScoringConfigurationSerializer.serialize(calibrationScoringConfiguration)).code(200);
 }
 
+async function activateVersion(request, h) {
+  const id = request.params.certificationVersionId;
+  await usecases.activateVersion({ id });
+  return h.response().code(204);
+}
+
 async function getInfo(request) {
   const framework = request.params.framework;
 
@@ -79,6 +85,7 @@ async function getInfo(request) {
 }
 
 export const certificationVersionController = {
+  activateVersion,
   createDraft,
   getVersionById,
   deleteCertificationVersion,

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -137,7 +137,10 @@ async function register(server) {
         },
         handler: certificationVersionController.activateVersion,
         tags: ['api', 'admin'],
-        notes: ['Cette route est restreinte au SUPER ADMIN', "Elle permet d'activer une version en cours d'édition"],
+        notes: [
+          'Cette route est restreinte au rôle SUPER ADMIN',
+          "Elle permet d'activer une version en cours d'édition",
+        ],
       },
     },
     {

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -118,6 +118,30 @@ async function register(server) {
     },
     {
       method: 'PATCH',
+      path: '/api/admin/certification-versions/{certificationVersionId}/activation',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationVersionId: identifiersType.certificationVersionId,
+          }),
+        },
+        handler: certificationVersionController.activateVersion,
+        tags: ['api', 'admin'],
+        notes: ['Cette route est restreinte au SUPER ADMIN', "Elle permet d'activer une version en cours d'édition"],
+      },
+    },
+    {
+      method: 'PATCH',
       path: '/api/admin/certification-versions/{certificationVersionId}/comments',
       config: {
         pre: [

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -149,6 +149,18 @@ export class Version {
     return this.status === VERSION_STATUSES.DRAFT;
   }
 
+  activate(activationDate) {
+    if (!this.isDraft) throw new VersionNotDraftError();
+    this.status = VERSION_STATUSES.ACTIVE;
+    this.startDate = activationDate;
+    this.expirationDate = null;
+  }
+
+  archive(archivingDate) {
+    this.status = VERSION_STATUSES.ARCHIVED;
+    this.expirationDate = archivingDate;
+  }
+
   static buildDraftFromActiveVersion({ scope, version, tubeIds }) {
     const draftVersion = new Version({
       id: null,

--- a/api/src/certification/configuration/domain/models/Version.js
+++ b/api/src/certification/configuration/domain/models/Version.js
@@ -116,6 +116,7 @@ export class Version {
     enablePassageByAllCompetences,
     externalCalibrationId,
     globalScoringConfiguration,
+    competencesScoringConfiguration,
   }) {
     if (!this.isDraft) {
       throw new VersionNotDraftError();
@@ -123,6 +124,7 @@ export class Version {
     this.startDate = startDate;
     this.assessmentDuration = assessmentDuration;
     this.minimumAnswersRequiredToValidateACertification = minimumAnswersRequiredForValidation;
+    this.competencesScoringConfiguration = competencesScoringConfiguration ?? this.competencesScoringConfiguration;
     this.challengesConfiguration = new FlashAssessmentAlgorithmConfiguration({
       maximumAssessmentLength,
       challengesBetweenSameCompetence,

--- a/api/src/certification/configuration/domain/usecases/activate-version.js
+++ b/api/src/certification/configuration/domain/usecases/activate-version.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { VersionNotDraftError } from '../errors.js';
 
 /**
@@ -15,10 +16,14 @@ export async function activateVersion({
 }) {
   const draftVersion = await versionRepository.getById({ id });
 
-  if (!draftVersion) throw new VersionNotDraftError();
+  if (!draftVersion) throw new NotFoundError(`No certification version found for id: ${id}`);
+
   if (!draftVersion.isDraft) throw new VersionNotDraftError();
 
   const calibration = await calibrationRepository.find(draftVersion.externalCalibrationId);
+  if (!calibration) {
+    throw new NotFoundError(`No certification version found for id: ${draftVersion.externalCalibrationId}`);
+  }
   await calibratedChallengesRepository.saveMany({
     calibratedChallenges: calibration.calibratedChallenges,
     versionId: draftVersion.id,

--- a/api/src/certification/configuration/domain/usecases/activate-version.js
+++ b/api/src/certification/configuration/domain/usecases/activate-version.js
@@ -1,0 +1,37 @@
+import { VersionNotDraftError } from '../errors.js';
+
+/**
+ * @param {object} params
+ * @param {number} params.id - ID de la version DRAFT à activer
+ * @param {object} params.versionRepository
+ * @param {object} params.calibrationRepository
+ * @param {object} params.calibratedChallengesRepository
+ */
+export async function activateVersion({
+  id,
+  versionRepository,
+  calibrationRepository,
+  calibratedChallengesRepository,
+}) {
+  const draftVersion = await versionRepository.getById({ id });
+
+  if (!draftVersion) throw new VersionNotDraftError();
+  if (!draftVersion.isDraft) throw new VersionNotDraftError();
+
+  const calibration = await calibrationRepository.find(draftVersion.externalCalibrationId);
+  await calibratedChallengesRepository.saveMany({
+    calibratedChallenges: calibration.calibratedChallenges,
+    versionId: draftVersion.id,
+  });
+
+  const now = new Date();
+
+  const activeVersion = await versionRepository.findActiveByScope({ scope: draftVersion.scope });
+  if (activeVersion) {
+    activeVersion.archive(now);
+    await versionRepository.save(activeVersion);
+  }
+
+  draftVersion.activate(now);
+  await versionRepository.save(draftVersion);
+}

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -3,6 +3,7 @@ import { injectDependencies } from '../../../../shared/infrastructure/utils/depe
 import * as targetProfileHistoryRepository from '../../../shared/infrastructure/repositories/target-profile-history-repository.js';
 import boundedContext from '../../dependencies.json' with { type: 'json' };
 import * as attachableTargetProfileRepository from '../../infrastructure/repositories/attachable-target-profiles-repository.js';
+import * as calibratedChallengesRepository from '../../infrastructure/repositories/calibrated-challenges-repository.js';
 import * as calibrationRepository from '../../infrastructure/repositories/calibration-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
 import * as certificationInfoRepository from '../../infrastructure/repositories/certification-info-repository.js';
@@ -13,6 +14,7 @@ import * as organizationRepository from '../../infrastructure/repositories/organ
 import * as ScoBlockedAccessDatesRepository from '../../infrastructure/repositories/sco-blocked-access-dates-repository.js';
 import * as versionDetailsRepository from '../../infrastructure/repositories/version-details-repository.js';
 import * as versionRepository from '../../infrastructure/repositories/version-repository.js';
+import { activateVersion } from './activate-version.js';
 import { attachBadges } from './attach-badges.js';
 import { createDraft } from './create-draft.js';
 import { deleteVersion } from './delete-version.js';
@@ -48,8 +50,10 @@ import { updateVersionComment } from './update-version-comment.js';
  * @typedef {versionRepository} VersionRepository
  * @typedef {versionDetailsRepository} VersionDetailsRepository
  * @typedef {calibrationRepository} CalibrationRepository
+ * @typedef {calibratedChallengesRepository} CalibratedChallengesRepository
  **/
 const dependencies = {
+  calibratedChallengesRepository,
   attachableTargetProfileRepository,
   centerRepository,
   ScoBlockedAccessDatesRepository,
@@ -66,6 +70,7 @@ const dependencies = {
 };
 
 const usecasesWithoutInjectedDependencies = {
+  activateVersion,
   attachBadges,
   createDraft,
   deleteVersion,

--- a/api/src/certification/configuration/domain/usecases/update-version.js
+++ b/api/src/certification/configuration/domain/usecases/update-version.js
@@ -19,6 +19,7 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @param {boolean} params.limitToOneQuestionPerTube
  * @param {boolean} params.enablePassageByAllCompetences
  * @param {object} params.globalScoringConfiguration
+ * @param {Array|null} params.competencesScoringConfiguration
  * @param {VersionRepository} params.versionRepository
  */
 export async function updateVersion({
@@ -36,6 +37,7 @@ export async function updateVersion({
   externalCalibrationId,
   versionRepository,
   globalScoringConfiguration,
+  competencesScoringConfiguration,
 }) {
   const version = await versionRepository.getById({ id });
 
@@ -56,6 +58,7 @@ export async function updateVersion({
     enablePassageByAllCompetences,
     externalCalibrationId,
     globalScoringConfiguration,
+    competencesScoringConfiguration,
   });
 
   return versionRepository.save(version);

--- a/api/src/certification/configuration/infrastructure/repositories/calibrated-challenges-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/calibrated-challenges-repository.js
@@ -1,0 +1,21 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+/**
+ * Persiste les challenges calibrés d'une calibration dans la table certification-frameworks-challenges.
+ *
+ * @param {object} params
+ * @param {import('../../domain/models/Calibration.js').CalibratedChallenge[]} params.calibratedChallenges
+ * @param {number} params.versionId
+ */
+export async function saveMany({ calibratedChallenges, versionId }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const rows = calibratedChallenges.map(({ challengeId, alpha, delta }) => ({
+    versionId,
+    challengeId,
+    discriminant: alpha,
+    difficulty: delta,
+  }));
+
+  await knexConn.batchInsert('certification-frameworks-challenges', rows);
+}

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -5,7 +5,7 @@
  */
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { FlashAssessmentAlgorithmConfiguration } from '../../../shared/domain/models/FlashAssessmentAlgorithmConfiguration.js';
-import { Version } from '../../domain/models/Version.js';
+import { Version, VERSION_STATUSES } from '../../domain/models/Version.js';
 
 /**
  * @returns {Promise<Version[]>}
@@ -39,6 +39,17 @@ export async function getById({ id }) {
 export async function findAllByScope({ scope }) {
   const dtosVersion = await buildBaseQuery().where({ scope });
   return dtosVersion.map(_toDomain);
+}
+
+/**
+ * @param {object} params
+ * @param {SCOPES} params.scope
+ * @returns {Promise<Version|null>}
+ */
+export async function findActiveByScope({ scope }) {
+  const versionData = await buildBaseQuery().where({ scope, status: VERSION_STATUSES.ACTIVE }).first();
+  if (!versionData) return null;
+  return _toDomain(versionData);
 }
 
 /**

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -25,6 +25,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
     server = await getServer();
     superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
     await databaseBuilder.commit();
+    await datamartBuilder.clean();
   });
 
   describe('GET /api/certifications/{framework}/info', function () {
@@ -923,6 +924,60 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
 
       // then
       expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('PATCH /api/admin/certification-versions/{certificationVersionId}/activation', function () {
+    it('activates the draft version, archives the active one, and persists calibrated challenges', async function () {
+      // given
+      const activeVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2024-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 10 })
+        .insertToDB({ databaseBuilder });
+      const draftVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 11, externalCalibrationId: 2 })
+        .insertToDB({ databaseBuilder });
+
+      await domainBuilder.certification.configuration
+        .calibrationBuilder()
+        .onScope({ scope: CALIBRATION_SCOPES.COEUR })
+        .withCalibratredChallenges([{ challengeId: 'challengeA', tubeId: 'tubeA' }])
+        .asValidated({ startedAt: new Date('2024-06-01') })
+        .withParameters({ id: 2 })
+        .insertToDB({ datamartBuilder });
+
+      databaseBuilder.factory.learningContent.build({
+        skills: [{ id: 'skillA', tubeId: 'tubeA' }],
+        challenges: [{ id: 'challengeA', skillId: 'skillA' }],
+      });
+
+      await databaseBuilder.commit();
+      await datamartBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/certification-versions/${draftVersion.id}/activation`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+
+      const activatedVersion = await knex('certification_versions').where({ id: draftVersion.id }).first();
+      expect(activatedVersion.status).to.equal(VERSION_STATUSES.ACTIVE);
+
+      const archivedVersion = await knex('certification_versions').where({ id: activeVersion.id }).first();
+      expect(archivedVersion.status).to.equal(VERSION_STATUSES.ARCHIVED);
+
+      const savedChallenges = await knex('certification-frameworks-challenges').where({ versionId: draftVersion.id });
+      expect(savedChallenges).to.have.lengthOf(1);
+      expect(savedChallenges[0].challengeId).to.equal('challengeA');
     });
   });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/calibrated-challenges-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/calibrated-challenges-repository_test.js
@@ -1,0 +1,35 @@
+import * as calibratedChallengesRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/calibrated-challenges-repository.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { expect } from '../../../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Configuration | Integration | Repository | CalibratedChallenges', function () {
+  describe('#saveMany', function () {
+    it('inserts all calibrated challenges for the given version id', async function () {
+      // given
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA', 'tubeB'], id: 1 })
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      const calibratedChallenges = [
+        { challengeId: 'chalA', tubeId: 'tubeA', alpha: 1.5, delta: -0.5 },
+        { challengeId: 'chalB', tubeId: 'tubeB', alpha: 2.1, delta: 0.3 },
+      ];
+
+      // when
+      await calibratedChallengesRepository.saveMany({ calibratedChallenges, versionId: version.id });
+
+      // then
+      const rows = await knex('certification-frameworks-challenges')
+        .where({ versionId: version.id })
+        .orderBy('challengeId');
+      expect(rows).to.have.lengthOf(2);
+      expect(rows[0]).to.include({ challengeId: 'chalA', discriminant: 1.5, difficulty: -0.5, versionId: version.id });
+      expect(rows[1]).to.include({ challengeId: 'chalB', discriminant: 2.1, difficulty: 0.3, versionId: version.id });
+    });
+  });
+});

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -395,4 +395,44 @@ describe('Certification | Configuration | Integration | Repository | Version', f
       expect(certificationVersionTubeIds).to.be.empty;
     });
   });
+
+  describe('#findActiveByScope', function () {
+    it('returns the active version for the given scope', async function () {
+      // given
+      const activeVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+        .insertToDB({ databaseBuilder });
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await versionRepository.findActiveByScope({ scope: SCOPES.CORE });
+
+      // then
+      expect(result.id).to.equal(activeVersion.id);
+      expect(result.status).to.equal('active');
+    });
+
+    it('returns null when there is no active version for the given scope', async function () {
+      // given
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await versionRepository.findActiveByScope({ scope: SCOPES.CORE });
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -371,7 +371,10 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/NOT_AN_ID/activation`);
+        const response = await httpTestServer.request(
+          'PATCH',
+          `/api/admin/certification-versions/NOT_AN_ID/activation`,
+        );
 
         // then
         expect(response.statusCode).to.equal(400);

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -324,4 +324,59 @@ describe('Unit | Certification | Configuration | Application | Router | certific
       sinon.assert.called(certificationVersionController.generateCalibrationReport);
     });
   });
+
+  describe('PATCH /api/admin/certification-versions/{certificationVersionId}/activation', function () {
+    context('when the user has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(certificationVersionController, 'activateVersion').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/activation`);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationVersionController.activateVersion);
+      });
+    });
+
+    context('when the user is super admin', function () {
+      it('should return 204 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon.stub(certificationVersionController, 'activateVersion').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/activation`);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        sinon.assert.called(certificationVersionController.activateVersion);
+      });
+    });
+
+    context('when the version id is not valid', function () {
+      it('should return 400 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon.stub(certificationVersionController, 'activateVersion').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/NOT_AN_ID/activation`);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        sinon.assert.notCalled(certificationVersionController.activateVersion);
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/domain/models/Version_test.js
+++ b/api/tests/certification/configuration/unit/domain/models/Version_test.js
@@ -223,6 +223,59 @@ describe('Certification | Configuration | Unit | Domain | Models | Version', fun
     });
   });
 
+  describe('#activate', function () {
+    context('when the version is a draft', function () {
+      it('changes the status to active and sets the startDate', function () {
+        // given
+        const activationDate = new Date('2025-09-01');
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+          .build();
+
+        // when
+        version.activate(activationDate);
+
+        // then
+        expect(version.status).to.equal('active');
+        expect(version.startDate).to.deep.equal(activationDate);
+        expect(version.expirationDate).to.be.null;
+      });
+    });
+
+    context('when the version is not a draft', function () {
+      it('throws a VersionNotDraftError', function () {
+        const version = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2024-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+          .build();
+
+        expect(() => version.activate(new Date())).to.throw(VersionNotDraftError);
+      });
+    });
+  });
+
+  describe('#archive', function () {
+    it('changes the status to archived and sets the expirationDate', function () {
+      // given
+      const archivingDate = new Date('2025-09-01');
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2024-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+        .build();
+
+      // when
+      version.archive(archivingDate);
+
+      // then
+      expect(version.status).to.equal('archived');
+      expect(version.expirationDate).to.deep.equal(archivingDate);
+    });
+  });
+
   describe('#update', function () {
     let baseVersionData, validUpdateData;
 

--- a/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
@@ -1,0 +1,155 @@
+import sinon from 'sinon';
+
+import { VersionNotDraftError } from '../../../../../../src/certification/configuration/domain/errors.js';
+import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
+import { activateVersion } from '../../../../../../src/certification/configuration/domain/usecases/activate-version.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { expect } from '../../../../../test-helper.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
+
+describe('Certification | Configuration | Unit | UseCase | activate-version', function () {
+  let versionRepository;
+  let calibrationRepository;
+  let calibratedChallengesRepository;
+
+  beforeEach(function () {
+    versionRepository = {
+      getById: sinon.stub(),
+      findActiveByScope: sinon.stub(),
+      save: sinon.stub(),
+    };
+    calibrationRepository = {
+      find: sinon.stub(),
+    };
+    calibratedChallengesRepository = {
+      saveMany: sinon.stub(),
+    };
+  });
+
+  context('when the version does not exist', function () {
+    it('throws a VersionNotDraftError', async function () {
+      // given
+      versionRepository.getById.resolves(null);
+
+      // when
+      const err = await catchErr(activateVersion)({
+        id: 1,
+        versionRepository,
+        calibrationRepository,
+        calibratedChallengesRepository,
+      });
+
+      // then
+      expect(err).to.be.instanceOf(VersionNotDraftError);
+    });
+  });
+
+  context('when the version is not a draft', function () {
+    it('throws a VersionNotDraftError', async function () {
+      // given
+      const activeVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive({ startDate: new Date('2024-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'] })
+        .build();
+      versionRepository.getById.resolves(activeVersion);
+
+      // when
+      const err = await catchErr(activateVersion)({
+        id: activeVersion.id,
+        versionRepository,
+        calibrationRepository,
+        calibratedChallengesRepository,
+      });
+
+      // then
+      expect(err).to.be.instanceOf(VersionNotDraftError);
+    });
+  });
+
+  context('when the version is a draft', function () {
+    it('fetches the calibration and persists the calibrated challenges', async function () {
+      // given
+      const calibratedChallenges = [{ challengeId: 'chalA', tubeId: 'tubeA', alpha: 1.5, delta: -0.5 }];
+      const calibration = { calibratedChallenges };
+      const draftVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 42, externalCalibrationId: 7 })
+        .build();
+      versionRepository.getById.resolves(draftVersion);
+      versionRepository.findActiveByScope.resolves(null);
+      versionRepository.save.resolves(draftVersion.id);
+      calibrationRepository.find.resolves(calibration);
+      calibratedChallengesRepository.saveMany.resolves();
+
+      // when
+      await activateVersion({ id: 42, versionRepository, calibrationRepository, calibratedChallengesRepository });
+
+      // then
+      sinon.assert.calledWithExactly(calibrationRepository.find, 7);
+      sinon.assert.calledWithExactly(calibratedChallengesRepository.saveMany, {
+        calibratedChallenges,
+        versionId: 42,
+      });
+    });
+
+    it('activates the draft version', async function () {
+      // given
+      const now = new Date('2025-09-01');
+      sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+      const draftVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'], id: 42, externalCalibrationId: 7 })
+        .build();
+      versionRepository.getById.resolves(draftVersion);
+      versionRepository.findActiveByScope.resolves(null);
+      versionRepository.save.resolves();
+      calibrationRepository.find.resolves({ calibratedChallenges: [] });
+      calibratedChallengesRepository.saveMany.resolves();
+
+      // when
+      await activateVersion({ id: 42, versionRepository, calibrationRepository, calibratedChallengesRepository });
+
+      // then
+      expect(draftVersion.status).to.equal(VERSION_STATUSES.ACTIVE);
+      expect(draftVersion.startDate).to.deep.equal(now);
+      sinon.assert.calledWithExactly(versionRepository.save, draftVersion);
+    });
+
+    context('when there is a currently active version for the same scope', function () {
+      it('archives it before activating the draft', async function () {
+        // given
+        const now = new Date('2025-09-01');
+        sinon.useFakeTimers({ now, toFake: ['Date'] });
+
+        const draftVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'], id: 42, externalCalibrationId: 7 })
+          .build();
+        const currentActiveVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asActive({ startDate: new Date('2024-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'], id: 10 })
+          .build();
+        versionRepository.getById.resolves(draftVersion);
+        versionRepository.findActiveByScope.resolves(currentActiveVersion);
+        versionRepository.save.resolves();
+        calibrationRepository.find.resolves({ calibratedChallenges: [] });
+        calibratedChallengesRepository.saveMany.resolves();
+
+        // when
+        await activateVersion({ id: 42, versionRepository, calibrationRepository, calibratedChallengesRepository });
+
+        // then
+        expect(currentActiveVersion.status).to.equal(VERSION_STATUSES.ARCHIVED);
+        expect(currentActiveVersion.expirationDate).to.deep.equal(now);
+        sinon.assert.calledWithExactly(versionRepository.save, currentActiveVersion);
+      });
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
@@ -4,6 +4,7 @@ import { VersionNotDraftError } from '../../../../../../src/certification/config
 import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { activateVersion } from '../../../../../../src/certification/configuration/domain/usecases/activate-version.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../../test-helper.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../../tooling/test-utils/error.js';
@@ -28,7 +29,7 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
   });
 
   context('when the version does not exist', function () {
-    it('throws a VersionNotDraftError', async function () {
+    it('throws a NotFoundError', async function () {
       // given
       versionRepository.getById.resolves(null);
 
@@ -41,7 +42,7 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
       });
 
       // then
-      expect(err).to.be.instanceOf(VersionNotDraftError);
+      expect(err).to.be.instanceOf(NotFoundError);
     });
   });
 
@@ -69,6 +70,26 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
   });
 
   context('when the version is a draft', function () {
+    context('when the calibration does not exist', function () {
+      it('throws a NotFoundError', async function () {
+        const draftVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-01-01') })
+          .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 42, externalCalibrationId: 7 })
+          .build();
+        versionRepository.getById.resolves(draftVersion);
+        calibrationRepository.find.resolves(null);
+
+        const err = await catchErr(activateVersion)({
+          id: 42,
+          versionRepository,
+          calibrationRepository,
+          calibratedChallengesRepository,
+        });
+
+        expect(err).to.be.instanceOf(NotFoundError);
+      });
+    });
     it('fetches the calibration and persists the calibrated challenges', async function () {
       // given
       const calibratedChallenges = [{ challengeId: 'chalA', tubeId: 'tubeA', alpha: 1.5, delta: -0.5 }];


### PR DESCRIPTION
## ☀️ Problème

La création d'une nouvelle version de référentiel était gérée manuellement en interne. Pour gagner en autonomie et en efficacité, on featurise ce processus directement depuis l'espace Admin.
On souhaite afficher les seuils de capacités par compétence récupérés de la calibration lors de la création d’une nouvelle version d’un référentiel.

## ⛱️ Proposition

Ajout d'un bouton "Activer la version"  à l'étape 4 de la création d'une version et de la route associée. 
Le bouton ouvre une modale. Après confirmation, on déclenche l'enregistrement des configuration de scoring, la récupération des challenges calibrés et le changement du statut et des dates de début/fin de la nouvelle version et de la précédente.

## 🧴 Remarques

à faire: bloquer le bouton en cas d'erreur dans le formulaire des compétences par mailles + enlever le bouton d'enregistrement

## 🏊 Pour tester

Activer une version
