### PR TITLE
[FEATURE] Écrire dans la table `users` lors de l’acceptation des CGUs certif (PIX-22563)

### DIFF
--- a/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
+++ b/api/src/legal-documents/domain/usecases/accept-legal-document-by-user-id.usecase.js
@@ -3,7 +3,7 @@ import { LegalDocumentService } from '../models/LegalDocumentService.js';
 import { LegalDocumentType } from '../models/LegalDocumentType.js';
 
 const { TOS } = LegalDocumentType.VALUES;
-const { PIX_APP } = LegalDocumentService.VALUES;
+const { PIX_APP, PIX_CERTIF } = LegalDocumentService.VALUES;
 
 /**
  * Accepts a legal document by user ID.
@@ -14,7 +14,7 @@ const { PIX_APP } = LegalDocumentService.VALUES;
  * @param {string} params.type - The type of the legal document.
  * @returns {Promise<void>} A promise that resolves when the operation is complete.
  */
-const acceptLegalDocumentByUserId = withTransaction(
+export const acceptLegalDocumentByUserId = withTransaction(
   async ({ userId, service, type, legalDocumentRepository, userAcceptanceRepository, userRepository, logger }) => {
     LegalDocumentType.assert(type);
     LegalDocumentService.assert(service);
@@ -22,6 +22,11 @@ const acceptLegalDocumentByUserId = withTransaction(
     // legacy document acceptance
     if (type === TOS && service === PIX_APP) {
       await userRepository.acceptLegacyPixAppTermsOfService(userId);
+    }
+
+    // legacy document acceptance
+    if (type === TOS && service === PIX_CERTIF) {
+      await userRepository.acceptLegacyPixCertifTermsOfService(userId);
     }
 
     const legalDocument = await legalDocumentRepository.findLastVersionByTypeAndService({ service, type });
@@ -42,5 +47,3 @@ const acceptLegalDocumentByUserId = withTransaction(
     await userAcceptanceRepository.create({ userId, legalDocumentVersionId: legalDocument.id });
   },
 );
-
-export { acceptLegalDocumentByUserId };

--- a/api/src/legal-documents/infrastructure/repositories/user.repository.js
+++ b/api/src/legal-documents/infrastructure/repositories/user.repository.js
@@ -37,3 +37,12 @@ export async function acceptLegacyPixAppTermsOfService(id) {
     cgu: true,
   });
 }
+
+export async function acceptLegacyPixCertifTermsOfService(id) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('users').where({ id }).update({
+    pixCertifTermsOfServiceAccepted: true,
+    lastPixCertifTermsOfServiceValidatedAt: knexConn.fn.now(),
+    updatedAt: knexConn.fn.now(),
+  });
+}

--- a/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
+++ b/api/tests/legal-documents/integration/domain/usecases/accept-legal-document-by-user-id.usecase.test.js
@@ -6,7 +6,7 @@ import { usecases } from '../../../../../src/legal-documents/domain/usecases/ind
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder, knex } from '../../../../tooling/databases.js';
 
-const { PIX_ORGA, PIX_APP } = LegalDocumentService.VALUES;
+const { PIX_APP, PIX_CERTIF, PIX_ORGA } = LegalDocumentService.VALUES;
 const { TOS } = LegalDocumentType.VALUES;
 
 describe('Integration | Legal documents | Domain | Use case | accept-legal-document-by-user-id', function () {
@@ -122,6 +122,31 @@ describe('Integration | Legal documents | Domain | Use case | accept-legal-docum
       expect(updatedUser.lastTermsOfServiceValidatedAt).to.exist;
       expect(updatedUser.cgu).to.be.true;
       expect(updatedUser.mustValidateTermsOfService).to.be.false;
+
+      // Verify the legal document acceptance was created
+      const userAcceptance = await knex('legal-document-version-user-acceptances')
+        .where('userId', user.id)
+        .where('legalDocumentVersionId', document.id)
+        .first();
+      expect(userAcceptance).to.exist;
+    });
+  });
+
+  context('when accepting TOS for PIX_CERTIF service (legacy)', function () {
+    it('updates the user table with acceptPixCertifTermsOfService and creates legal document acceptance', async function () {
+      // given
+      const user = databaseBuilder.factory.buildUser({ pixCertifTermsOfServiceAccepted: false });
+      const document = databaseBuilder.factory.buildLegalDocumentVersion({ service: PIX_CERTIF, type: TOS });
+      await databaseBuilder.commit();
+
+      // when
+      await usecases.acceptLegalDocumentByUserId({ userId: user.id, service: PIX_CERTIF, type: TOS });
+
+      // then
+      // Verify the user table was updated (legacy behavior)
+      const updatedUser = await knex('users').where({ id: user.id }).first();
+      expect(updatedUser.pixCertifTermsOfServiceAccepted).to.be.true;
+      expect(updatedUser.lastPixCertifTermsOfServiceValidatedAt).to.be.instanceOf(Date);
 
       // Verify the legal document acceptance was created
       const userAcceptance = await knex('legal-document-version-user-acceptances')


### PR DESCRIPTION
## ☀️ Problème

Quand les CGU de pix-certif sont validées via le nouveau usecase `acceptLegalDocumentByUserId`, l’ancien stockage des CGU pix-certif dans la table `users` doit aussi être mis à jour.

## ⛱️ Proposition

Mettre à jour la table `users`.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Pas testable fonctionnellement.

Faire de la non régression sur PixApp :

1. Créer une nouvelle version des CGU de Pix App
2. Se connecter avec un utilsateur
3. Vérifier que pas de régression
