### PR TITLE
[FEATURE] Ajouter un délai avant d'afficher le feedmoji (PIX-23979).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import ENV from 'mon-pix/config/environment';
 
 import ResultsDetails from '../../../campaigns/assessment/results/evaluation-results-tabs/results-details';
 import Rewards from '../../../campaigns/assessment/results/evaluation-results-tabs/rewards';
@@ -86,9 +87,11 @@ export default class EvaluationResultsRecommendationEngine extends Component {
   }
 
   @action revealNps() {
-    this._drawerRevealedByScroll = true;
-    this._expandedDrawer = true;
-    this.pixMetrics.trackEvent('Moteur de reco - affichage du feedback NPS');
+    setTimeout(() => {
+      this._drawerRevealedByScroll = true;
+      this._expandedDrawer = true;
+      this.pixMetrics.trackEvent('Moteur de reco - affichage du feedback NPS');
+    }, ENV.APP.DRAWER_REVEAL_DELAY_MS);
   }
 
   @action collapseDrawer() {

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -71,7 +71,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     return badges.some((badge) => badge.isAcquired || badge.isAlwaysVisible);
   }
 
-  get shouldShowNps() {
+  get shouldShowDrawer() {
     if (this.args.model.hasAnsweredSurvey) {
       return false;
     }
@@ -79,14 +79,14 @@ export default class EvaluationResultsRecommendationEngine extends Component {
   }
 
   get shouldExpandDrawer() {
-    return this.shouldShowNps && this._expandedDrawer;
+    return this.shouldShowDrawer && this._expandedDrawer;
   }
 
   get scrollBehavior() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
   }
 
-  @action revealNps() {
+  @action revealDrawer() {
     setTimeout(() => {
       this._drawerRevealedByScroll = true;
       this._expandedDrawer = true;
@@ -135,7 +135,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
           @onCardClick={{this.onCardClick}}
           @onModalButtonClick={{this.onModalButtonClick}}
           @onModalAccordionClick={{this.onModalAccordionClick}}
-          @onFullyVisible={{this.revealNps}}
+          @onFullyVisible={{this.revealDrawer}}
         />
       {{/if}}
 
@@ -148,7 +148,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         <Rewards @badges={{@model.campaignParticipationResult.campaignParticipationBadges}} />
       {{/if}}
 
-      {{#if this.shouldShowNps}}
+      {{#if this.shouldShowDrawer}}
         <Drawer @campaignId={{@model.campaign.id}} @onHide={{this.collapseDrawer}} />
       {{/if}}
     </main>

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -64,6 +64,11 @@ module.exports = function (environment) {
         defaultValue: 7000,
         minValue: 0,
       }),
+      DRAWER_REVEAL_DELAY_MS: _getEnvironmentVariableAsNumber({
+        environmentVariableName: 'DRAWER_REVEAL_DELAY_MS',
+        defaultValue: 15000,
+        minValue: 0,
+      }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       INFORMATION_BANNER_POLLING_TIME:

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -213,6 +213,7 @@ module.exports = function (environment) {
     };
 
     ENV.APP.MODULIX_VERIFICATION_RESPONSE_DELAY = 0;
+    ENV.APP.DRAWER_REVEAL_DELAY_MS = 0;
   }
 
   if (environment === 'production') {

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -127,6 +127,7 @@ module(
           // when
           await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
           observerCallback([{ isIntersecting: true }]);
+          await settled();
 
           //then
           sinon.assert.calledWith(pixMetrics.trackEvent, 'Moteur de reco - affichage du feedback NPS');


### PR DESCRIPTION
## ☀️ Problème

Le feedmoji apparaît lorsque l'utilisateur scroll sur la partie des contenus formatifs. Ce qui ne laisse pas le temps à ce dernier de consulter les contenus formatifs pour pouvoir donner son avis.

## ⛱️ Proposition

Appliquer 15 secondes avant d'afficher le feedmoji.

## 🧴 Remarques

Ajout d'une variable d'env coté front.

## 🏊 Pour tester

- Se connecter avec dave-comp@example.net
- aller sur la campagne EDUMULTIP
- Atteindre les contenus formatifs
- Attendre (lancez vous un café, ou cliquez sur un contenu formatif justement)
- Voir que le feedmoji apparaît

