### PR TITLE
[FEATURE] Ajout du référentiel 6e pour la sélection des tubes à la création d'un schéma de parcours (PIX-23978)

### DIFF
--- a/admin/app/components/combined-course-blueprints/details.gjs
+++ b/admin/app/components/combined-course-blueprints/details.gjs
@@ -133,7 +133,8 @@ export default class Details extends Component {
                     </div>
                     <div class="card__content">
                       <p>{{t "components.combined-course-blueprints.reward-requirements.threshold"}}:
-                        {{rewardRequirement.cappedTubesThreshold}}%</p>
+                        {{rewardRequirement.cappedTubesThreshold}}%
+                      </p>
                       {{#if rewardRequirement.areas.length}}
                         {{#each rewardRequirement.areas as |area|}}
                           <Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -179,11 +179,20 @@ export default class CombinedCourseBlueprintForm extends Component {
   }
 
   async refreshAreas() {
-    const framework = this.args.model.frameworks.find((framework) => framework.name === 'Pix');
-    if (framework.areas.isFulfilled) {
-      await framework.areas.reload();
-    }
-    this.areas = Promise.resolve(await framework.areas).then((areasByFramework) => areasByFramework.flat());
+    const frameworks = this.args.model.frameworks.filter(
+      (framework) => framework.name === 'Pix' || framework.name === 'Pix 6e',
+    );
+
+    const areasByFramework = await Promise.all(
+      frameworks.map(async (framework) => {
+        if (framework.areas.isFulfilled) {
+          await framework.areas.reload();
+        }
+        return framework.areas;
+      }),
+    );
+
+    this.areas = areasByFramework.flat();
   }
 
   get validCappedTubeRequirements() {

--- a/admin/app/models/reward-requirement.js
+++ b/admin/app/models/reward-requirement.js
@@ -1,8 +1,7 @@
-import Model, { attr, hasMany } from '@warp-drive/legacy/model';
+import Model, { attr } from '@warp-drive/legacy/model';
 
 export default class RewardRequirement extends Model {
   @attr() cappedTubesThreshold;
   @attr() name;
-
-  @hasMany('area', { async: true, inverse: null }) areas;
+  @attr() areas;
 }

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -231,6 +231,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
           areas: [area],
         });
       });
+
       test('it should display tubes selection component only if the user selects an attestation and chooses type of selection', async function (assert) {
         //given
         const frameworks = [
@@ -290,6 +291,121 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         );
         assert.ok(screen.queryByLabelText('Taux de réussite requis', { exact: false }));
       });
+
+      test('it should display tubes from multiple frameworks', async function (assert) {
+        // given
+        const tube3 = store.createRecord('tube', {
+          id: 'tubeId3',
+          name: '@tubeName3',
+          practicalTitle: 'Tube 3',
+          skills: [],
+          level: 8,
+        });
+
+        const thematic2 = store.createRecord('thematic', {
+          id: 'thematicId2',
+          name: 'Thématique 2',
+          tubes: [tube3],
+        });
+
+        const competence2 = store.createRecord('competence', {
+          id: 'competenceId2',
+          index: '2',
+          name: 'Titre competence 2',
+          thematics: [thematic2],
+        });
+
+        const area2 = store.createRecord('area', {
+          id: 'areaId2',
+          title: 'Titre domaine 2',
+          code: 2,
+          competences: [competence2],
+        });
+
+        const framework2 = store.createRecord('framework', {
+          id: 'frameworkId2',
+          name: 'Pix 6e',
+          areas: [area2],
+        });
+
+        const model = {
+          attestations,
+          frameworks: [framework, framework2],
+          blueprint,
+        };
+
+        //when
+        const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+        await click(
+          screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+        );
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Parentalite' }));
+        await click(
+          screen.getByRole('radio', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
+          }),
+        );
+
+        //then
+        assert.ok(screen.getByText('1 · Titre domaine'));
+        assert.ok(screen.getByText('2 · Titre domaine 2'));
+      });
+
+      test('it should not include tubes from unexpected frameworks', async function (assert) {
+        // given
+        const thematic2 = store.createRecord('thematic', {
+          id: 'thematicId2',
+          name: 'Thématique',
+          tubes: [],
+        });
+
+        const competence2 = store.createRecord('competence', {
+          id: 'competenceId2',
+          index: '3',
+          name: 'Compétence',
+          thematics: [thematic2],
+        });
+
+        const area2 = store.createRecord('area', {
+          id: 'areaId2',
+          title: 'Area',
+          code: 3,
+          competences: [competence2],
+        });
+
+        const excludedFramework = store.createRecord('framework', {
+          id: 'otherFrameworkIdE',
+          name: 'Other Framework',
+          areas: [area2],
+        });
+
+        const model = {
+          attestations,
+          frameworks: [framework, excludedFramework],
+          blueprint,
+        };
+
+        //when
+        const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
+
+        await click(
+          screen.getByRole('button', { name: t('components.combined-course-blueprints.attestation.select-label') }),
+        );
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'Parentalite' }));
+        await click(
+          screen.getByRole('radio', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
+          }),
+        );
+
+        //then
+        assert.ok(screen.getByText('1 · Titre domaine'));
+        assert.notOk(screen.queryByText('3 · Other Framework'));
+      });
+
       test('it should save blueprint with selected tubes requirements when they are selected', async function (assert) {
         //when
         const model = {
@@ -342,6 +458,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
           },
         });
       });
+
       test('it should save blueprint with multiple selections of capped tubes', async function (assert) {
         const model = {
           attestations,

--- a/api/src/quest/domain/errors.js
+++ b/api/src/quest/domain/errors.js
@@ -20,9 +20,3 @@ export class FrameworkNotFoundError extends DomainError {
     super('Framework not found for specified capped tubes.');
   }
 }
-
-export class MultipleFrameworksError extends DomainError {
-  constructor() {
-    super('Multiple frameworks found for specified capped tubes.');
-  }
-}

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -1,5 +1,5 @@
 import { NotFoundError } from '../../../shared/domain/errors.js';
-import { FrameworkNotFoundError, MultipleFrameworksError } from '../errors.js';
+import { FrameworkNotFoundError } from '../errors.js';
 import { AdminCombinedCourseBlueprintDetails } from '../models/combined-course-blueprints/value-objects/AdminCombinedCourseBlueprintDetails.js';
 import { REQUIREMENT_TYPES } from '../models/quests/entities/Quest.js';
 
@@ -38,32 +38,32 @@ export const getCombinedCourseBlueprintById = async ({
 
       let formattedAreas;
 
-      if (frameworks.length === 1) {
-        formattedAreas = frameworks[0].areas.map((area) => ({
-          ...area,
-          competences: area.competences.map((competence) => ({
-            id: competence.id,
-            name: competence.name,
-            index: competence.index,
-            thematics: competence.thematics.map((thematic) => ({
-              id: thematic.id,
-              name: thematic.name,
-              index: thematic.index,
-              tubes: thematic.tubes
-                .filter((tube) => cappedTubesLevelById.has(tube.id))
-                .map((tube) => ({
-                  id: tube.id,
-                  level: cappedTubesLevelById.get(tube.id),
-                  name: tube.name,
-                  practicalTitle: tube.practicalTitle,
-                })),
-            })),
-          })),
-        }));
-      } else if (!frameworks.length) {
+      if (!frameworks.length) {
         throw new FrameworkNotFoundError();
       } else {
-        throw new MultipleFrameworksError();
+        formattedAreas = frameworks.flatMap((framework) =>
+          framework.areas.map((area) => ({
+            ...area,
+            competences: area.competences.map((competence) => ({
+              id: competence.id,
+              name: competence.name,
+              index: competence.index,
+              thematics: competence.thematics.map((thematic) => ({
+                id: thematic.id,
+                name: thematic.name,
+                index: thematic.index,
+                tubes: thematic.tubes
+                  .filter((tube) => cappedTubesLevelById.has(tube.id))
+                  .map((tube) => ({
+                    id: tube.id,
+                    level: cappedTubesLevelById.get(tube.id),
+                    name: tube.name,
+                    practicalTitle: tube.practicalTitle,
+                  })),
+              })),
+            })),
+          })),
+        );
       }
 
       return {

--- a/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
+++ b/api/src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js
@@ -22,26 +22,6 @@ const serialize = function (adminCombinedCourseBlueprintDetails) {
       ref: 'id',
       included: true,
       attributes: ['name', 'cappedTubesThreshold', 'areas'],
-      areas: {
-        ref: 'id',
-        included: true,
-        attributes: ['title', 'code', 'color', 'competences'],
-        competences: {
-          ref: 'id',
-          included: true,
-          attributes: ['name', 'index', 'thematics'],
-          thematics: {
-            ref: 'id',
-            included: true,
-            attributes: ['name', 'index', 'tubes'],
-            tubes: {
-              ref: 'id',
-              included: true,
-              attributes: ['level', 'name', 'practicalTitle'],
-            },
-          },
-        },
-      },
     },
   }).serialize(adminCombinedCourseBlueprintDetails);
 };

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -8,7 +8,6 @@ import { usecases } from '../../../../../src/quest/domain/usecases/index.js';
 import { NotFoundError } from '../../../../../src/shared/domain/errors.js';
 import { expect } from '../../../../test-helper.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
-import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprint-by-id', function () {
@@ -24,12 +23,6 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
 
     const { id: rewardId, label: attestationLabel } = await databaseBuilder.factory.buildAttestation();
 
-    const tube1Id = 'tubeId1';
-    const tube2Id = 'tubeId2';
-    const tube1Level = 3;
-    const tube2Level = 5;
-    const requirement1Threshold = 50;
-    const requirement2Threshold = 60;
     const quest = databaseBuilder.factory.buildQuest({
       rewardType: REWARD_TYPES.ATTESTATION,
       rewardId,
@@ -40,91 +33,13 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
         CombinedCourseBlueprint.buildRequirementForCombinedCourse({
           moduleId: '9beb922f-4d8e-495d-9c85-0e7265ca78d6',
         }).toDTO(),
-        {
-          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
-          data: {
-            name: 'requirements group name 1',
-            threshold: requirement1Threshold,
-            cappedTubes: [{ level: tube1Level, tubeId: tube1Id }],
-          },
-        },
-        {
-          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
-          data: {
-            name: 'requirements group name 2',
-            threshold: requirement2Threshold,
-            cappedTubes: [{ level: tube2Level, tubeId: tube2Id }],
-          },
-        },
       ],
     });
     await databaseBuilder.factory.buildCombinedCourseBlueprint({
       id: 1,
       questId: quest.id,
     });
-
-    const framework = await databaseBuilder.factory.learningContent.buildFramework();
-
-    const thematic1 = await databaseBuilder.factory.learningContent.buildThematic({
-      tubeIds: [tube1Id],
-      competenceId: 'competenceIdA',
-    });
-
-    const competence1 = await databaseBuilder.factory.learningContent.buildCompetence({
-      areaId: 'area1',
-      thematicIds: [thematic1.id],
-    });
-
-    await databaseBuilder.factory.learningContent.buildArea({
-      id: 'area1',
-      competenceIds: [competence1.id],
-      frameworkId: framework.id,
-    });
-
-    await databaseBuilder.factory.learningContent.buildTube({
-      id: tube1Id,
-      competenceId: competence1.id,
-      thematicId: thematic1.id,
-    });
-
-    await databaseBuilder.factory.learningContent.buildTube({
-      id: tube2Id,
-      competenceId: competence1.id,
-      thematicId: thematic1.id,
-    });
-
     await databaseBuilder.commit();
-
-    const expectedTube = domainBuilder.buildTube({
-      id: tube1Id,
-      competenceId: competence1.id,
-      thematicId: thematic1.id,
-    });
-    const expectedThematic = domainBuilder.buildThematic({
-      id: thematic1.id,
-      competenceId: competence1.id,
-      tubeIds: [tube1Id],
-      tubes: [expectedTube],
-    });
-    const expectedCompetence = domainBuilder.buildCompetence({
-      id: competence1.id,
-      thematicIds: [thematic1.id],
-      thematics: [expectedThematic],
-      tubes: [expectedTube],
-    });
-    const expectedArea = domainBuilder.buildArea({
-      id: 'area1',
-      code: 'code Domaine A',
-      name: 'name Domaine A',
-      title: 'title FR Domaine A',
-      color: 'color Domaine A',
-      frameworkId: framework.id,
-      competences: [expectedCompetence],
-    });
-    const expectedArea2 = domainBuilder.buildArea({
-      ...expectedArea,
-      competences: [expectedCompetence],
-    });
 
     //when
     const combinedCourseBlueprintForCreation = await usecases.getCombinedCourseBlueprintById({
@@ -148,6 +63,110 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
       { type: COMBINED_COURSE_ITEM_TYPES.CAMPAIGN, value: targetProfileId },
       { type: COMBINED_COURSE_ITEM_TYPES.MODULE, value: '9beb922f-4d8e-495d-9c85-0e7265ca78d6', shortId: 'e074af34' },
     ]);
+  });
+
+  it('should return a combined course blueprint with correct rewardRequirements', async function () {
+    //given
+    const { id: rewardId } = await databaseBuilder.factory.buildAttestation();
+
+    const tube1Id = 'tubeId1';
+    const tube2Id = 'tubeId2';
+    const tube3Id = 'tubeId3';
+    const tube1Level = 3;
+    const tube2Level = 5;
+    const tube3Level = 6;
+    const requirement1Threshold = 50;
+    const requirement2Threshold = 60;
+    const quest = databaseBuilder.factory.buildQuest({
+      rewardType: REWARD_TYPES.ATTESTATION,
+      rewardId,
+      successRequirements: [
+        {
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+          data: {
+            name: 'requirements group name 1',
+            threshold: requirement1Threshold,
+            cappedTubes: [{ level: tube1Level, tubeId: tube1Id }],
+          },
+        },
+        {
+          requirement_type: REQUIREMENT_TYPES.CAPPED_TUBES,
+          data: {
+            name: 'requirements group name 2',
+            threshold: requirement2Threshold,
+            cappedTubes: [
+              { level: tube2Level, tubeId: tube2Id },
+              { level: tube3Level, tubeId: tube3Id },
+            ],
+          },
+        },
+      ],
+    });
+    await databaseBuilder.factory.buildCombinedCourseBlueprint({
+      id: 1,
+      questId: quest.id,
+    });
+
+    // build first framework, with tubes 1 & 2
+    const framework = await databaseBuilder.factory.learningContent.buildFramework({ id: 'framework1' });
+    const thematic1 = await databaseBuilder.factory.learningContent.buildThematic({
+      id: 'thematic1',
+      tubeIds: [tube1Id, tube2Id],
+      competenceId: 'competence1',
+    });
+    const competence1 = await databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'competence1',
+      areaId: 'area1',
+      thematicIds: [thematic1.id],
+    });
+    await databaseBuilder.factory.learningContent.buildArea({
+      id: 'area1',
+      competenceIds: [competence1.id],
+      frameworkId: framework.id,
+    });
+    await databaseBuilder.factory.learningContent.buildTube({
+      id: tube1Id,
+      competenceId: competence1.id,
+      thematicId: thematic1.id,
+    });
+    await databaseBuilder.factory.learningContent.buildTube({
+      id: tube2Id,
+      competenceId: competence1.id,
+      thematicId: thematic1.id,
+    });
+
+    // build second framework, with tube 3
+    const framework2 = await databaseBuilder.factory.learningContent.buildFramework({ id: 'framework2' });
+    const thematic2 = await databaseBuilder.factory.learningContent.buildThematic({
+      id: 'thematic2',
+      tubeIds: [tube3Id],
+      competenceId: 'competence2',
+    });
+    const competence2 = await databaseBuilder.factory.learningContent.buildCompetence({
+      id: 'competence2',
+      areaId: 'area2',
+      thematicIds: [thematic2.id],
+    });
+    await databaseBuilder.factory.learningContent.buildArea({
+      id: 'area2',
+      competenceIds: [competence2.id],
+      frameworkId: framework2.id,
+    });
+    await databaseBuilder.factory.learningContent.buildTube({
+      id: tube3Id,
+      competenceId: competence2.id,
+      thematicId: thematic2.id,
+    });
+
+    await databaseBuilder.commit();
+
+    //when
+    const combinedCourseBlueprintForCreation = await usecases.getCombinedCourseBlueprintById({
+      id: 1,
+    });
+
+    //then
+    expect(combinedCourseBlueprintForCreation).to.be.instanceOf(CombinedCourseBlueprintForCreation);
 
     const { rewardRequirements } = combinedCourseBlueprintForCreation;
     expect(combinedCourseBlueprintForCreation.rewardRequirements).to.have.lengthOf(2);
@@ -156,10 +175,6 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
     expect(firstRequirement.id).to.equal('1-reward-requirement-0');
     expect(firstRequirement.cappedTubesThreshold).to.equal(requirement1Threshold);
     expect(firstRequirement.name).to.equal('requirements group name 1');
-    expect(firstRequirement.areas).to.have.lengthOf(1);
-    expect(firstRequirement.areas[0].id).to.equal(expectedArea.id);
-    expect(firstRequirement.areas[0].competences[0].id).to.equal(expectedCompetence.id);
-    expect(firstRequirement.areas[0].competences[0].thematics[0].id).to.equal(expectedThematic.id);
     const firstRequirementsTubes = firstRequirement.areas[0].competences[0].thematics[0].tubes;
     expect(firstRequirementsTubes).to.have.lengthOf(1);
     expect(firstRequirementsTubes[0]).to.deep.equal({
@@ -172,18 +187,16 @@ describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprin
     expect(secondRequirement.id).to.equal('1-reward-requirement-1');
     expect(secondRequirement.cappedTubesThreshold).to.equal(requirement2Threshold);
     expect(secondRequirement.name).to.equal('requirements group name 2');
-    expect(secondRequirement.areas).to.have.lengthOf(1);
-    expect(secondRequirement.areas[0].id).to.equal(expectedArea2.id);
-    expect(secondRequirement.areas[0].competences[0].id).to.equal(expectedCompetence.id);
-    expect(secondRequirement.areas[0].competences[0].thematics[0].id).to.equal(expectedThematic.id);
-    const secondRequirementsTubes = secondRequirement.areas[0].competences[0].thematics[0].tubes;
-    expect(secondRequirementsTubes).to.have.lengthOf(1);
-    expect(secondRequirementsTubes[0]).to.deep.equal({
-      id: tube2Id,
-      level: tube2Level,
-      name: 'name Tube A',
-      practicalTitle: 'practicalTitle FR Tube A',
-    });
+    const secondRequirementAreas = secondRequirement.areas;
+    expect(secondRequirementAreas).to.have.lengthOf(2);
+    const tubesFromArea1 = secondRequirementAreas[0].competences[0].thematics[0].tubes;
+    expect(tubesFromArea1).to.deep.equal([
+      { id: tube2Id, level: tube2Level, name: 'name Tube A', practicalTitle: 'practicalTitle FR Tube A' },
+    ]);
+    const tubesFromArea2 = secondRequirementAreas[1].competences[0].thematics[0].tubes;
+    expect(tubesFromArea2).to.deep.equal([
+      { id: tube3Id, level: tube3Level, name: 'name Tube A', practicalTitle: 'practicalTitle FR Tube A' },
+    ]);
   });
 
   it('should throw when no combined course blueprint is found for a given id', async function () {

--- a/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
+++ b/api/tests/quest/unit/infrastructure/serializers/admin-combined-course-blueprint-details-serializer_test.js
@@ -3,7 +3,6 @@ import { AdminCombinedCourseBlueprintDetails } from '../../../../../src/quest/do
 import { Quest, REQUIREMENT_TYPES } from '../../../../../src/quest/domain/models/quests/entities/Quest.js';
 import { adminCombinedCourseBlueprintDetailsSerializer } from '../../../../../src/quest/infrastructure/serializers/admin-combined-course-blueprint-details-serializer.js';
 import { expect } from '../../../../test-helper.js';
-import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
 describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-blueprint-details', function () {
   it('#serialize', function () {
@@ -20,32 +19,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
       rewardType: null,
     });
 
-    // constructing whole framework
-    const tube = domainBuilder.buildTube({
-      id: 'tubeA',
-      name: 'testTubeName',
-      practicalTitle: 'testTubePracticalTitle',
-    });
-    const thematic = domainBuilder.buildThematic({
-      competenceId: 'competence1',
-      tubeIds: ['tubeA'],
-      tubes: [tube],
-    });
-    const cappedTube = { id: 'ABC', level: 4 };
-    thematic.tubes = [
-      { id: cappedTube.id, level: cappedTube.level, name: tube.name, practicalTitle: tube.practicalTitle },
-    ];
-
-    const competence = domainBuilder.buildCompetence({
-      id: 'competence1',
-      areaId: 'area1',
-      thematics: [thematic],
-      tubes: [tube],
-    });
-    const area = domainBuilder.buildArea({
-      id: 'area1',
-      competences: [competence],
-    });
+    const areas = Symbol('areasData');
 
     const adminCombinedCourseBlueprintDetails = new AdminCombinedCourseBlueprintDetails({
       id: 1,
@@ -69,7 +43,7 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
       rewardRequirements: [
         {
           id: 'reward-requirements-1',
-          areas: [area],
+          areas,
           cappedTubesThreshold: '50',
           name: 'requirements group name',
         },
@@ -78,7 +52,6 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
     });
 
     // when
-    // console.log(adminCombinedCourseBlueprintDetails);
     const serialized = adminCombinedCourseBlueprintDetailsSerializer.serialize(adminCombinedCourseBlueprintDetails);
 
     // then
@@ -115,84 +88,11 @@ describe('Quest | Unit | Infrastructure | Serializers | admin-combined-course-bl
       included: [
         {
           attributes: {
-            level: cappedTube.level,
-            name: tube.name,
-            'practical-title': tube.practicalTitle,
-          },
-          id: cappedTube.id,
-          type: 'tubes',
-        },
-        {
-          attributes: {
-            index: 0,
-            name: thematic.name,
-          },
-          id: thematic.id,
-          relationships: {
-            tubes: {
-              data: [
-                {
-                  id: cappedTube.id,
-                  type: 'tubes',
-                },
-              ],
-            },
-          },
-          type: 'thematics',
-        },
-        {
-          attributes: {
-            index: '1.1',
-            name: 'Manger des fruits',
-          },
-          id: competence.id,
-          relationships: {
-            thematics: {
-              data: [
-                {
-                  id: thematic.id,
-                  type: 'thematics',
-                },
-              ],
-            },
-          },
-          type: 'competences',
-        },
-        {
-          attributes: {
-            code: '5',
-            color: 'red',
-            title: 'Super domaine',
-          },
-          id: area.id,
-          relationships: {
-            competences: {
-              data: [
-                {
-                  id: competence.id,
-                  type: 'competences',
-                },
-              ],
-            },
-          },
-          type: 'areas',
-        },
-        {
-          attributes: {
             name: 'requirements group name',
             'capped-tubes-threshold': '50',
+            areas: areas,
           },
           id: 'reward-requirements-1',
-          relationships: {
-            areas: {
-              data: [
-                {
-                  id: area.id,
-                  type: 'areas',
-                },
-              ],
-            },
-          },
           type: 'rewardRequirements',
         },
       ],


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Aujourd’hui, on ne peut pas sélectionner des sujets du ref 6e pour créer une reward adossée à un combined course. 

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Ajout du référentiel Pix 6e en plus du référentiel coeur dans le form de création de schéma de parcours.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Fix sur la récupération des tubes pour l'affichage des détails du schéma côté Admin : prise en compte de plusieurs frameworks (si on a sélectionné des tubes appartenant à différents frameworks).

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
- Se connecter en Admin
- Créer un schéma de parcours avec attestation : on doit voir des domaines de compétence appartenant aux référentiels Pix + Pix 6e. Sélectionner des tubes dans différents référentiels.
- Afficher le schéma créer : on doit retrouver tous les tubes sélectionnés.
