### PR TITLE
[BUGFIX] Retours catalogue post MEP (PIX-23895)

### DIFF
--- a/orga/app/components/catalogue/course-card.gjs
+++ b/orga/app/components/catalogue/course-card.gjs
@@ -71,6 +71,7 @@ export default class CourseCard extends Component {
             @model={{@type}}
             @query={{hash targetProfileId=@course.id}}
             {{on "click" @selectCourse}}
+            title={{@course.name}}
             aria-label={{t "pages.catalogue.modal.open-modal" name=@course.name}}
           />
         {{else if (eq @course.type "blueprint")}}
@@ -79,6 +80,7 @@ export default class CourseCard extends Component {
             @model={{@type}}
             @query={{hash blueprintId=@course.id}}
             {{on "click" @selectCourse}}
+            title={{@course.name}}
             aria-label={{t "pages.catalogue.modal.open-modal" name=@course.name}}
           />
         {{/if}}

--- a/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
+++ b/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
@@ -1,12 +1,15 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
-import { eq } from 'ember-truth-helpers';
 
 import CombinedCourseBlueprintItem from './combined-course-blueprint-item';
 
 function getStepIndex(index) {
   return index + 1;
+}
+
+function displayModuleSubTitle(stepType, stepIndex) {
+  return stepType === 'module' && stepIndex > 0;
 }
 
 export default class TargetProfileContent extends Component {
@@ -26,7 +29,7 @@ export default class TargetProfileContent extends Component {
                 {{t "pages.catalogue.modal.combined-course-content.step" number=(getStepIndex index)}}
               </h4>
             {{/if}}
-            {{#if (eq step.type "module")}}
+            {{#if (displayModuleSubTitle step.type index)}}
               <p class="pix-body-s combined-course-blueprint-step__description">
                 {{t "pages.catalogue.modal.combined-course-content.module-info"}}
               </p>

--- a/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
+++ b/orga/app/components/catalogue/course-modal/combined-course-blueprint-content.gjs
@@ -1,3 +1,5 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
 import { t } from 'ember-intl';
 import { eq } from 'ember-truth-helpers';
 
@@ -7,26 +9,36 @@ function getStepIndex(index) {
   return index + 1;
 }
 
-<template>
-  <div class="combined-course-blueprint-content">
-    {{#each @combinedCourseBlueprint.steps as |step index|}}
-      <div class="combined-course-blueprint-step">
-        <div class="combined-course-blueprint-step__title">
-          <h4 class="pix-title-xs">
-            {{t "pages.catalogue.modal.combined-course-content.step" number=(getStepIndex index)}}
-          </h4>
-          {{#if (eq step.type "module")}}
-            <p class="pix-body-s combined-course-blueprint-step__description">
-              {{t "pages.catalogue.modal.combined-course-content.module-info"}}
-            </p>
-          {{/if}}
+export default class TargetProfileContent extends Component {
+  @service intl;
+
+  get courseHasAtLeastOneStep() {
+    return this.args.combinedCourseBlueprint.steps.length > 1;
+  }
+
+  <template>
+    <div class="combined-course-blueprint-content">
+      {{#each @combinedCourseBlueprint.steps as |step index|}}
+        <div class="combined-course-blueprint-step">
+          <div class="combined-course-blueprint-step__title">
+            {{#if this.courseHasAtLeastOneStep}}
+              <h4 class="pix-title-xs">
+                {{t "pages.catalogue.modal.combined-course-content.step" number=(getStepIndex index)}}
+              </h4>
+            {{/if}}
+            {{#if (eq step.type "module")}}
+              <p class="pix-body-s combined-course-blueprint-step__description">
+                {{t "pages.catalogue.modal.combined-course-content.module-info"}}
+              </p>
+            {{/if}}
+          </div>
+          <div class="combined-course-blueprint-step__items">
+            {{#each step.items as |item|}}
+              <CombinedCourseBlueprintItem @item={{item}} />
+            {{/each}}
+          </div>
         </div>
-        <div class="combined-course-blueprint-step__items">
-          {{#each step.items as |item|}}
-            <CombinedCourseBlueprintItem @item={{item}} />
-          {{/each}}
-        </div>
-      </div>
-    {{/each}}
-  </div>
-</template>
+      {{/each}}
+    </div>
+  </template>
+}

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -207,7 +207,11 @@ export default class List extends Component {
           {{/each}}
         </div>
       {{else}}
-        <EmptyState @infoText={{t "pages.catalogue.empty-state"}} />
+        {{#if @isFiltered}}
+          <EmptyState @infoText={{t "pages.catalogue.empty-state-with-filters"}} />
+        {{else}}
+          <EmptyState @infoText={{t "pages.catalogue.empty-state"}} />
+        {{/if}}
       {{/if}}
 
       {{#if @currentCourse}}

--- a/orga/app/controllers/authenticated/catalogue/list.js
+++ b/orga/app/controllers/authenticated/catalogue/list.js
@@ -12,6 +12,10 @@ export default class CatalogueListController extends Controller {
   @tracked targetProfileId = null;
   @tracked blueprintId = null;
 
+  get isFiltered() {
+    return this.search !== '' || this.category !== '' || this.areas.length > 0 || this.competences.length > 0;
+  }
+
   @action
   updateFilter(fieldName, value) {
     this[fieldName] = value;

--- a/orga/app/styles/components/courses/course-card.scss
+++ b/orga/app/styles/components/courses/course-card.scss
@@ -30,3 +30,11 @@
     height: 100%;
   }
 }
+
+// Temporary fixes to PixCard (faster fix)
+// TODO Move in Pix UI later OR move Pix Card back to monorepo (maybe best)
+.pix-card {
+  &__title {
+    overflow-wrap: anywhere;
+  }
+}

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -10,7 +10,6 @@
   min-height: auto;
   max-height: 42.5rem;
   margin: 0 auto;
-  overflow: hidden;
   background-color: var(--pix-orga-50);
   border-radius: var(--pix-spacing-4x);
   margin-block: auto;
@@ -44,6 +43,7 @@
       padding-right: var(--pix-spacing-6x);
       padding-left: var(--pix-spacing-6x);
       background-color: var(--pix-orga-50);
+      border-top-right-radius: var(--pix-spacing-4x);
 
       &__exit {
         align-self: flex-end;

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -30,6 +30,7 @@
     z-index: 1;
     display: flex;
     height: 100%;
+    width: 100%;
     padding: var(--pix-spacing-4x);
     padding-top: $content-header-height;
     padding-left: var(--pix-spacing-6x);
@@ -216,6 +217,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-8x);
+  width: 100%;
   margin-top: auto;
   margin-bottom: auto;
   padding-top: var(--pix-spacing-4x);

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -24,15 +24,10 @@
   $content-header-height: 4.5rem;
 
   &__course-content {
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 1;
     display: flex;
-    height: 100%;
+    height: calc(100% - $content-header-height);
     width: 100%;
-    padding: var(--pix-spacing-4x);
-    padding-top: $content-header-height;
+    padding-right: var(--pix-spacing-6x);
     padding-left: var(--pix-spacing-6x);
     overflow-y: scroll;
 
@@ -41,7 +36,6 @@
     &__title {
       position: sticky;
       top: 0;
-      z-index: 10;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -149,11 +143,6 @@
   }
 }
 
-// TODO move these properties to stay consistent in the css file
-.target-profile-content {
-  padding-bottom: var(--pix-spacing-6x);
-}
-
 .target-profile-competence {
   padding-bottom: var(--pix-spacing-2x);
 
@@ -224,6 +213,10 @@
 }
 
 .combined-course-blueprint-step {
+  &:last-child {
+    padding-bottom: var(--pix-spacing-6x);
+  }
+
   &__title {
     margin-bottom: var(--pix-spacing-4x);
   }

--- a/orga/app/styles/components/courses/course-modal.scss
+++ b/orga/app/styles/components/courses/course-modal.scss
@@ -24,8 +24,8 @@
 
   &__course-content {
     display: flex;
-    height: calc(100% - $content-header-height);
     width: 100%;
+    height: calc(100% - $content-header-height);
     padding-right: var(--pix-spacing-6x);
     padding-left: var(--pix-spacing-6x);
     overflow-y: scroll;

--- a/orga/app/templates/authenticated/catalogue/list.gjs
+++ b/orga/app/templates/authenticated/catalogue/list.gjs
@@ -12,5 +12,6 @@ import List from 'pix-orga/components/catalogue/list';
     @competences={{@controller.competences}}
     @currentCourse={{@model.currentCourse}}
     @hasBlueprints={{@model.hasBlueprints}}
+    @isFiltered={{@controller.isFiltered}}
   />
 </template>

--- a/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
+++ b/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
@@ -7,6 +7,110 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Catalogue | Course Modale::CombinedCourseBlueprintContent', function (hooks) {
   setupIntlRenderingTest(hooks);
+
+  module('step number title', function () {
+    test('it shows titles and content of each step', async function (assert) {
+      const store = this.owner.lookup('service:store');
+
+      //given
+      const itemEval = store.createRecord('combined-course-blueprint-item', {
+        name: 'Diagnostic',
+        type: 'evaluation',
+      });
+      const itemModule = store.createRecord('combined-course-blueprint-item', {
+        name: 'Le module IA',
+        type: 'module',
+        duration: 5,
+        image: 'mon-image.svg',
+        isRecommendable: true,
+      });
+      const itemModule2 = store.createRecord('combined-course-blueprint-item', {
+        name: 'Le module IA 2',
+        type: 'module',
+        duration: 5,
+        image: 'mon-image.svg',
+        isRecommendable: true,
+      });
+      const itemEval2 = store.createRecord('combined-course-blueprint-item', {
+        name: 'Diagnostic2',
+        type: 'evaluation',
+      });
+      const itemModule3 = store.createRecord('combined-course-blueprint-item', {
+        name: 'Le module IA 3',
+        type: 'module',
+        duration: 5,
+        image: 'mon-image.svg',
+        isRecommendable: false,
+      });
+      const blueprint = store.createRecord('combined-course-blueprint-overview', {
+        name: 'Le module EDU',
+        illustration: 'mon-image.svg',
+        description: 'description',
+        items: [itemEval, itemModule, itemModule2, itemEval2, itemModule3],
+      });
+
+      // when
+      const screen = await render(
+        <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
+      );
+
+      // then
+      const stepTitle1 = screen.getByRole('heading', {
+        name: t('pages.catalogue.modal.combined-course-content.step', { number: 1 }),
+      });
+      const stepTitle2 = screen.getByRole('heading', {
+        name: t('pages.catalogue.modal.combined-course-content.step', { number: 2 }),
+      });
+      const stepTitle3 = screen.getByRole('heading', {
+        name: t('pages.catalogue.modal.combined-course-content.step', { number: 3 }),
+      });
+      const stepTitle4 = screen.getByRole('heading', {
+        name: t('pages.catalogue.modal.combined-course-content.step', { number: 4 }),
+      });
+
+      assert.dom(stepTitle1).exists();
+      assert.dom(screen.getByText(itemEval.name)).exists();
+
+      assert.dom(stepTitle2).exists();
+      assert.dom(screen.getByText(itemModule.name)).exists();
+      assert.dom(screen.getByText(itemModule2.name)).exists();
+
+      assert.dom(stepTitle3).exists();
+      assert.dom(screen.getByText(itemEval2.name)).exists();
+
+      assert.dom(stepTitle4).exists();
+      assert.dom(screen.getByText(itemModule3.name)).exists();
+    });
+
+    test('it shows step content without title if only one step', async function (assert) {
+      const store = this.owner.lookup('service:store');
+
+      //given
+      const itemEval = store.createRecord('combined-course-blueprint-item', {
+        name: 'Diagnostic',
+        type: 'evaluation',
+      });
+      const blueprint = store.createRecord('combined-course-blueprint-overview', {
+        name: 'Le module EDU',
+        illustration: 'mon-image.svg',
+        description: 'description',
+        items: [itemEval],
+      });
+
+      // when
+      const screen = await render(
+        <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
+      );
+
+      // then
+      const stepTitle1 = screen.queryByRole('heading', {
+        name: t('pages.catalogue.modal.combined-course-content.step', { number: 1 }),
+      });
+      assert.dom(stepTitle1).doesNotExist();
+      assert.dom(screen.getByText(itemEval.name)).exists();
+    });
+  });
+
   test('it shows explanation for module step', async function (assert) {
     const store = this.owner.lookup('service:store');
 
@@ -29,6 +133,7 @@ module('Integration | Component | Catalogue | Course Modale::CombinedCourseBluep
 
     assert.dom(screen.getByText(t('pages.catalogue.modal.combined-course-content.module-info'))).exists();
   });
+
   test('it hides explanation for module step if there are no module step', async function (assert) {
     const store = this.owner.lookup('service:store');
 
@@ -47,34 +152,5 @@ module('Integration | Component | Catalogue | Course Modale::CombinedCourseBluep
     );
 
     assert.dom(screen.queryByText(t('pages.catalogue.modal.combined-course-content.module-info'))).doesNotExist();
-  });
-  test('it shows the combined course blueprint content items name', async function (assert) {
-    const store = this.owner.lookup('service:store');
-
-    //given
-    const itemEval = store.createRecord('combined-course-blueprint-item', {
-      name: 'Diagnostic',
-      type: 'evaluation',
-    });
-    const itemModule = store.createRecord('combined-course-blueprint-item', {
-      name: 'Le module IA',
-      type: 'module',
-      duration: 5,
-      image: 'mon-image.svg',
-      isRecommendable: true,
-    });
-    const blueprint = store.createRecord('combined-course-blueprint-overview', {
-      name: 'Le module EDU',
-      illustration: 'mon-image.svg',
-      description: 'description',
-      items: [itemEval, itemModule],
-    });
-
-    const screen = await render(
-      <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
-    );
-
-    const steps = screen.getAllByRole('heading', { level: 4 });
-    assert.strictEqual(steps.length, 2);
   });
 });

--- a/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
+++ b/orga/tests/integration/components/catalogue/combined-course-blueprint-content-test.gjs
@@ -111,46 +111,79 @@ module('Integration | Component | Catalogue | Course Modale::CombinedCourseBluep
     });
   });
 
-  test('it shows explanation for module step', async function (assert) {
-    const store = this.owner.lookup('service:store');
+  module('module step explanation subtitle', function () {
+    test('it shows module step explanation for a step after an evaluation step', async function (assert) {
+      const store = this.owner.lookup('service:store');
 
-    const itemModule = store.createRecord('combined-course-blueprint-item', {
-      name: 'Le module IA',
-      type: 'module',
-      duration: 5,
-      image: 'mon-image.svg',
-      isRecommendable: true,
+      const itemEval = store.createRecord('combined-course-blueprint-item', {
+        name: 'Diagnostic',
+        type: 'evaluation',
+      });
+      const itemModule = store.createRecord('combined-course-blueprint-item', {
+        name: 'Le module IA',
+        type: 'module',
+        duration: 5,
+        image: 'mon-image.svg',
+        isRecommendable: true,
+      });
+      const blueprint = store.createRecord('combined-course-blueprint-overview', {
+        name: 'Le module EDU',
+        illustration: 'mon-image.svg',
+        description: 'description',
+        items: [itemEval, itemModule],
+      });
+      const screen = await render(
+        <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
+      );
+
+      assert.dom(screen.getByText(t('pages.catalogue.modal.combined-course-content.module-info'))).exists();
     });
-    const blueprint = store.createRecord('combined-course-blueprint-overview', {
-      name: 'Le module EDU',
-      illustration: 'mon-image.svg',
-      description: 'description',
-      items: [itemModule],
+
+    test('it does not show module step explanation if module step is not after an evaluation step', async function (assert) {
+      const store = this.owner.lookup('service:store');
+
+      const itemModule = store.createRecord('combined-course-blueprint-item', {
+        name: 'Le module IA',
+        type: 'module',
+        duration: 5,
+        image: 'mon-image.svg',
+        isRecommendable: true,
+      });
+      const itemEval = store.createRecord('combined-course-blueprint-item', {
+        name: 'Diagnostic',
+        type: 'evaluation',
+      });
+      const blueprint = store.createRecord('combined-course-blueprint-overview', {
+        name: 'Le module EDU',
+        illustration: 'mon-image.svg',
+        description: 'description',
+        items: [itemModule, itemEval],
+      });
+      const screen = await render(
+        <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
+      );
+
+      assert.dom(screen.queryByText(t('pages.catalogue.modal.combined-course-content.module-info'))).doesNotExist();
     });
-    const screen = await render(
-      <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
-    );
 
-    assert.dom(screen.getByText(t('pages.catalogue.modal.combined-course-content.module-info'))).exists();
-  });
+    test('it does not show module step explanation for an evaluation step', async function (assert) {
+      const store = this.owner.lookup('service:store');
 
-  test('it hides explanation for module step if there are no module step', async function (assert) {
-    const store = this.owner.lookup('service:store');
+      const itemEval = store.createRecord('combined-course-blueprint-item', {
+        name: 'Diagnostic',
+        type: 'evaluation',
+      });
+      const blueprint = store.createRecord('combined-course-blueprint-overview', {
+        name: 'Le module EDU',
+        illustration: 'mon-image.svg',
+        description: 'description',
+        items: [itemEval],
+      });
+      const screen = await render(
+        <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
+      );
 
-    const itemEval = store.createRecord('combined-course-blueprint-item', {
-      name: 'Diagnostic',
-      type: 'evaluation',
+      assert.dom(screen.queryByText(t('pages.catalogue.modal.combined-course-content.module-info'))).doesNotExist();
     });
-    const blueprint = store.createRecord('combined-course-blueprint-overview', {
-      name: 'Le module EDU',
-      illustration: 'mon-image.svg',
-      description: 'description',
-      items: [itemEval],
-    });
-    const screen = await render(
-      <template><CombinedCourseBlueprintContent @combinedCourseBlueprint={{blueprint}} /></template>,
-    );
-
-    assert.dom(screen.queryByText(t('pages.catalogue.modal.combined-course-content.module-info'))).doesNotExist();
   });
 });

--- a/orga/tests/integration/components/catalogue/course-card-test.gjs
+++ b/orga/tests/integration/components/catalogue/course-card-test.gjs
@@ -58,6 +58,28 @@ module('Integration | Component | Catalogue::CourseCard', function (hooks) {
 
       assert.dom(screen.getByText(t('pages.catalogue.card.tubes-count', { count: 3 }))).exists();
     });
+
+    test('it should have a link to open modal with the correct targetProfileId', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', {
+        id: '1',
+        name: 'Ma super formation',
+        type: 'targetProfile',
+        nbTubes: 5,
+      });
+
+      // when
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
+      const link = screen.getByRole('link', {
+        name: t('pages.catalogue.modal.open-modal', { name: 'Ma super formation' }),
+      });
+
+      // then
+      assert.strictEqual(link.getAttribute('href'), '/catalogue/all?targetProfileId=1');
+    });
   });
 
   module('for a "blueprint" type course', function () {
@@ -82,6 +104,28 @@ module('Integration | Component | Catalogue::CourseCard', function (hooks) {
       );
 
       assert.dom(screen.getByText(t('pages.catalogue.card.modules-count', { count: 4 }))).exists();
+    });
+
+    test('it should have a link to open modal with the correct blueprintId', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const course = store.createRecord('course', {
+        id: '2',
+        name: 'Ma super formation',
+        type: 'blueprint',
+        nbTubes: 5,
+      });
+
+      // when
+      const screen = await render(
+        <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
+      );
+      const link = screen.getByRole('link', {
+        name: t('pages.catalogue.modal.open-modal', { name: 'Ma super formation' }),
+      });
+
+      // then
+      assert.strictEqual(link.getAttribute('href'), '/catalogue/all?blueprintId=2');
     });
   });
 
@@ -149,55 +193,6 @@ module('Integration | Component | Catalogue::CourseCard', function (hooks) {
       );
 
       assert.notOk(screen.queryByText(t('pages.catalogue.card.simplified-access')));
-    });
-  });
-
-  module('modal', function () {
-    module('for a "targetProfile" type course', function () {
-      test('it should redirect with targetProfileId parameter to open the modal when the card is clicked', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const course = store.createRecord('course', {
-          id: '1',
-          name: 'Ma super formation',
-          type: 'targetProfile',
-          nbTubes: 5,
-        });
-
-        // when
-        const screen = await render(
-          <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
-        );
-        const link = screen.getByRole('link', {
-          name: t('pages.catalogue.modal.open-modal', { name: 'Ma super formation' }),
-        });
-
-        // then
-        assert.strictEqual(link.getAttribute('href'), '/catalogue/all?targetProfileId=1');
-      });
-    });
-    module('for a "blueprint" type course', function () {
-      test('it should redirect with blueprintId parameter to open the modal when the card is clicked', async function (assert) {
-        // given
-        const store = this.owner.lookup('service:store');
-        const course = store.createRecord('course', {
-          id: '2',
-          name: 'Ma super formation',
-          type: 'blueprint',
-          nbTubes: 5,
-        });
-
-        // when
-        const screen = await render(
-          <template><CourseCard @course={{course}} @type="all" @selectCourse={{selectCourse}} /></template>,
-        );
-        const link = screen.getByRole('link', {
-          name: t('pages.catalogue.modal.open-modal', { name: 'Ma super formation' }),
-        });
-
-        // then
-        assert.strictEqual(link.getAttribute('href'), '/catalogue/all?blueprintId=2');
-      });
     });
   });
 });

--- a/orga/tests/integration/components/catalogue/list-test.gjs
+++ b/orga/tests/integration/components/catalogue/list-test.gjs
@@ -28,6 +28,21 @@ module('Integration | Component | Catalogue::List', function (hooks) {
     assert.dom(screen.getByText(t('pages.catalogue.empty-state'))).exists();
   });
 
+  test('it displays a different empty state when there are no items and filters are on', async function (assert) {
+    // given
+    const courses = [];
+    const updateFilter = sinon.stub();
+    const isFiltered = true;
+
+    // when
+    const screen = await render(
+      <template><List @courses={{courses}} @updateFilter={{updateFilter}} @isFiltered={{isFiltered}} /></template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(t('pages.catalogue.empty-state-with-filters'))).exists();
+  });
+
   test('it shows all items', async function (assert) {
     // given
     const courses = [

--- a/orga/tests/unit/controllers/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/catalogue/list-test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+
+module('Unit | Controller | authenticated/catalogue/list', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/catalogue/list');
+  });
+
+  module('#updateFilter', function () {
+    test('it should update controller field (search as example)', async function (assert) {
+      // given
+      controller.search = '';
+      const expectedValue = 'Parcours';
+
+      // when
+      await controller.updateFilter('search', expectedValue);
+
+      // then
+      assert.strictEqual(controller.search, expectedValue);
+    });
+  });
+
+  module('#resetFilters', function () {
+    test('it should reset defined filters', async function (assert) {
+      // given
+      controller.search = 'Parcours';
+      controller.category = 'Category';
+      controller.areas = ['Area1', 'Area2'];
+      controller.competences = ['Competence1', 'Competence2'];
+
+      // when
+      await controller.resetFilters();
+
+      // then
+      assert.strictEqual(controller.search, '');
+      assert.strictEqual(controller.category, '');
+      assert.deepEqual(controller.areas, []);
+      assert.deepEqual(controller.competences, []);
+    });
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/catalogue/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/catalogue/list-test.js
@@ -10,6 +10,59 @@ module('Unit | Controller | authenticated/catalogue/list', function (hooks) {
     controller = this.owner.lookup('controller:authenticated/catalogue/list');
   });
 
+  module('#isFiltered', function () {
+    test('it should be false if no filter is filled', async function (assert) {
+      // given
+      controller.search = '';
+      controller.category = '';
+      controller.areas = [];
+      controller.competences = [];
+
+      // then
+      assert.false(controller.isFiltered);
+    });
+    test('it should be true if search filter is filled', async function (assert) {
+      // given
+      controller.search = 'Parcours';
+      controller.category = '';
+      controller.areas = [];
+      controller.competences = [];
+
+      // then
+      assert.true(controller.isFiltered);
+    });
+    test('it should be true if category filter is filled', async function (assert) {
+      // given
+      controller.search = '';
+      controller.category = 'Category';
+      controller.areas = [];
+      controller.competences = [];
+
+      // then
+      assert.true(controller.isFiltered);
+    });
+    test('it should be true if areas filter is filled', async function (assert) {
+      // given
+      controller.search = '';
+      controller.category = '';
+      controller.areas = ['Area1', 'Area2'];
+      controller.competences = [];
+
+      // then
+      assert.true(controller.isFiltered);
+    });
+    test('it should be true if competences filter is filled', async function (assert) {
+      // given
+      controller.search = '';
+      controller.category = '';
+      controller.areas = [];
+      controller.competences = ['Competence1', 'Competence2'];
+
+      // then
+      assert.true(controller.isFiltered);
+    });
+  });
+
   module('#updateFilter', function () {
     test('it should update controller field (search as example)', async function (assert) {
       // given

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1048,6 +1048,7 @@
         "tubes-count": "{count, plural, =0 {Kein Thema} =1 {{count} thema} other {{count} themen}}"
       },
       "empty-state": "Derzeit sind keine Kurse verfügbar. Kontaktieren Sie Pix, um welche zu erhalten.",
+      "empty-state-with-filters": "Keine Kurse entsprechen Ihren Suchkriterien.",
       "filters": {
         "areas": {
           "empty": "Kein Bereich",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1048,6 +1048,7 @@
         "tubes-count": "{count, plural, =0 {No topic} =1 {{count} topic} other {{count} topics}}"
       },
       "empty-state": "No courses available at the moment. Contact Pix to obtain some.",
+      "empty-state-with-filters": "No courses match your search criteria.",
       "filters": {
         "areas": {
           "empty": "No domain",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1048,6 +1048,7 @@
         "tubes-count": "{count, plural, =0 {Sin temas} =1 {{count} tema} other {{count} temas}}"
       },
       "empty-state": "No hay cursos disponibles por el momento. Póngase en contacto con Pix para obtenerlos.",
+      "empty-state-with-filters": "Ningún curso coincide con sus criterios de búsqueda.",
       "filters": {
         "areas": {
           "empty": "Ningún dominio",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1048,6 +1048,7 @@
         "tubes-count": "{count, plural, =0 {Aucun sujet} =1 {{count} sujet} other {{count} sujets}}"
       },
       "empty-state": "Aucun parcours disponible pour l'instant. Contactez Pix pour en obtenir.",
+      "empty-state-with-filters": "Aucun parcours ne correspond à vos critères de recherche.",
       "filters": {
         "areas": {
           "empty": "Aucun domaine",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1048,6 +1048,7 @@
         "tubes-count": "{count, plural, =0 {Nessun argomento} =1 {{count} argomento} other {{count} argomenti}}"
       },
       "empty-state": "Nessun percorso disponibile al momento. Contattare Pix per ottenerne.",
+      "empty-state-with-filters": "Nessun percorso corrisponde ai criteri di ricerca.",
       "filters": {
         "areas": {
           "empty": "Nessun dominio",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1048,6 +1048,7 @@
         "tubes-count": "{count, plural, =0 {Geen onderwerp} =1 {{count} onderwerp} other {{count} onderwerpen}}"
       },
       "empty-state": "Er zijn momenteel geen traject beschikbaar. Neem contact op met Pix om er enkele te verkrijgen.",
+      "empty-state-with-filters": "Geen enkel traject komt overeen met uw zoekcriteria.",
       "filters": {
         "areas": {
           "empty": "Geen domein",


### PR DESCRIPTION
## ☀️ Problème

Après MEP du catalogue, on a remarqué quelques détails à corriger  

## ⛱️ Proposition

Appliquer les corrections

## 🧴 Remarques

Un peu de clean en plus dans les tests et le css 

## 🏊 Pour tester

Se connecter à Pix Orga et valider les points suivants :
- [x] Filtres catalogue : Si j'ai des filtres et pas de parcours qui matche, un message d'empty state spécifique aux filtres s'affiche. Si je n'ai pas de parcours sur l'orga (sans filtre rempli), l'autre empty state initial s'affiche 
- [x] Card catalogue : au hover sur une card, j'aperçois le titre entier du parcours
- [x] Card catalogue : ajouter un titre de parcours sans espaces -> les titres longs sans espaces ont un retour à la ligne forcé
- [x] Modal catalogue : hover sur le badge le plus à gauche d'un parcours -> son infobulle n'est plus croppée et dépasse bien du cadre de la modal
- [x] Modal catalogue : "Etape 1" ne s'affiche pas s'il n'y a qu'une seule étape
- [x] Modal catalogue : L'explication de l'étape de type module ne s'affiche que si l'étape module se trouve après une étape d'évaluation
