### PR TITLE
[FEATURE] PixOrga - Implémentation du nouveau PixSelect 

### DIFF
--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -165,11 +165,10 @@ class SixthGrade extends Component {
     <div class="attestations-page__action">
       <PixMultiSelect
         @isSearchable={{true}}
-        @locale={{this.locale.currentLocale}}
+        @texts={{hash placeholder=(t "common.filters.placeholder") searchLabel=(t "common.filters.search-label-list")}}
         @options={{@divisions}}
         @values={{this.selectedDivisions}}
         @onChange={{this.onSelectDivision}}
-        @placeholder={{t "common.filters.placeholder"}}
       >
         <:label>{{t "pages.attestations.select-divisions-label"}}</:label>
         <:default as |option|>{{option.label}}</:default>

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -122,7 +123,7 @@ class OtherAttestations extends Component {
           @value={{@selectedAttestation}}
           @options={{this.options}}
           @onChange={{this.onSelectedAttestationChange}}
-          @placeholder={{t "common.filters.placeholder"}}
+          @texts={{hash placeholder=(t "common.filters.placeholder")}}
         >
           <:label>{{t "pages.attestations.select-label"}}</:label>
         </PixSelect>

--- a/orga/app/components/attestations.gjs
+++ b/orga/app/components/attestations.gjs
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import { and, eq } from 'ember-truth-helpers';
 import List from 'pix-orga/components/attestations/list';
+import { isSearchValid } from 'pix-orga/utils/normalize-text.js';
 
 import PageTitle from './ui/page-title';
 
@@ -142,6 +143,7 @@ class OtherAttestations extends Component {
 
 class SixthGrade extends Component {
   @tracked selectedDivisions = [];
+  @tracked searchQuery = '';
   @tracked isLoading = false;
   @service locale;
 
@@ -157,6 +159,23 @@ class SixthGrade extends Component {
     this.selectedDivisions = value;
   }
 
+  @action
+  onSearch(query) {
+    this.searchQuery = query;
+  }
+
+  get divisionsOptions() {
+    return this.args.divisions.flatMap((division) => {
+      if ((this.searchQuery && isSearchValid(division.name, this.searchQuery)) || !this.searchQuery) return division;
+
+      return [];
+    });
+  }
+
+  get selectedFields() {
+    return this.args.divisions?.filter((division) => this.args.selectedDivisions?.includes(division.name)).join(',');
+  }
+
   get isDisabled() {
     return !this.selectedDivisions.length || this.isLoading;
   }
@@ -169,8 +188,10 @@ class SixthGrade extends Component {
         @options={{@divisions}}
         @values={{this.selectedDivisions}}
         @onChange={{this.onSelectDivision}}
+        @onSearch={{this.onSearch}}
       >
         <:label>{{t "pages.attestations.select-divisions-label"}}</:label>
+        <:placeholder>{{this.selectedFields}}</:placeholder>
         <:default as |option|>{{option.label}}</:default>
       </PixMultiSelect>
       <PixButton @triggerAction={{this.onSubmit}} @size="small" @isDisabled={{this.isDisabled}}>

--- a/orga/app/components/authentication/oidc-provider-selector.gjs
+++ b/orga/app/components/authentication/oidc-provider-selector.gjs
@@ -1,4 +1,5 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -32,9 +33,11 @@ export default class OidcProviderSelector extends Component {
       @isSearchable={{true}}
       @onChange={{this.onProviderChange}}
       @options={{this.providerOptions}}
-      @placeholder={{t "components.authentication.oidc-provider-selector.placeholder"}}
-      @locale={{this.locale.currentLocale}}
-      @searchPlaceholder={{t "components.authentication.oidc-provider-selector.searchLabel"}}
+      @texts={{hash
+        placeholder=(t "components.authentication.oidc-provider-selector.placeholder")
+        searchPlaceholder=(t "components.authentication.oidc-provider-selector.searchLabel")
+        selectSearchLabel=(t "components.authentication.oidc-provider-selector.searchLabel")
+      }}
       @value={{this.selectedIdentityProviderCode}}
       class="oidc-provider-selector"
       ...attributes

--- a/orga/app/components/campaign/create-form.gjs
+++ b/orga/app/components/campaign/create-form.gjs
@@ -4,7 +4,7 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixRadioButton from '@1024pix/pix-ui/components/pix-radio-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -347,10 +347,12 @@ export default class CreateForm extends Component {
               @onChange={{this.onChangeCampaignOwner}}
               @value="{{@campaign.ownerId}}"
               @isSearchable={{true}}
-              @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
-              @locale={{this.locale.currentLocale}}
-              @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
-              @requiredLabel={{t "common.form.mandatory-fields-title"}}
+              @texts={{hash
+                placeholder=(t "pages.campaign-creation.owner.placeholder")
+                searchPlaceholder=(t "pages.campaign-creation.owner.search-placeholder")
+                selectSearchLabel=(t "pages.campaign-creation.owner.search-label")
+                requiredLabel=(t "common.form.mandatory-fields-title")
+              }}
               @hideDefaultOption={{true}}
             >
               <:label>{{t "pages.campaign-creation.owner.label"}}</:label>
@@ -420,15 +422,15 @@ export default class CreateForm extends Component {
         <FormField>
           <:default>
             <PixSelect
-              @placeholder={{t "pages.campaign-creation.combined-course-blueprints-label"}}
+              @texts={{hash
+                placeholder=(t "pages.campaign-creation.combined-course-blueprints-label")
+                requiredLabel=(t "common.form.mandatory-fields-title")
+              }}
               @options={{this.blueprintOwnerOptions}}
               @hideDefaultOption={{true}}
               @onChange={{this.selectCombinedCourseBlueprint}}
               @value={{@campaign.combinedCourseBlueprint.id}}
-              @requiredLabel={{t "common.form.mandatory-fields-title"}}
               @errorMessage={{if @errors.blueprint (t "api-error-messages.campaign-creation.target-profile-required")}}
-              @locale={{this.locale.currentLocale}}
-              @searchLabel={{t "pages.campaign-creation.combined-course-blueprints-search-placeholder"}}
             >
               <:label>{{t "pages.campaign-creation.combined-course-blueprints-list-label"}}</:label>
             </PixSelect>

--- a/orga/app/components/campaign/create-form/campaign-owner.gjs
+++ b/orga/app/components/campaign/create-form/campaign-owner.gjs
@@ -1,4 +1,5 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -33,10 +34,12 @@ export default class CampaignOwner extends Component {
           @onChange={{this.onChangeCampaignOwner}}
           @value="{{@campaign.ownerId}}"
           @isSearchable={{true}}
-          @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
-          @locale={{this.locale.currentLocale}}
-          @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
-          @requiredLabel={{t "common.form.mandatory-fields-title"}}
+          @texts={{hash
+            placeholder=(t "pages.campaign-creation.owner.placeholder")
+            searchPlaceholder=(t "pages.campaign-creation.owner.search-placeholder")
+            selectSearchLabel=(t "pages.campaign-creation.owner.search-label")
+            requiredLabel=(t "common.form.mandatory-fields-title")
+          }}
           @hideDefaultOption={{true}}
         >
           <:label>{{t "pages.campaign-creation.owner.label"}}</:label>

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -3,6 +3,7 @@ import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixStars from '@1024pix/pix-ui/components/pix-stars';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -191,7 +192,7 @@ export default class ParticipationFilters extends Component {
             @options={{this.statusOptions}}
             @onChange={{this.onSelectStatus}}
             @value={{@selectedStatus}}
-            @placeholder={{t "pages.campaign-results.filters.type.status.empty"}}
+            @texts={{hash placeholder=(t "pages.campaign-results.filters.type.status.empty")}}
             @hideDefaultOption={{false}}
           >
             <:label>{{t "pages.campaign-results.filters.type.status.title"}}</:label>
@@ -279,7 +280,7 @@ export default class ParticipationFilters extends Component {
             @value={{@selectedCertificability}}
             @onChange={{this.onSelectCertificability}}
             @screenReaderOnly={{true}}
-            @placeholder={{t "components.certificability.placeholder-select"}}
+            @texts={{hash placeholder=(t "components.certificability.placeholder-select")}}
           >
             <:label>{{t "pages.sco-organization-participants.filter.certificability.label"}}</:label>
           </PixSelect>

--- a/orga/app/components/campaign/filter/participation-filters.gjs
+++ b/orga/app/components/campaign/filter/participation-filters.gjs
@@ -230,8 +230,8 @@ export default class ParticipationFilters extends Component {
         {{/if}}
         {{#if this.displayStagesFilter}}
           <PixMultiSelect
-            @placeholder={{t "pages.campaign-results.filters.type.stages"}}
             @screenReaderOnly={{true}}
+            @texts={{hash placeholder=(t "pages.campaign-results.filters.type.stages")}}
             @onChange={{this.onSelectStage}}
             @values={{@selectedStages}}
             @options={{this.stageOptions}}
@@ -251,7 +251,7 @@ export default class ParticipationFilters extends Component {
         {{/if}}
         {{#if this.displayBadgesFilter}}
           <PixMultiSelect
-            @placeholder={{t "pages.campaign-results.filters.type.badges"}}
+            @texts={{hash placeholder=(t "pages.campaign-results.filters.type.badges")}}
             @screenReaderOnly={{true}}
             @onChange={{this.onSelectBadge}}
             @values={{@selectedBadges}}
@@ -263,7 +263,7 @@ export default class ParticipationFilters extends Component {
           </PixMultiSelect>
 
           <PixMultiSelect
-            @placeholder={{t "pages.campaign-results.filters.type.unacquired-badges"}}
+            @texts={{hash placeholder=(t "pages.campaign-results.filters.type.unacquired-badges")}}
             @screenReaderOnly={{true}}
             @onChange={{this.onSelectUnacquiredBadge}}
             @values={{@selectedUnacquiredBadges}}

--- a/orga/app/components/campaign/update-form.gjs
+++ b/orga/app/components/campaign/update-form.gjs
@@ -3,7 +3,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTextarea from '@1024pix/pix-ui/components/pix-textarea';
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -119,10 +119,12 @@ export default class UpdateForm extends Component {
           @onChange={{this.onChangeCampaignOwner}}
           @value={{this.ownerIdOption}}
           @isSearchable={{true}}
-          @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
-          @locale={{this.locale.currentLocale}}
-          @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
-          @requiredLabel={{t "common.form.mandatory-fields-title"}}
+          @texts={{hash
+            placeholder=(t "pages.campaign-creation.owner.placeholder")
+            searchPlaceholder=(t "pages.campaign-creation.owner.search-placeholder")
+            selectSearchLabel=(t "pages.campaign-creation.owner.search-label")
+            requiredLabel=(t "common.form.mandatory-fields-title")
+          }}
           @hideDefaultOption={{true}}
         >
           <:label>{{t "pages.campaign-creation.owner.label"}}</:label>

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -176,9 +176,11 @@ export default class List extends Component {
         {{/if}}
         <PixMultiSelect
           @isDisabled={{eq this.areasOptions.length 0}}
-          @emptyMessage={{t "pages.catalogue.filters.areas.empty"}}
+          @texts={{hash
+            emptySearchMessage=(t "pages.catalogue.filters.areas.empty")
+            searchLabel=(t "common.filters.search-label-list")
+          }}
           @screenReaderOnly={{true}}
-          @locale={{this.locale.currentLocale}}
           @values={{@areas}}
           @options={{this.areasOptions}}
           @onChange={{fn @updateFilter "areas"}}
@@ -190,9 +192,11 @@ export default class List extends Component {
 
         <PixMultiSelect
           @isDisabled={{eq this.competencesOptions.length 0}}
-          @emptyMessage={{t "pages.catalogue.filters.competences.empty"}}
+          @texts={{hash
+            emptySearchMessage=(t "pages.catalogue.filters.competences.empty")
+            searchLabel=(t "common.filters.search-label-list")
+          }}
           @screenReaderOnly={{true}}
-          @locale={{this.locale.currentLocale}}
           @values={{@competences}}
           @options={{this.competencesOptions}}
           @onChange={{fn @updateFilter "competences"}}

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -176,10 +176,7 @@ export default class List extends Component {
         {{/if}}
         <PixMultiSelect
           @isDisabled={{eq this.areasOptions.length 0}}
-          @texts={{hash
-            emptySearchMessage=(t "pages.catalogue.filters.areas.empty")
-            searchLabel=(t "common.filters.search-label-list")
-          }}
+          @texts={{hash emptySearchMessage=(t "pages.catalogue.filters.areas.empty")}}
           @screenReaderOnly={{true}}
           @values={{@areas}}
           @options={{this.areasOptions}}
@@ -192,10 +189,7 @@ export default class List extends Component {
 
         <PixMultiSelect
           @isDisabled={{eq this.competencesOptions.length 0}}
-          @texts={{hash
-            emptySearchMessage=(t "pages.catalogue.filters.competences.empty")
-            searchLabel=(t "common.filters.search-label-list")
-          }}
+          @texts={{hash emptySearchMessage=(t "pages.catalogue.filters.competences.empty")}}
           @screenReaderOnly={{true}}
           @values={{@competences}}
           @options={{this.competencesOptions}}

--- a/orga/app/components/catalogue/list.gjs
+++ b/orga/app/components/catalogue/list.gjs
@@ -3,7 +3,7 @@ import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
@@ -164,7 +164,7 @@ export default class List extends Component {
         {{#if (eq @type "targetProfile")}}
           <PixSelect
             @isDisabled={{eq this.categoriesOptions.length 0}}
-            @placeholder={{t "pages.catalogue.filters.categories.all"}}
+            @texts={{hash placeholder=(t "pages.catalogue.filters.categories.all")}}
             @hideDefaultOption={{false}}
             @screenReaderOnly={{true}}
             @value={{@category}}

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -10,12 +10,14 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import EmptyState from 'pix-orga/components/campaign/empty-state';
 import Pagination from 'pix-orga/components/ui/pagination';
 import ParticipationStatus from 'pix-orga/components/ui/participation-status';
 import ENV from 'pix-orga/config/environment';
 import { COMBINED_COURSE_PARTICIPATION_STATUSES } from 'pix-orga/models/combined-course-participation.js';
+import { isSearchValid } from 'pix-orga/utils/normalize-text.js';
 
 const debounceTime = ENV.pagination.debounce;
 
@@ -24,6 +26,8 @@ export default class CombinedCourse extends Component {
   @service locale;
   @service router;
   @service currentUser;
+
+  @tracked searchQuery = '';
 
   get statusesOptions() {
     return [
@@ -69,7 +73,16 @@ export default class CombinedCourse extends Component {
   }
 
   get divisionOptions() {
-    return this.args.divisions.map((division) => ({ label: division.name, value: division.name }));
+    return this.args.divisions.flatMap((division) => {
+      if ((this.searchQuery && isSearchValid(division.name, this.searchQuery)) || !this.searchQuery)
+        return { label: division.name, value: division.name };
+
+      return [];
+    });
+  }
+
+  get selectedFields() {
+    return this.args.divisions?.filter((division) => this.args.divisionsFilter?.includes(division.name)).join(',');
   }
 
   @action
@@ -86,6 +99,11 @@ export default class CombinedCourse extends Component {
   onSearchDivisions(divisions) {
     const eventName = this.isScoOrganization ? 'divisions' : 'groups';
     this.args.onFilter(eventName, divisions);
+  }
+
+  @action
+  onSearch(query) {
+    this.searchQuery = query;
   }
 
   <template>
@@ -112,8 +130,10 @@ export default class CombinedCourse extends Component {
           @onChange={{this.onSearchDivisions}}
           @options={{this.divisionOptions}}
           @isSearchable={{true}}
+          @onSearch={{this.onSearch}}
         >
           <:label>{{t this.divisionFilterLabels.label}}</:label>
+          <:placeholder>{{this.selectedFields}}</:placeholder>
           <:default as |option|>{{option.label}}</:default>
         </PixMultiSelect>
       {{/if}}

--- a/orga/app/components/combined-course/participations.gjs
+++ b/orga/app/components/combined-course/participations.gjs
@@ -5,7 +5,7 @@ import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
-import { uniqueId } from '@ember/helper';
+import { hash, uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
@@ -102,8 +102,11 @@ export default class CombinedCourse extends Component {
 
       {{#if this.displayDivisionColumn}}
         <PixMultiSelect
-          @placeholder={{t this.divisionFilterLabels.placeholder}}
-          @emptyMessage={{t this.divisionFilterLabels.empty}}
+          @texts={{hash
+            placeholder=(t this.divisionFilterLabels.placeholder)
+            emptySearchMessage=(t this.divisionFilterLabels.empty)
+            searchLabel=(t "common.filters.search-label-list")
+          }}
           @screenReaderOnly={{true}}
           @values={{@divisionsFilter}}
           @onChange={{this.onSearchDivisions}}
@@ -116,7 +119,10 @@ export default class CombinedCourse extends Component {
       {{/if}}
 
       <PixMultiSelect
-        @placeholder={{t "pages.combined-course.filters.status.placeholder"}}
+        @texts={{hash
+          placeholder=(t "pages.combined-course.filters.status.placeholder")
+          searchLabel=(t "common.filters.search-label-list")
+        }}
         @screenReaderOnly={{true}}
         @options={{this.statusesOptions}}
         @onChange={{this.onSelectStatus}}

--- a/orga/app/components/layout/sidebar.gjs
+++ b/orga/app/components/layout/sidebar.gjs
@@ -1,6 +1,7 @@
 import PixNavigation from '@1024pix/pix-ui/components/pix-navigation';
 import PixNavigationButton from '@1024pix/pix-ui/components/pix-navigation-button';
 import PixNavigationSeparator from '@1024pix/pix-ui/components/pix-navigation-separator';
+import { hash } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -109,9 +110,11 @@ export default class SidebarMenu extends Component {
   <template>
     <PixNavigation
       @variant="orga"
-      @navigationAriaLabel={{t "navigation.main.aria-label"}}
-      @openLabel={{t "navigation.main.open"}}
-      @closeLabel={{t "navigation.main.close"}}
+      @texts={{hash
+        mainNavigation=(t "navigation.main.aria-label")
+        openMenu=(t "navigation.main.open")
+        closeMenu=(t "navigation.main.close")
+      }}
     >
       <:brand>
         <LinkTo @route="authenticated.index">

--- a/orga/app/components/locale-switcher.gjs
+++ b/orga/app/components/locale-switcher.gjs
@@ -3,6 +3,7 @@
 // and propagate the changes in the copies in all the fronts
 
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -43,6 +44,7 @@ export default class LocaleSwitcher extends Component {
       @onChange={{this.onChange}}
       @hideDefaultOption="true"
       @screenReaderOnly="true"
+      @texts={{hash placeholder=(t "components.locale-switcher.placeholder")}}
     >
       <:label>{{t "components.locale-switcher.label"}}</:label>
     </PixSelect>

--- a/orga/app/components/participant/assessment/header.gjs
+++ b/orga/app/components/participant/assessment/header.gjs
@@ -2,6 +2,7 @@ import PixBlock from '@1024pix/pix-ui/components/pix-block';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixProgressBar from '@1024pix/pix-ui/components/pix-progress-bar';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -116,6 +117,7 @@ export default class Header extends Component {
             @onChange={{this.selectAParticipation}}
             @inlineLabel={{true}}
             @hideDefaultOption={{true}}
+            @texts={{hash placeholder=(t "pages.assessment-individual-results.participation-selector")}}
           >
             <:label>{{t "pages.assessment-individual-results.participation-selector"}}</:label>
           </PixSelect>

--- a/orga/app/components/statistics/index.gjs
+++ b/orga/app/components/statistics/index.gjs
@@ -3,6 +3,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -122,7 +123,7 @@ export default class Statistics extends Component {
           @onChange={{this.handleDomainFilter}}
           @value={{this.currentDomainFilter}}
           @options={{this.domainsName}}
-          @placeholder={{t "common.filters.placeholder"}}
+          @texts={{hash placeholder=(t "common.filters.placeholder")}}
           @hideDefaultOption={{true}}
         >
           <:label>{{t "pages.statistics.select-label"}}</:label>

--- a/orga/app/components/team/members-list-item.gjs
+++ b/orga/app/components/team/members-list-item.gjs
@@ -2,7 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -185,7 +185,7 @@ export default class MembersListItem extends Component {
           <PixSelect
             @screenReaderOnly={{true}}
             @hideDefaultOption={{true}}
-            @placeholder="{{t 'pages.team-members.actions.select-role.label'}}"
+            @texts={{hash placeholder=(t "pages.team-members.actions.select-role.label")}}
             @onChange={{this.setRoleSelection}}
             @options={{this.organizationRoles}}
             @value={{this.roleSelection}}

--- a/orga/app/components/tube/tube.gjs
+++ b/orga/app/components/tube/tube.gjs
@@ -2,6 +2,7 @@ import PixCheckbox from '@1024pix/pix-ui/components/pix-checkbox';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -67,7 +68,7 @@ export default class Tube extends Component {
           @options={{this.levelOptions}}
           @value={{this.selectedLevel}}
           @onChange={{this.setTubeLevel}}
-          @placeholder={{t "pages.preselect-target-profile.levels.placeholder"}}
+          @texts={{hash placeholder=(t "pages.preselect-target-profile.levels.placeholder")}}
           @hideDefaultOption={{true}}
         >
           <:label>{{t "pages.preselect-target-profile.levels.label" title=@tube.practicalTitle}}</:label>

--- a/orga/app/components/ui/divisions-filter.gjs
+++ b/orga/app/components/ui/divisions-filter.gjs
@@ -1,14 +1,18 @@
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import { hash } from '@ember/helper';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { isSearchValid } from 'pix-orga/utils/normalize-text.js';
 
 export default class DivisionsFilter extends Component {
   @service locale;
+  @service intl;
   @tracked isLoading;
   @tracked divisions;
+  @tracked searchQuery = '';
 
   constructor() {
     super(...arguments);
@@ -20,8 +24,25 @@ export default class DivisionsFilter extends Component {
     });
   }
 
+  get selectedFields() {
+    return (
+      this.divisions?.filter((division) => this.args.selected?.includes(division.name)).join(',') ||
+      this.intl.t('common.filters.divisions.placeholder')
+    );
+  }
+
   get options() {
-    return this.divisions?.map(({ name }) => ({ value: name, label: name }));
+    return this.divisions?.flatMap((division) => {
+      if ((this.searchQuery && isSearchValid(division.name, this.searchQuery)) || !this.searchQuery)
+        return { value: division.name, label: division.name };
+
+      return [];
+    });
+  }
+
+  @action
+  onSearch(query) {
+    this.searchQuery = query;
   }
 
   <template>
@@ -39,9 +60,11 @@ export default class DivisionsFilter extends Component {
         @onChange={{@onSelect}}
         @options={{this.options}}
         @isSearchable={{true}}
+        @onSearch={{this.onSearch}}
         ...attributes
       >
         <:label>{{t "common.filters.divisions.label"}}</:label>
+        <:placeholder>{{this.selectedFields}}</:placeholder>
         <:default as |option|>{{option.label}}</:default>
       </PixMultiSelect>
     {{/if}}

--- a/orga/app/components/ui/divisions-filter.gjs
+++ b/orga/app/components/ui/divisions-filter.gjs
@@ -1,4 +1,5 @@
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -28,14 +29,16 @@ export default class DivisionsFilter extends Component {
       <div class="divisions-filter--is-loading placeholder-box"></div>
     {{else}}
       <PixMultiSelect
-        @placeholder={{t "common.filters.divisions.placeholder"}}
-        @emptyMessage={{t "common.filters.divisions.empty"}}
+        @texts={{hash
+          placeholder=(t "common.filters.divisions.placeholder")
+          emptySearchMessage=(t "common.filters.divisions.empty")
+          searchLabel=(t "common.filters.search-label-list")
+        }}
         @screenReaderOnly={{true}}
         @values={{@selected}}
         @onChange={{@onSelect}}
         @options={{this.options}}
         @isSearchable={{true}}
-        @locale={{this.locale.currentLocale}}
         ...attributes
       >
         <:label>{{t "common.filters.divisions.label"}}</:label>

--- a/orga/app/components/ui/groups-filter.gjs
+++ b/orga/app/components/ui/groups-filter.gjs
@@ -1,14 +1,18 @@
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import { hash } from '@ember/helper';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { isSearchValid } from 'pix-orga/utils/normalize-text.js';
 
 export default class GroupsFilter extends Component {
   @service locale;
+  @service intl;
   @tracked isLoading;
   @tracked groups;
+  @tracked searchQuery = '';
 
   constructor() {
     super(...arguments);
@@ -21,7 +25,24 @@ export default class GroupsFilter extends Component {
   }
 
   get options() {
-    return this.groups?.map(({ name }) => ({ value: name, label: name }));
+    return this.groups?.flatMap((group) => {
+      if ((this.searchQuery && isSearchValid(group.name, this.searchQuery)) || !this.searchQuery)
+        return { value: group.name, label: group.name };
+
+      return [];
+    });
+  }
+
+  get selectedFields() {
+    return (
+      this.groups?.filter((group) => this.args.selectedGroups?.includes(group.name)).join(',') ||
+      this.intl.t('common.filters.groups.placeholder')
+    );
+  }
+
+  @action
+  onSearch(query) {
+    this.searchQuery = query;
   }
 
   <template>
@@ -36,12 +57,14 @@ export default class GroupsFilter extends Component {
         }}
         @screenReaderOnly={{true}}
         @isSearchable={{true}}
+        @onSearch={{this.onSearch}}
         @onChange={{@onSelect}}
         @values={{@selectedGroups}}
         @options={{this.options}}
         ...attributes
       >
         <:default as |option|>{{option.label}}</:default>
+        <:placeholder>{{this.selectedFields}}</:placeholder>
         <:label>{{t "common.filters.groups.label"}}</:label>
       </PixMultiSelect>
     {{/if}}

--- a/orga/app/components/ui/groups-filter.gjs
+++ b/orga/app/components/ui/groups-filter.gjs
@@ -1,4 +1,5 @@
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -28,11 +29,13 @@ export default class GroupsFilter extends Component {
       <div class="groups-filter--is-loading placeholder-box"></div>
     {{else}}
       <PixMultiSelect
-        @placeholder={{t "common.filters.groups.placeholder"}}
-        @emptyMessage={{t "common.filters.groups.empty"}}
+        @texts={{hash
+          placeholder=(t "common.filters.groups.placeholder")
+          emptySearchMessage=(t "common.filters.groups.empty")
+          searchLabel=(t "common.filters.search-label-list")
+        }}
         @screenReaderOnly={{true}}
         @isSearchable={{true}}
-        @locale={{this.locale.currentLocale}}
         @onChange={{@onSelect}}
         @values={{@selectedGroups}}
         @options={{this.options}}

--- a/orga/app/components/ui/multi-select-filter.gjs
+++ b/orga/app/components/ui/multi-select-filter.gjs
@@ -1,7 +1,9 @@
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { t } from 'ember-intl';
 
 export default class MultiSelectFilter extends Component {
   @service locale;
@@ -17,11 +19,13 @@ export default class MultiSelectFilter extends Component {
       <div class="multi-select-filter--is-loading placeholder-box"></div>
     {{else}}
       <PixMultiSelect
-        @placeholder={{@placeholder}}
+        @texts={{hash
+          placeholder=@placeholder
+          emptySearchMessage=@emptyMessage
+          searchLabel=(t "common.filters.search-label-list")
+        }}
         @screenReaderOnly={{true}}
-        @emptyMessage={{@emptyMessage}}
         @isSearchable={{true}}
-        @locale={{this.locale.currentLocale}}
         @onChange={{this.onSelect}}
         @values={{@selectedOption}}
         @options={{@options}}

--- a/orga/app/components/ui/multi-select-filter.gjs
+++ b/orga/app/components/ui/multi-select-filter.gjs
@@ -3,15 +3,38 @@ import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
+import { isSearchValid } from 'pix-orga/utils/normalize-text.js';
 
 export default class MultiSelectFilter extends Component {
   @service locale;
+  @tracked searchQuery = '';
 
   @action
   onSelect(value) {
     const { onSelect, field } = this.args;
     onSelect(field, value);
+  }
+
+  @action
+  onSearch(query) {
+    this.searchQuery = query;
+  }
+
+  get options() {
+    return this.args.options?.flatMap((options) => {
+      if ((this.searchQuery && isSearchValid(options.label, this.searchQuery)) || !this.searchQuery) return options;
+
+      return [];
+    });
+  }
+
+  get selectedFields() {
+    return (
+      this.args.options?.filter((division) => this.args.selectedOption?.includes(division.name)).join(',') ||
+      this.args.placeholder
+    );
   }
 
   <template>
@@ -26,11 +49,13 @@ export default class MultiSelectFilter extends Component {
         }}
         @screenReaderOnly={{true}}
         @isSearchable={{true}}
+        @onSearch={{this.onSearch}}
         @onChange={{this.onSelect}}
         @values={{@selectedOption}}
-        @options={{@options}}
+        @options={{this.options}}
       >
         <:label>{{@label}}</:label>
+        <:placeholder>{{this.selectedFields}}</:placeholder>
         <:default as |option|>{{option.label}}</:default>
       </PixMultiSelect>
     {{/if}}

--- a/orga/app/components/ui/select-filter.gjs
+++ b/orga/app/components/ui/select-filter.gjs
@@ -1,4 +1,5 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
@@ -15,7 +16,7 @@ export default class SelectFilter extends Component {
       @onChange={{this.onChange}}
       @options={{@options}}
       @value={{@selectedOption}}
-      @placeholder={{@emptyOptionLabel}}
+      @texts={{hash placeholder=@emptyOptionLabel}}
     >
       <:label>{{@label}}</:label>
     </PixSelect>

--- a/orga/app/templates/authenticated/certifications.gjs
+++ b/orga/app/templates/authenticated/certifications.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
+import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -32,9 +33,7 @@ export default class Certifications extends Component {
             @hideDefaultOption={{true}}
             @onChange={{@controller.onSelectDivision}}
             @isSearchable={{true}}
-            @locale={{this.locale.currentLocale}}
-            @isValidationActive={{true}}
-            @placeholder={{@controller.firstTwoDivisions}}
+            @texts={{hash placeholder=@controller.firstTwoDivisions}}
             required={{true}}
           >
             <:label>{{t "pages.certifications.select-label"}}</:label>

--- a/orga/app/templates/authenticated/missions/mission/activities.gjs
+++ b/orga/app/templates/authenticated/missions/mission/activities.gjs
@@ -1,9 +1,11 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import ActivityTable from 'pix-orga/components/mission/activity-table';
 import DivisionsFilter from 'pix-orga/components/ui/divisions-filter';
+
 <template>
   <PixFilterBanner
     @title={{t "common.filters.title"}}
@@ -32,9 +34,8 @@ import DivisionsFilter from 'pix-orga/components/ui/divisions-filter';
     <PixMultiSelect
       @options={{@controller.statusOptions}}
       @values={{@controller.statuses}}
-      @placeholder={{t "pages.missions.mission.table.activities.filters.status.label"}}
+      @texts={{hash placeholder=(t "pages.missions.mission.table.activities.filters.status.label")}}
       @onChange={{@controller.onSelectStatuses}}
-      @isSearchable={{false}}
       @screenReaderOnly={{true}}
     >
       <:label>{{t "pages.missions.mission.table.activity.filters.status.label"}}</:label>

--- a/orga/app/templates/authenticated/missions/mission/results.gjs
+++ b/orga/app/templates/authenticated/missions/mission/results.gjs
@@ -1,6 +1,7 @@
 import PixFilterBanner from '@1024pix/pix-ui/components/pix-filter-banner';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
 import PixSearchInput from '@1024pix/pix-ui/components/pix-search-input';
+import { hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import ResultTable from 'pix-orga/components/mission/result-table';
 import DivisionsFilter from 'pix-orga/components/ui/divisions-filter';
@@ -32,9 +33,8 @@ import DivisionsFilter from 'pix-orga/components/ui/divisions-filter';
     <PixMultiSelect
       @options={{@controller.resultOptions}}
       @values={{@controller.results}}
-      @placeholder={{t "pages.missions.mission.table.result.filters.global-result.label"}}
+      @texts={{hash placeholder=(t "pages.missions.mission.table.result.filters.global-result.label")}}
       @onChange={{@controller.onSelectResults}}
-      @isSearchable={{false}}
       @screenReaderOnly={{true}}
     >
       <:label>{{t "pages.missions.mission.table.result.filters.global-result.label"}}</:label>

--- a/orga/app/utils/normalize-text.js
+++ b/orga/app/utils/normalize-text.js
@@ -1,0 +1,14 @@
+const normalizeText = (text) =>
+  text
+    .normalize('NFD')
+    .toLowerCase()
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+
+export default function normalizeValue(value) {
+  return normalizeText(value);
+}
+
+export function isSearchValid(item, search) {
+  return normalizeText(item).includes(normalizeText(search));
+}

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.44",
         "@1024pix/eslint-plugin": "^3.0.4",
-        "@1024pix/pix-ui": "^63.0.0",
+        "@1024pix/pix-ui": "^68.0.0",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/plugin-proposal-decorators": "^7.29.7",
@@ -278,15 +278,14 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "63.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-63.0.0.tgz",
-      "integrity": "sha512-FC1PRgTF6CmczE6lvFmpTpYg98pDe2aCxScIrgTvZS+sg3+Gfg3wxLJgmVhPCnDP8Ke2Fi0IRpDhHpR7XCrc9A==",
+      "version": "68.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-68.0.0.tgz",
+      "integrity": "sha512-Ljk7T74t7qrglw1BWVahWISPn0EPRKA0yruG/r/Vie+LjpYxrW5G/C2pJuF9PlOz/31BcheBP6jnGJsNnQzD2g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@formatjs/intl": "^4.0.0",
         "check-engine": "^1.14.0",
         "ember-auto-import": "^2.7.4",
         "ember-cli-babel": "^8.2.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.44",
     "@1024pix/eslint-plugin": "^3.0.4",
-    "@1024pix/pix-ui": "^63.0.0",
+    "@1024pix/pix-ui": "^68.0.0",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.6",
     "@babel/plugin-proposal-decorators": "^7.29.7",

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -240,6 +240,7 @@
         "label": "Externe ID-Suche"
       },
       "placeholder": "-- -- Auswählen --",
+      "search-label-list": "Externe",
       "title": "Filter"
     },
     "form": {

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -466,7 +466,8 @@
       }
     },
     "locale-switcher": {
-      "label": "Wählen Sie eine Sprache"
+      "label": "Wählen Sie eine Sprache",
+      "placeholder": "Wählen Sie eine Sprache"
     },
     "organization-participants-header": {
       "default": {
@@ -811,6 +812,7 @@
         "info": "Der Besitzer der Kampagne sowie die Administratoren dieser Organisation, sind die einzigen Personen, die diese Kampagne bearbeiten oder archivieren können.",
         "label": "Besitzer der Kampagne",
         "placeholder": "Name und Vorname des Besitzers",
+        "search-label": "Nach einem Besitzer suchen",
         "search-placeholder": "Nach einem Besitzer suchen",
         "title": "Besitzer der Kampagne"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -466,7 +466,8 @@
       }
     },
     "locale-switcher": {
-      "label": "Select a language"
+      "label": "Select a language",
+      "placeholder": "Select a language"
     },
     "organization-participants-header": {
       "default": {
@@ -811,6 +812,7 @@
         "info": "The campaign owner, along with the organisation administrators, are the only ones who can modify or archive this campaign.",
         "label": "Campaign owner",
         "placeholder": "Owner’s first and last name",
+        "search-label": "Search for an owner",
         "search-placeholder": "Search for an owner",
         "title": "Campaign owner"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -240,6 +240,7 @@
         "label": "Search by external id"
       },
       "placeholder": "-- Select --",
+      "search-label-list": "Search",
       "title": "Filters"
     },
     "form": {

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -466,7 +466,8 @@
       }
     },
     "locale-switcher": {
-      "label": "Seleccione un idioma"
+      "label": "Seleccione un idioma",
+      "placeholder": "Seleccione un idioma"
     },
     "organization-participants-header": {
       "default": {
@@ -811,6 +812,7 @@
         "info": "El propietario de la campaña y los administradores de esta organización son las únicas personas que pueden modificar o archivar esta campaña.",
         "label": "Propietario de la campaña",
         "placeholder": "Nombre completo del propietario",
+        "search-label": "Encontrar un propietario",
         "search-placeholder": "Encontrar un propietario",
         "title": "Propietario de la campaña"
       },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -240,6 +240,7 @@
         "label": "Búsqueda por ID externo"
       },
       "placeholder": "-- Selecciona --",
+      "search-label-list": "Búsqueda",
       "title": "Filtros"
     },
     "form": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -240,6 +240,7 @@
         "label": "Recherche sur l'identifiant externe"
       },
       "placeholder": "-- Sélectionner --",
+      "search-label-list": "Rechercher",
       "title": "Filtres"
     },
     "form": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -466,7 +466,8 @@
       }
     },
     "locale-switcher": {
-      "label": "Sélectionnez une langue"
+      "label": "Sélectionnez une langue",
+      "placeholder": "Sélectionnez une langue"
     },
     "organization-participants-header": {
       "default": {
@@ -811,6 +812,7 @@
         "info": "Le propriétaire de la campagne ainsi que les administrateurs de cette organisation, sont les seules personnes qui peuvent modifier ou archiver cette campagne.",
         "label": "Propriétaire de la campagne",
         "placeholder": "Nom et prénom du propriétaire",
+        "search-label": "Rechercher un propriétaire",
         "search-placeholder": "Rechercher un propriétaire",
         "title": "Propriétaire de la campagne"
       },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -240,6 +240,7 @@
         "label": "Ricerca di identificatore esterno"
       },
       "placeholder": "-- Seleziona...",
+      "search-label-list": "Ricerca",
       "title": "Filtri"
     },
     "form": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -466,7 +466,8 @@
       }
     },
     "locale-switcher": {
-      "label": "Selezionare una lingua"
+      "label": "Selezionare una lingua",
+      "placeholder": "Selezionare una lingua"
     },
     "organization-participants-header": {
       "default": {
@@ -811,6 +812,7 @@
         "info": "Il proprietario della campagna e gli amministratori di questa organizzazione sono le uniche persone che possono modificare o archiviare questa campagna.",
         "label": "Proprietario della campagna",
         "placeholder": "Nome e cognome del proprietario",
+        "search-label": "Trovare un proprietario",
         "search-placeholder": "Trovare un proprietario",
         "title": "Proprietario della campagna"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -240,6 +240,7 @@
         "label": "Zoeken op extern identificatienummer"
       },
       "placeholder": "-- Selecteer --",
+      "search-label-list": "Zoeken",
       "title": "Filters"
     },
     "form": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -466,7 +466,8 @@
       }
     },
     "locale-switcher": {
-      "label": "Selecteer een taal"
+      "label": "Selecteer een taal",
+      "placeholder": "Selecteer een taal"
     },
     "organization-participants-header": {
       "default": {
@@ -811,6 +812,7 @@
         "info": "De eigenaar van de campagne en de beheerders van deze organisatie zijn de enige personen die deze campagne kunnen wijzigen of archiveren.",
         "label": "Eigenaar van de campagne",
         "placeholder": "Naam en voornaam eigenaar",
+        "search-label": "Een eigenaar zoeken",
         "search-placeholder": "Een eigenaar zoeken",
         "title": "Eigenaar van de campagne"
       },


### PR DESCRIPTION
## ☀️ Problème

Actuellement certaines traduction sont faites dans PixUI. Or, ce n'est pas au design system de porter de la traduction. 

## ⛱️ Proposition

Ajouter la propriété `@texts` et regrouper dedans les informations traduites pour les composants suivants: 
- PixSelect

## 🧴 Remarques

Les PixSelect de PixOrga ont été mis à jour, mais il faut mettre à jour les autres applications.

Implémentation de 🤡  [ça](https://github.com/1024pix/pix-ui/pull/1042) 🤡 

## 🏊 Pour tester

Faire un tour de PixOrga et vérifier que les PixSelect se comportent correctement. 