### PR TITLE
[BUGFIX] Afficher correctement la page d'acceptation des CGU sur mobile (PIX-24023)

### DIFF
--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -52,11 +52,3 @@
     flex-grow: 1;
   }
 }
-
-.terms-of-service-form-conditions {
-  &__validation-error {
-    margin-top: 16px;
-    color: var(--pix-error-500);
-    font-weight: normal;
-  }
-}

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -1,3 +1,4 @@
+@use 'pix-design-tokens/breakpoints';
 @use "pix-design-tokens/colors";
 @use "pix-design-tokens/typography";
 
@@ -6,7 +7,9 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 100%;
+  height: auto;
+  min-height: 100%;
+  padding: var(--pix-spacing-4x);
   background: var(--pix-primary-500);
 }
 
@@ -15,11 +18,11 @@
   flex-direction: column;
   gap: var(--pix-spacing-4x);
   align-items: center;
-  max-width: 700px;
+  width: min(700px, 100%);
   margin: auto;
-  padding: 32px;
+  padding: var(--pix-spacing-8x);
   background: var(--pix-neutral-0);
-  border-radius: 8px;
+  border-radius: var(--pix-spacing-2x);
   box-shadow: 0 6px 12px 0 rgb(7 20 46 / 8%);
 
   &__illustration {
@@ -42,10 +45,16 @@
 
   &__actions {
     display: flex;
-    gap: var(--pix-spacing-6x);
+    flex-direction: column-reverse;
+    gap: var(--pix-spacing-4x);
     width: 100%;
     padding-top: var(--pix-spacing-4x);
     border-top: 1px solid var(--pix-neutral-100);
+
+    @include breakpoints.device-is('tablet') {
+      flex-flow: row wrap;
+      gap: var(--pix-spacing-6x);
+    }
   }
 
   &__accept-action {

--- a/mon-pix/app/templates/terms-of-service.gjs
+++ b/mon-pix/app/templates/terms-of-service.gjs
@@ -17,7 +17,7 @@ import pageTitle from 'ember-page-title/helpers/page-title';
         <p class="pix-body-m">{{t "pages.terms-of-service.requested.message"}}</p>
       {{/if}}
 
-      <div class="terms-of-service-acceptation__illustration">
+      <div class="terms-of-service-form__illustration">
         <img src="{{this.rootURL}}/images/terms-of-service.svg" alt="" role="none" />
         <a
           href={{@controller.legalDocumentUrl}}

--- a/orga/app/styles/pages/authenticated/terms-of-service.scss
+++ b/orga/app/styles/pages/authenticated/terms-of-service.scss
@@ -6,7 +6,9 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 100%;
+  height: auto;
+  min-height: 100%;
+  padding: var(--pix-spacing-4x);
   background: var(--pix-orga-500);
 }
 
@@ -14,8 +16,12 @@
   display: flex;
   flex-direction: column;
   gap: var(--pix-spacing-4x);
-  max-width: 700px;
+  width: min(700px, 100%);
+  margin: auto;
   padding: var(--pix-spacing-8x);
+  background: var(--pix-neutral-0);
+  border-radius: var(--pix-spacing-2x);
+  box-shadow: 0 6px 12px 0 rgb(7 20 46 / 8%);
 
   &__illustration {
     display: flex;
@@ -37,9 +43,15 @@
 
   &__actions {
     display: flex;
-    gap: var(--pix-spacing-6x);
+    flex-direction: column-reverse;
+    gap: var(--pix-spacing-4x);
     padding-top: var(--pix-spacing-4x);
     border-top: 1px solid var(--pix-neutral-100);
+
+    @include breakpoints.device-is('tablet') {
+      flex-flow: row wrap;
+      gap: var(--pix-spacing-6x);
+    }
   }
 
   &__accept-action {


### PR DESCRIPTION
## ☀️ Problème

La page d'acceptation des CGU de Pix App et Pix Orga ne s'affiche pas correctement sur mobile.

## ⛱️ Proposition

Correction du CSS de la page d'acceptation des CGU (Pix App et Pix Orga) : 
- gestion du débordement de contenu, 
- marges sur mobile, 
- ordre des boutons (Accepter avant Refuser sur mobile).

## 🧴 Remarques

La solution ne propose pas d'utiliser le composant Pix Modal car nous ne sommes pas dans le cas d'une modale mais bien d'une page.

## 🏊 Pour tester

[Si vous testez en local : Supprimez toutes les acceptations de cgu d'un utilisateur ayant des droits sur Pix Orga (orgacces@example.net) - attention pour Pix App le feature toggle `newPixAppLegalDocumentsVersioning` doit être à `true`. (nom de la table : `legal-document-version-user-acceptances`)]

Connectez-vous sur chaque app avec orgacces@example.net et vérifiez que les pages d'acceptation des cgu s'affichent correctement, sur mobile et tablette/desktop.
