### PR TITLE
[FEATURE] Remplacer le bouton "quitter" par "voir mes recommandations" (PIX-23977)

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -67,6 +67,11 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
     this.isResetModalVisible = !this.isResetModalVisible;
   }
 
+  @action
+  onSeeRecommendationsButtonClicked() {
+    this.args.onSeeRecommendationsButtonClicked();
+  }
+
   <template>
     <div class="evaluation-results-hero-recommendation-engine">
       <div class="evaluation-results-hero-recommendation-engine__content">
@@ -114,6 +119,15 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
         {{/if}}
 
         <div class="evaluation-results-hero-recommendation-engine__actions">
+          {{#if @hasTrainings}}
+            <PixButton
+              @triggerAction={{this.onSeeRecommendationsButtonClicked}}
+              @size="small"
+              @variant="secondary-white"
+            >
+              {{t "pages.skill-review.hero.see-my-recommendations"}}
+            </PixButton>
+          {{/if}}
           {{#if @campaignParticipationResult.canReset}}
             <PixButton
               @iconBefore="refresh"

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -114,9 +114,6 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
         {{/if}}
 
         <div class="evaluation-results-hero-recommendation-engine__actions">
-          <PixButtonLink @route="authentication.login" @size="small" @variant="secondary-white">
-            {{t "pages.skill-review.actions.back-to-pix"}}
-          </PixButtonLink>
           {{#if @campaignParticipationResult.canReset}}
             <PixButton
               @iconBefore="refresh"

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -3,8 +3,15 @@ import onIntersect from 'mon-pix/modifiers/on-intersect';
 
 import TrainingCard from './training/card';
 
+export const TRAININGS_LIST_ID = 'results-recommendation-engine-training-list';
+
 <template>
-  <section class="results-recommendation-engine-training" {{onIntersect @onFullyVisible threshold=1}}>
+  <section
+    id={{TRAININGS_LIST_ID}}
+    class="results-recommendation-engine-training"
+    tabindex="-1"
+    {{onIntersect @onFullyVisible threshold=1}}
+  >
     <h2 class="results-recommendation-engine-training__title">{{t
         "pages.skill-review.recommended-engine.trainings.title"
       }}</h2>

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -9,7 +9,7 @@ import Rewards from '../../../campaigns/assessment/results/evaluation-results-ta
 import QuitResults from '../../../campaigns/assessment/results/quit-results';
 import Drawer from '../../../campaigns/assessment/results-recommendation-engine/drawer';
 import EvaluationResultsHeroRecommendationEngine from '../../../campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine';
-import Trainings from '../../../campaigns/assessment/results-recommendation-engine/trainings';
+import Trainings, { TRAININGS_LIST_ID } from '../../../campaigns/assessment/results-recommendation-engine/trainings';
 
 export default class EvaluationResultsRecommendationEngine extends Component {
   @service media;
@@ -81,6 +81,10 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     return this.shouldShowNps && this._expandedDrawer;
   }
 
+  get scrollBehavior() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
+  }
+
   @action revealNps() {
     this._drawerRevealedByScroll = true;
     this._expandedDrawer = true;
@@ -89,6 +93,14 @@ export default class EvaluationResultsRecommendationEngine extends Component {
 
   @action collapseDrawer() {
     this._expandedDrawer = false;
+  }
+
+  @action onSeeRecommendationsButtonClicked() {
+    if (this.hasTrainings) {
+      const trainingsList = document.getElementById(TRAININGS_LIST_ID);
+      trainingsList.focus({ preventScroll: true, focusVisible: true });
+      trainingsList.scrollIntoView({ behavior: this.scrollBehavior });
+    }
   }
 
   <template>
@@ -109,6 +121,8 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       <EvaluationResultsHeroRecommendationEngine
         @campaign={{@model.campaign}}
         @campaignParticipationResult={{@model.campaignParticipationResult}}
+        @hasTrainings={{this.hasTrainings}}
+        @onSeeRecommendationsButtonClicked={{this.onSeeRecommendationsButtonClicked}}
         @questResults={{@model.questResults}}
       />
 

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/trainings.scss
@@ -3,6 +3,10 @@
 @use 'pix-design-tokens/breakpoints';
 
 .results-recommendation-engine-training {
+  &:focus-visible {
+    outline: var(--pix-neutral-900) solid 2px;
+  }
+
   &__title {
     @extend %pix-title-s;
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -37,6 +37,7 @@ module(
           return observerInstance;
         };
       });
+
       test('should display trainings', async function (assert) {
         // given
         const training = store.createRecord('training', {
@@ -65,6 +66,37 @@ module(
           .exists();
         const trainingTitle = screen.getAllByText('Super training');
         assert.strictEqual(trainingTitle.length, 2);
+      });
+
+      module('when clicking on see-my-recommendations button', function () {
+        test('should scroll to trainings section and focus the content', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          // when
+          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.skill-review.hero.see-my-recommendations') }));
+
+          // then
+          const trainings = screen.getByRole('heading', {
+            name: t('pages.skill-review.recommended-engine.trainings.title'),
+            level: 2,
+          }).parentElement;
+          assert.strictEqual(document.activeElement, trainings);
+        });
       });
 
       module('tracking', function (hooks) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index-test.gjs
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl/test-support';
 import EvaluationResultsHeroRecommendationEngine from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { stubCurrentUserService } from '../../../../../../helpers/service-stubs';
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
@@ -344,26 +345,80 @@ module(
       });
     });
 
-    test('it displays a back-to-homepage link', async function (assert) {
-      // given
-      stubCurrentUserService(this.owner, { firstName: 'Hermione' });
-      const campaign = { organizationId: 1, hasCustomResultPageButton: false };
-      const campaignParticipationResult = { masteryRate: 0.75 };
+    module('when campaign has recommended trainings', function () {
+      test('it displays a see-recommended-trainings button', async function (assert) {
+        // given
+        stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+        const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+        const campaignParticipationResult = { masteryRate: 0.75 };
 
-      // when
-      const screen = await render(
-        <template>
-          <EvaluationResultsHeroRecommendationEngine
-            @campaign={{campaign}}
-            @campaignParticipationResult={{campaignParticipationResult}}
-            @hasTrainings={{false}}
-          />
-        </template>,
-      );
+        // when
+        const screen = await render(
+          <template>
+            <EvaluationResultsHeroRecommendationEngine
+              @campaign={{campaign}}
+              @campaignParticipationResult={{campaignParticipationResult}}
+              @hasTrainings={{true}}
+            />
+          </template>,
+        );
 
-      // then
-      assert.dom(screen.getByRole('link', { name: t('pages.skill-review.actions.back-to-pix') })).exists();
-      assert.dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-trainings') })).doesNotExist();
+        // then
+        assert
+          .dom(await screen.findByRole('button', { name: t('pages.skill-review.hero.see-my-recommendations') }))
+          .exists();
+      });
+
+      module('when clicking on the see-recommended-trainings button', function () {
+        test('it calls the function passed as argument of onSeeRecommendationsButtonClicked', async function (assert) {
+          // given
+          stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+          const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+          const campaignParticipationResult = { masteryRate: 0.75 };
+          const onSeeRecommendationsButtonClicked = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <EvaluationResultsHeroRecommendationEngine
+                @campaign={{campaign}}
+                @campaignParticipationResult={{campaignParticipationResult}}
+                @hasTrainings={{true}}
+                @onSeeRecommendationsButtonClicked={{onSeeRecommendationsButtonClicked}}
+              />
+            </template>,
+          );
+          await click(await screen.findByRole('button', { name: t('pages.skill-review.hero.see-my-recommendations') }));
+
+          // then
+          assert.ok(onSeeRecommendationsButtonClicked.calledOnce);
+        });
+      });
+    });
+
+    module('when campaign does not have recommended trainings', function () {
+      test('it does not display a see-recommended-trainings button', async function (assert) {
+        // given
+        stubCurrentUserService(this.owner, { firstName: 'Hermione' });
+        const campaign = { organizationId: 1, hasCustomResultPageButton: false };
+        const campaignParticipationResult = { masteryRate: 0.75 };
+
+        // when
+        const screen = await render(
+          <template>
+            <EvaluationResultsHeroRecommendationEngine
+              @campaign={{campaign}}
+              @campaignParticipationResult={{campaignParticipationResult}}
+              @hasTrainings={{false}}
+            />
+          </template>,
+        );
+
+        // then
+        assert
+          .dom(screen.queryByRole('button', { name: t('pages.skill-review.hero.see-my-recommendations') }))
+          .doesNotExist();
+      });
     });
 
     module('when campaign can be reset', function (hooks) {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2232,6 +2232,7 @@
           "retryIn": "Du kannst diesen Lernpfad noch nicht wiederholen, kehre zurück in {duration}.",
           "title": "Verbessere deine Ergebnisse"
         },
+        "see-my-recommendations": "Meine Empfehlungen ansehen",
         "see-trainings": "Übung ansehen",
         "shared-message": "Deine Ergebnisse wurden am {date} an {time} gesendet.",
         "staged-message": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2232,6 +2232,7 @@
           "retryIn": "You cannot replay this customised tests. Come back in {duration}.",
           "title": "Improve your results"
         },
+        "see-my-recommendations": "See my recommendations",
         "see-trainings": "See trainings",
         "shared-message": "Your results were sent on {date} at {time}.",
         "staged-message": {

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2232,6 +2232,7 @@
           "retryIn": "Aún no puedes retomar este curso. Vuelve dentro de {duration}.",
           "title": "Mejora tus resultados"
         },
+        "see-my-recommendations": "Ver mis recomendaciones",
         "see-trainings": "Ver los cursos",
         "shared-message": "Tus resultados se enviaron el {date} a las {time}.",
         "staged-message": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2232,6 +2232,7 @@
           "retryIn": "Vous ne pouvez pas encore repasser ce parcours, revenez dans {duration}.",
           "title": "Améliorez vos résultats"
         },
+        "see-my-recommendations": "Voir mes recommandations",
         "see-trainings": "Voir les formations",
         "shared-message": "Vos résultats ont été envoyés le {date} à {time}.",
         "staged-message": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2232,6 +2232,7 @@
           "retryIn": "Non è ancora possibile rigiocare questo percorso, tornare a {duration}.",
           "title": "Migliorare i risultati"
         },
+        "see-my-recommendations": "Vedere le mie raccomandazioni",
         "see-trainings": "Vedere i corsi",
         "shared-message": "I risultati sono stati inviati da {date} a {time}.",
         "staged-message": {

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2232,6 +2232,7 @@
           "retryIn": "Je kunt deze cursus nog niet opnieuw doen. Kom over {duration} terug.",
           "title": "Verbeter uw resultaten"
         },
+        "see-my-recommendations": "Bekijk mijn aanbevelingen",
         "see-trainings": "Bekijk de cursussen",
         "shared-message": "Je resultaten zijn verzonden op {date} om {time}.",
         "staged-message": {


### PR DESCRIPTION
## ☀️ Problème

On souhaite enlever le bouton `quitter et revenir chez Pix` dans la bannière sur la page de résultats. Cela concerne uniquement les campagnes de type moteur de reco.

## ⛱️ Proposition

Enlever ce bouton et le remplacer par un autre bouton `voir mes recommandations`. Celui-ci va, au clic, scroller et focus la section des contenus formatifs.

## 🧴 Remarques

RAS

## 🏊 Pour tester

- Passer la campagne `EDUMULTIP` avec le compte `dave-comp@example.net`
- Sur la page de résultats, constater que le bouton `quitter et revenir chez Pix` n'apparaît plus dans la bannière
- Voir qu'un autre bouton `Voir mes recommandations` existe à sa place 🥷 
- Cliquer dessus
- Constater que cela scroll jusqu'à la section des contenus formatifs ainsi qu'un focus sur cette section ⬇️ 