### PR TITLE
[FEATURE] Pouvoir révoquer une session utilisateur (PIX-23146)

### DIFF
--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -114,6 +114,12 @@ class UserIdIsRequiredError extends DomainError {
   }
 }
 
+class SessionIdIsRequiredError extends DomainError {
+  constructor(message = 'Session Id is required') {
+    super(message);
+  }
+}
+
 class UserShouldChangePasswordError extends DomainError {
   constructor(message = 'User password must be changed.', meta) {
     super(message);
@@ -144,6 +150,7 @@ export {
   PixAdminLoginFromPasswordDisabledError,
   RevokedPasswordCannotBeReusedError,
   RevokeUntilMustBeAnInstanceOfDate,
+  SessionIdIsRequiredError,
   UserCantBeCreatedError,
   UserIdIsRequiredError,
   UserShouldChangePasswordError,

--- a/api/src/identity-access-management/domain/errors.js
+++ b/api/src/identity-access-management/domain/errors.js
@@ -102,24 +102,6 @@ class UserCantBeCreatedError extends DomainError {
   }
 }
 
-class RevokeUntilMustBeAnInstanceOfDate extends DomainError {
-  constructor(message = 'Revoke Until must be an instance of Date') {
-    super(message);
-  }
-}
-
-class UserIdIsRequiredError extends DomainError {
-  constructor(message = 'User Id is required') {
-    super(message);
-  }
-}
-
-class SessionIdIsRequiredError extends DomainError {
-  constructor(message = 'Session Id is required') {
-    super(message);
-  }
-}
-
 class UserShouldChangePasswordError extends DomainError {
   constructor(message = 'User password must be changed.', meta) {
     super(message);
@@ -149,9 +131,6 @@ export {
   PasswordResetTokenInvalidOrExpired,
   PixAdminLoginFromPasswordDisabledError,
   RevokedPasswordCannotBeReusedError,
-  RevokeUntilMustBeAnInstanceOfDate,
-  SessionIdIsRequiredError,
   UserCantBeCreatedError,
-  UserIdIsRequiredError,
   UserShouldChangePasswordError,
 };

--- a/api/src/identity-access-management/domain/models/AuthenticationMethod.js
+++ b/api/src/identity-access-management/domain/models/AuthenticationMethod.js
@@ -5,6 +5,8 @@ import { validateEntity } from '../../../shared/domain/validators/entity-validat
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
 import { POLE_EMPLOI } from '../constants/oidc-identity-providers.js';
 
+const REVOKED_PASSWORD_VALUE = '[revoked]';
+
 class PixAuthenticationComplement {
   constructor({ password, shouldChangePassword, revokedHashedPassword } = {}) {
     this.password = password;
@@ -26,7 +28,11 @@ class PixAuthenticationComplement {
 
   revokePassword() {
     this.revokedHashedPassword = this.password;
-    this.password = '[revoked]';
+    this.password = REVOKED_PASSWORD_VALUE;
+  }
+
+  get hasRevokedPassword() {
+    return this.password == REVOKED_PASSWORD_VALUE;
   }
 }
 

--- a/api/src/identity-access-management/domain/models/RevokedUserAccess.js
+++ b/api/src/identity-access-management/domain/models/RevokedUserAccess.js
@@ -1,7 +1,9 @@
 export class RevokedUserAccess {
-  constructor(revokeTimeStamp) {
+  constructor({ revokeTimeStamp, revokeSessions }) {
     this.revokeTimeStamp = revokeTimeStamp;
+    this.revokeSessions = revokeSessions;
   }
+
   isAccessTokenRevoked(decodedToken) {
     const issuedAt = decodedToken.iat;
     if (!this.revokeTimeStamp) {

--- a/api/src/identity-access-management/domain/models/RevokedUserAccess.js
+++ b/api/src/identity-access-management/domain/models/RevokedUserAccess.js
@@ -1,17 +1,23 @@
 export class RevokedUserAccess {
-  constructor({ revokeTimeStamp, revokeSessions }) {
-    this.revokeTimeStamp = revokeTimeStamp;
-    this.revokeSessions = revokeSessions;
+  /**
+   * @param {{
+   *   revokedAllTimeStamp?: number
+   *   revokedSessionTimeStamps?: Record<string, number | undefined>
+   * }} param
+   */
+  constructor({ revokedAllTimeStamp, revokedSessionTimeStamps }) {
+    this.revokedAllTimeStamp = revokedAllTimeStamp;
+    this.revokedSessionTimeStamps = revokedSessionTimeStamps;
   }
 
   isAccessTokenRevoked(decodedToken) {
     const issuedAt = decodedToken.iat;
-    if (this.revokeTimeStamp && issuedAt < this.revokeTimeStamp) {
+    if (this.revokedAllTimeStamp && issuedAt < this.revokedAllTimeStamp) {
       return true;
     }
 
     const sessionId = decodedToken.sid;
-    if (this.revokeSessions?.[sessionId] && issuedAt < this.revokeSessions[sessionId]) {
+    if (this.revokedSessionTimeStamps?.[sessionId] && issuedAt < this.revokedSessionTimeStamps[sessionId]) {
       return true;
     }
 

--- a/api/src/identity-access-management/domain/models/RevokedUserAccess.js
+++ b/api/src/identity-access-management/domain/models/RevokedUserAccess.js
@@ -6,9 +6,15 @@ export class RevokedUserAccess {
 
   isAccessTokenRevoked(decodedToken) {
     const issuedAt = decodedToken.iat;
-    if (!this.revokeTimeStamp) {
-      return false;
+    if (this.revokeTimeStamp && issuedAt < this.revokeTimeStamp) {
+      return true;
     }
-    return issuedAt < this.revokeTimeStamp;
+
+    const sessionId = decodedToken.sid;
+    if (this.revokeSessions?.[sessionId] && issuedAt < this.revokeSessions[sessionId]) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/api/src/identity-access-management/domain/models/User.js
+++ b/api/src/identity-access-management/domain/models/User.js
@@ -8,6 +8,7 @@ import {
 } from '../../../shared/domain/services/locale-service.js';
 import { anonymizeGeneralizeDate } from '../../../shared/infrastructure/utils/date-utils.js';
 import { NON_OIDC_IDENTITY_PROVIDERS } from '../constants/identity-providers.js';
+import { AuthenticationMethod } from './AuthenticationMethod.js';
 
 const { toLower } = lodash;
 
@@ -77,6 +78,19 @@ class User {
     );
 
     return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement?.shouldChangePassword : null;
+  }
+
+  get hasRevokedPassword() {
+    const pixAuthenticationMethod = this.authenticationMethods.find(
+      (authenticationMethod) => authenticationMethod.identityProvider === NON_OIDC_IDENTITY_PROVIDERS.PIX.code,
+    );
+
+    if (!pixAuthenticationMethod) {
+      false;
+    }
+
+    return new AuthenticationMethod.PixAuthenticationComplement(pixAuthenticationMethod.authenticationComplement)
+      .hasRevokedPassword;
   }
 
   get passwordHash() {

--- a/api/src/identity-access-management/domain/services/pix-authentication-service.js
+++ b/api/src/identity-access-management/domain/services/pix-authentication-service.js
@@ -1,5 +1,6 @@
 import { PasswordNotMatching, UserIsBlocked, UserIsTemporaryBlocked } from '../../../shared/domain/errors.js';
 import { cryptoService } from '../../../shared/domain/services/crypto-service.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import * as userLoginRepository from '../../infrastructure/repositories/user-login-repository.js';
 
 /**
@@ -29,6 +30,12 @@ async function getUserByUsernameAndPassword({
     await dependencies.cryptoService.assertMatchPassword({ password, passwordHash });
   } catch (error) {
     if (error instanceof PasswordNotMatching) {
+      if (foundUser.hasRevokedPassword) {
+        logger.warn({
+          message: 'User with revoked password trying to authenticate',
+        });
+      }
+
       userLogin.incrementFailureCount();
 
       if (userLogin.shouldMarkUserAsBlocked()) {

--- a/api/src/identity-access-management/domain/usecases/logout-oidc-user.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/logout-oidc-user.usecase.js
@@ -17,7 +17,7 @@ async function logoutOidcUser({
 }) {
   // Revoke user AccessToken
   //temporarily pause revoke user access token to fix SSO bugs
-  /*await revokedUserAccessRepository.saveForUser({
+  /*await revokedUserAccessRepository.revokeAll({
     userId,
     revokeUntil: new Date(),
   });*/

--- a/api/src/identity-access-management/domain/usecases/revoke-access-for-users.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/revoke-access-for-users.usecase.js
@@ -15,7 +15,7 @@ export const revokeAccessForUsers = async function ({
 }) {
   for (const userId of userIds) {
     // Revoke user AccessToken
-    await revokedUserAccessRepository.saveForUser({ userId, revokeUntil: new Date() });
+    await revokedUserAccessRepository.revokeAll({ userId, revokeUntil: new Date() });
 
     // Revoke user RefreshToken
     await refreshTokenRepository.revokeAllByUserId({ userId });

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -14,7 +14,7 @@ const revokedUserAccessLifespanMs = config.authentication.revokedUserAccessLifes
  * @param {string} params.userId - The ID of the user to revoke access for.
  * @param {Date} params.revokeUntil - The date until the user's access should be revoked.
  */
-const saveForUser = async function ({ userId, revokeUntil }) {
+async function revokeAll({ userId, revokeUntil }) {
   if (!userId) {
     throw new UserIdIsRequiredError();
   }
@@ -28,7 +28,7 @@ const saveForUser = async function ({ userId, revokeUntil }) {
     value: Math.floor(revokeUntil.getTime() / 1000),
     expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
   });
-};
+}
 
 /**
  * Retrieves the revoked access for a user from the temporary storage.
@@ -36,9 +36,9 @@ const saveForUser = async function ({ userId, revokeUntil }) {
  * @param {string} userId - The ID of the user to retrieve the revocation date for.
  * @returns {Promise<RevokedUserAccess>} - The revoked user access object.
  */
-const findByUserId = async function (userId) {
+async function findByUserId(userId) {
   const value = await revokedUserAccessTemporaryStorage.get(userId);
   return new RevokedUserAccess(value);
-};
+}
 
-export const revokedUserAccessRepository = { saveForUser, findByUserId };
+export const revokedUserAccessRepository = { revokeAll, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -1,11 +1,14 @@
 import { config } from '../../../../src/shared/config.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
+import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
 import { UserIdIsRequiredError } from '../../domain/errors.js';
 import { RevokeUntilMustBeAnInstanceOfDate } from '../../domain/errors.js';
 import { RevokedUserAccess } from '../../domain/models/RevokedUserAccess.js';
 
 const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
 const revokedUserAccessLifespanMs = config.authentication.revokedUserAccessLifespanMs;
+
+const isSessionLogoutEnabled = featureToggles.use('isSessionLogoutEnabled');
 
 /**
  * Saves the revoke date for a user in the temporary storage.
@@ -25,6 +28,12 @@ async function revokeAll({ userId, revokeUntil }) {
 
   await revokedUserAccessTemporaryStorage.save({
     key: userId,
+    value: Math.floor(revokeUntil.getTime() / 1000),
+    expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
+  });
+
+  await revokedUserAccessTemporaryStorage.save({
+    key: `${userId}:all`,
     value: Math.floor(revokeUntil.getTime() / 1000),
     expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
   });

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -62,21 +62,21 @@ async function revokeSession({ userId, sessionId, revokeUntil }) {
  */
 async function findByUserId(userId) {
   if (!isSessionLogoutEnabled.value) {
-    const revokeTimeStamp = await revokedUserAccessTemporaryStorage.get(userId);
-    return new RevokedUserAccess({ revokeTimeStamp });
+    const revokedAllTimeStamp = await revokedUserAccessTemporaryStorage.get(userId);
+    return new RevokedUserAccess({ revokedAllTimeStamp });
   }
 
   const revokeKeys = await revokedUserAccessTemporaryStorage.keys(`${userId}:*`);
 
-  const revokeTimeStamps = Object.fromEntries(
+  const revokedTimeStamps = Object.fromEntries(
     await Promise.all(
       revokeKeys.map(async (key) => [key.split(':')[1], await revokedUserAccessTemporaryStorage.get(key)]),
     ),
   );
 
-  const { all: revokeTimeStamp, ...revokeSessions } = revokeTimeStamps;
+  const { all: revokedAllTimeStamp, ...revokedSessionTimeStamps } = revokedTimeStamps;
 
-  return new RevokedUserAccess({ revokeTimeStamp, revokeSessions });
+  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessionTimeStamps });
 }
 
 export const revokedUserAccessRepository = { revokeAll, revokeSession, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -74,8 +74,22 @@ async function revokeSession({ userId, sessionId, revokeUntil }) {
  * @returns {Promise<RevokedUserAccess>} - The revoked user access object.
  */
 async function findByUserId(userId) {
-  const value = await revokedUserAccessTemporaryStorage.get(userId);
-  return new RevokedUserAccess(value);
+  if (!isSessionLogoutEnabled.value) {
+    const revokeTimeStamp = await revokedUserAccessTemporaryStorage.get(userId);
+    return new RevokedUserAccess({ revokeTimeStamp });
+  }
+
+  const revokeKeys = await revokedUserAccessTemporaryStorage.keys(`${userId}:*`);
+
+  const revokeTimeStamps = Object.fromEntries(
+    await Promise.all(
+      revokeKeys.map(async (key) => [key.split(':')[1], await revokedUserAccessTemporaryStorage.get(key)]),
+    ),
+  );
+
+  const { all: revokeTimeStamp, ...revokeSessions } = revokeTimeStamps;
+
+  return new RevokedUserAccess({ revokeTimeStamp, revokeSessions });
 }
 
 export const revokedUserAccessRepository = { revokeAll, revokeSession, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -1,7 +1,7 @@
 import { config } from '../../../../src/shared/config.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
-import { UserIdIsRequiredError } from '../../domain/errors.js';
+import { SessionIdIsRequiredError, UserIdIsRequiredError } from '../../domain/errors.js';
 import { RevokeUntilMustBeAnInstanceOfDate } from '../../domain/errors.js';
 import { RevokedUserAccess } from '../../domain/models/RevokedUserAccess.js';
 
@@ -11,7 +11,7 @@ const revokedUserAccessLifespanMs = config.authentication.revokedUserAccessLifes
 const isSessionLogoutEnabled = featureToggles.use('isSessionLogoutEnabled');
 
 /**
- * Saves the revoke date for a user in the temporary storage.
+ * Saves the revoke date for all the accesses of a user.
  *
  * @param {Object} params - The params object.
  * @param {string} params.userId - The ID of the user to revoke access for.
@@ -40,6 +40,34 @@ async function revokeAll({ userId, revokeUntil }) {
 }
 
 /**
+ * Saves the revoke date for a user session.
+ *
+ * @param {Object} params - The params object.
+ * @param {string} params.userId - The ID of the user to revoke access for.
+ * @param {string} params.sessionId - The ID of the user’s session to revoke.
+ * @param {Date} params.revokeUntil - The date until the user's access should be revoked.
+ */
+async function revokeSession({ userId, sessionId, revokeUntil }) {
+  if (!userId) {
+    throw new UserIdIsRequiredError();
+  }
+
+  if (!sessionId) {
+    throw new SessionIdIsRequiredError();
+  }
+
+  if (!(revokeUntil instanceof Date)) {
+    throw new RevokeUntilMustBeAnInstanceOfDate();
+  }
+
+  await revokedUserAccessTemporaryStorage.save({
+    key: `${userId}:${sessionId}`,
+    value: Math.floor(revokeUntil.getTime() / 1000),
+    expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
+  });
+}
+
+/**
  * Retrieves the revoked access for a user from the temporary storage.
  *
  * @param {string} userId - The ID of the user to retrieve the revocation date for.
@@ -50,4 +78,4 @@ async function findByUserId(userId) {
   return new RevokedUserAccess(value);
 }
 
-export const revokedUserAccessRepository = { revokeAll, findByUserId };
+export const revokedUserAccessRepository = { revokeAll, revokeSession, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -1,8 +1,8 @@
+import Joi from 'joi';
+
 import { config } from '../../../../src/shared/config.js';
 import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
 import { featureToggles } from '../../../shared/infrastructure/feature-toggles/index.js';
-import { SessionIdIsRequiredError, UserIdIsRequiredError } from '../../domain/errors.js';
-import { RevokeUntilMustBeAnInstanceOfDate } from '../../domain/errors.js';
 import { RevokedUserAccess } from '../../domain/models/RevokedUserAccess.js';
 
 const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
@@ -18,13 +18,8 @@ const isSessionLogoutEnabled = featureToggles.use('isSessionLogoutEnabled');
  * @param {Date} params.revokeUntil - The date until the user's access should be revoked.
  */
 async function revokeAll({ userId, revokeUntil }) {
-  if (!userId) {
-    throw new UserIdIsRequiredError();
-  }
-
-  if (!(revokeUntil instanceof Date)) {
-    throw new RevokeUntilMustBeAnInstanceOfDate();
-  }
+  Joi.assert(userId, Joi.required());
+  Joi.assert(revokeUntil, Joi.date().required());
 
   await revokedUserAccessTemporaryStorage.save({
     key: userId,
@@ -48,17 +43,9 @@ async function revokeAll({ userId, revokeUntil }) {
  * @param {Date} params.revokeUntil - The date until the user's access should be revoked.
  */
 async function revokeSession({ userId, sessionId, revokeUntil }) {
-  if (!userId) {
-    throw new UserIdIsRequiredError();
-  }
-
-  if (!sessionId) {
-    throw new SessionIdIsRequiredError();
-  }
-
-  if (!(revokeUntil instanceof Date)) {
-    throw new RevokeUntilMustBeAnInstanceOfDate();
-  }
+  Joi.assert(userId, Joi.required());
+  Joi.assert(sessionId, Joi.required());
+  Joi.assert(revokeUntil, Joi.date().required());
 
   await revokedUserAccessTemporaryStorage.save({
     key: `${userId}:${sessionId}`,

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -11,14 +11,14 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
     await revokedUserAccessTemporaryStorage.flushAll();
   });
 
-  describe('#saveForUser', function () {
+  describe('#revokeAll', function () {
     it('saves revoked user access in Redis', async function () {
       // given
       const revokeUntil = new Date();
       const revokedTimeStamp = Math.floor(revokeUntil.getTime() / 1000);
 
       // when
-      await revokedUserAccessRepository.saveForUser({ userId: 12345, revokeUntil });
+      await revokedUserAccessRepository.revokeAll({ userId: 12345, revokeUntil });
 
       // then
       const result = await revokedUserAccessTemporaryStorage.get(12345);
@@ -31,7 +31,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       // given
       const revokeUntil = new Date();
       const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
-      await revokedUserAccessRepository.saveForUser({ userId: 12345, revokeUntil });
+      await revokedUserAccessRepository.revokeAll({ userId: 12345, revokeUntil });
 
       // when
       const result = await revokedUserAccessRepository.findByUserId(12345);

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -50,16 +50,16 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   describe('#findByUserId', function () {
     it('finds revoked user access by user id', async function () {
       // given
-      const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
-      await revokedUserAccessTemporaryStorage.save({ key: 12345, value: revokeTimeStamp });
+      const revokedAllTimeStamp = Math.floor(new Date().getTime() / 1000);
+      await revokedUserAccessTemporaryStorage.save({ key: 12345, value: revokedAllTimeStamp });
 
       // when
       const result = await revokedUserAccessRepository.findByUserId(12345);
 
       // then
       expect(result).to.deep.equal({
-        revokeTimeStamp,
-        revokeSessions: undefined,
+        revokedAllTimeStamp,
+        revokedSessionTimeStamps: undefined,
       });
       expect(result).to.be.instanceOf(RevokedUserAccess);
     });
@@ -72,24 +72,24 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
 
       it('finds revoked user access by user id', async function () {
         // given
-        const revokeTimeStamp = Math.floor(new Date('2026-08-27T15:00:50Z').getTime() / 1000);
-        await revokedUserAccessTemporaryStorage.save({ key: '12345:all', value: revokeTimeStamp });
+        const revokedAllTimeStamp = Math.floor(new Date('2026-08-27T15:00:50Z').getTime() / 1000);
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:all', value: revokedAllTimeStamp });
 
-        const session1RevokeTimestamp = Math.floor(new Date().getTime('2026-08-27T16:00:50Z') / 1000);
-        await revokedUserAccessTemporaryStorage.save({ key: '12345:session1', value: session1RevokeTimestamp });
+        const session1RevokedTimestamp = Math.floor(new Date().getTime('2026-08-27T16:00:50Z') / 1000);
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:session1', value: session1RevokedTimestamp });
 
-        const session2RevokeTimestamp = Math.floor(new Date().getTime('2026-08-27T17:00:50Z') / 1000);
-        await revokedUserAccessTemporaryStorage.save({ key: '12345:session2', value: session2RevokeTimestamp });
+        const session2RevokedTimestamp = Math.floor(new Date().getTime('2026-08-27T17:00:50Z') / 1000);
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:session2', value: session2RevokedTimestamp });
 
         // when
         const result = await revokedUserAccessRepository.findByUserId(12345);
 
         // then
         expect(result).to.deep.equal({
-          revokeTimeStamp,
-          revokeSessions: {
-            session1: session1RevokeTimestamp,
-            session2: session2RevokeTimestamp,
+          revokedAllTimeStamp,
+          revokedSessionTimeStamps: {
+            session1: session1RevokedTimestamp,
+            session2: session2RevokedTimestamp,
           },
         });
         expect(result).to.be.instanceOf(RevokedUserAccess);

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -15,7 +15,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   });
 
   describe('#revokeAll', function () {
-    it('saves revoked user access in Redis', async function () {
+    it('saves revoked user access in TemporaryStorage', async function () {
       // given
       const revokeUntil = new Date();
       const revokedTimeStamp = Math.floor(revokeUntil.getTime() / 1000);
@@ -28,6 +28,21 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       expect(legacyResult).to.equal(revokedTimeStamp);
 
       const result = await revokedUserAccessTemporaryStorage.get('12345:all');
+      expect(result).to.equal(revokedTimeStamp);
+    });
+  });
+
+  describe('#revokeSession', function () {
+    it('saves revoked access for user session in TemporaryStorage', async function () {
+      // given
+      const revokeUntil = new Date();
+      const revokedTimeStamp = Math.floor(revokeUntil.getTime() / 1000);
+
+      // when
+      await revokedUserAccessRepository.revokeSession({ userId: 12345, sessionId: 67890, revokeUntil });
+
+      // then
+      const result = await revokedUserAccessTemporaryStorage.get('12345:67890');
       expect(result).to.equal(revokedTimeStamp);
     });
   });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -1,7 +1,10 @@
+import { setImmediate } from 'node:timers/promises';
+
 import { expect } from 'chai';
 
 import { RevokedUserAccess } from '../../../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
 import { revokedUserAccessRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
+import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
 import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
 
 const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
@@ -21,7 +24,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       await revokedUserAccessRepository.revokeAll({ userId: 12345, revokeUntil });
 
       // then
-      const result = await revokedUserAccessTemporaryStorage.get(12345);
+      const legacyResult = await revokedUserAccessTemporaryStorage.get(12345);
+      expect(legacyResult).to.equal(revokedTimeStamp);
+
+      const result = await revokedUserAccessTemporaryStorage.get('12345:all');
       expect(result).to.equal(revokedTimeStamp);
     });
   });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -50,18 +50,50 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   describe('#findByUserId', function () {
     it('finds revoked user access by user id', async function () {
       // given
-      const revokeUntil = new Date();
       const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
-      await revokedUserAccessRepository.revokeAll({ userId: 12345, revokeUntil });
+      await revokedUserAccessTemporaryStorage.save({ key: 12345, value: revokeTimeStamp });
 
       // when
       const result = await revokedUserAccessRepository.findByUserId(12345);
 
       // then
       expect(result).to.deep.equal({
-        revokeTimeStamp: revokeTimeStamp,
+        revokeTimeStamp,
+        revokeSessions: undefined,
       });
       expect(result).to.be.instanceOf(RevokedUserAccess);
+    });
+
+    describe('when isSessionLogoutEnabled FT is true', function () {
+      beforeEach(async function () {
+        await featureToggles.set('isSessionLogoutEnabled', true);
+        await setImmediate();
+      });
+
+      it('finds revoked user access by user id', async function () {
+        // given
+        const revokeTimeStamp = Math.floor(new Date('2026-08-27T15:00:50Z').getTime() / 1000);
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:all', value: revokeTimeStamp });
+
+        const session1RevokeTimestamp = Math.floor(new Date().getTime('2026-08-27T16:00:50Z') / 1000);
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:session1', value: session1RevokeTimestamp });
+
+        const session2RevokeTimestamp = Math.floor(new Date().getTime('2026-08-27T17:00:50Z') / 1000);
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:session2', value: session2RevokeTimestamp });
+
+        // when
+        const result = await revokedUserAccessRepository.findByUserId(12345);
+
+        // then
+        expect(result).to.deep.equal({
+          revokeTimeStamp,
+          revokeSessions: {
+            session1: session1RevokeTimestamp,
+            session2: session2RevokeTimestamp,
+          },
+        });
+        expect(result).to.be.instanceOf(RevokedUserAccess);
+      });
     });
   });
 });

--- a/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
@@ -7,7 +7,7 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     it('builds a revoke user access model', function () {
       //when
       const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
-      const revokedUserAccess = new RevokedUserAccess(revokeTimeStamp);
+      const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
 
       //then
       expect(revokedUserAccess.revokeTimeStamp).to.equal(revokeTimeStamp);
@@ -21,7 +21,7 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
         const revokeTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
         const decodedToken = { iat: iat };
-        const revokedUserAccess = new RevokedUserAccess(revokeTimeStamp);
+        const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
@@ -37,7 +37,7 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
         const revokeTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const decodedToken = { iat: iat };
-        const revokedUserAccess = new RevokedUserAccess(revokeTimeStamp);
+        const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);

--- a/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
@@ -7,10 +7,12 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     it('builds a revoke user access model', function () {
       //when
       const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
-      const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
+      const revokeSessions = { 12345: Math.floor(new Date().getTime() / 1000) };
+      const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp, revokeSessions });
 
       //then
       expect(revokedUserAccess.revokeTimeStamp).to.equal(revokeTimeStamp);
+      expect(revokedUserAccess.revokeSessions).to.equal(revokeSessions);
     });
   });
 
@@ -20,7 +22,7 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
         //given
         const revokeTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
-        const decodedToken = { iat: iat };
+        const decodedToken = { iat };
         const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
 
         //when
@@ -36,8 +38,42 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
         //given
         const revokeTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
-        const decodedToken = { iat: iat };
+        const decodedToken = { iat };
         const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
+
+        //when
+        const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
+
+        //then
+        expect(result).to.equal(false);
+      });
+    });
+
+    context("when access token's session is revoked", function () {
+      it('returns true', function () {
+        //given
+        const revokeTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
+        const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
+        const sid = crypto.randomUUID();
+        const decodedToken = { iat, sid };
+        const revokedUserAccess = new RevokedUserAccess({ revokeSessions: { [sid]: revokeTimeStamp } });
+
+        //when
+        const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
+
+        //then
+        expect(result).to.equal(true);
+      });
+    });
+
+    context("when access token's session is not revoked", function () {
+      it('returns false', function () {
+        //given
+        const revokeTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
+        const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
+        const sid = crypto.randomUUID();
+        const decodedToken = { iat, sid };
+        const revokedUserAccess = new RevokedUserAccess({ revokeSessions: { [sid]: revokeTimeStamp } });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);

--- a/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
@@ -6,13 +6,13 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
   describe('#constructor', function () {
     it('builds a revoke user access model', function () {
       //when
-      const revokeTimeStamp = Math.floor(new Date().getTime() / 1000);
-      const revokeSessions = { 12345: Math.floor(new Date().getTime() / 1000) };
-      const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp, revokeSessions });
+      const revokedAllTimeStamp = Math.floor(new Date().getTime() / 1000);
+      const revokedSessionTimeStamps = { 12345: Math.floor(new Date().getTime() / 1000) };
+      const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp, revokedSessionTimeStamps });
 
       //then
-      expect(revokedUserAccess.revokeTimeStamp).to.equal(revokeTimeStamp);
-      expect(revokedUserAccess.revokeSessions).to.equal(revokeSessions);
+      expect(revokedUserAccess.revokedAllTimeStamp).to.equal(revokedAllTimeStamp);
+      expect(revokedUserAccess.revokedSessionTimeStamps).to.equal(revokedSessionTimeStamps);
     });
   });
 
@@ -20,10 +20,10 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     context('when access token is revoked', function () {
       it('returns true', function () {
         //given
-        const revokeTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
+        const revokedAllTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
         const decodedToken = { iat };
-        const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
+        const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
@@ -36,10 +36,10 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     context('when access token is not revoked', function () {
       it('returns false', function () {
         //given
-        const revokeTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
+        const revokedAllTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const decodedToken = { iat };
-        const revokedUserAccess = new RevokedUserAccess({ revokeTimeStamp });
+        const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
@@ -52,11 +52,11 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     context("when access token's session is revoked", function () {
       it('returns true', function () {
         //given
-        const revokeTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
+        const revokedAllTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
         const sid = crypto.randomUUID();
         const decodedToken = { iat, sid };
-        const revokedUserAccess = new RevokedUserAccess({ revokeSessions: { [sid]: revokeTimeStamp } });
+        const revokedUserAccess = new RevokedUserAccess({ revokedSessionTimeStamps: { [sid]: revokedAllTimeStamp } });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
@@ -69,11 +69,11 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     context("when access token's session is not revoked", function () {
       it('returns false', function () {
         //given
-        const revokeTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
+        const revokedAllTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
         const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const sid = crypto.randomUUID();
         const decodedToken = { iat, sid };
-        const revokedUserAccess = new RevokedUserAccess({ revokeSessions: { [sid]: revokeTimeStamp } });
+        const revokedUserAccess = new RevokedUserAccess({ revokedSessionTimeStamps: { [sid]: revokedAllTimeStamp } });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);


### PR DESCRIPTION
## ☀️ Problème

On souhaite pouvoir révoquer une session utilisateur.

## ⛱️ Proposition

Rendre possible la révocation d'une session particulière d'un utilisateur :

 - lors de la révocation de tous les accès utilisateur, stocker une nouvelle clé Redis `"<userId>:all"` (en plus de l'ancienne clé ne contenant que le `userId`)
 - créer une nouvelle méthode `revokeSession`, qui créé une clé Redis `"<userId>:<sessionId>"`
 - si le FT est actif, lire et prendre en compte les clés au format `"<userId>:*"` pour vérifier si un access token est révoqué

## 🧴 Remarques

Contrairement à ce qui a été prévu dans le ticket, on fait une double écriture de l'ancienne et de la nouvelle clé Redis pour une révocation d'accès au niveau de l'utilisateur, sans prendre en compte le FT.

## 🏊 Pour tester

Le FT est actif sur la RA.

Se connecter, puis révoquer la session (en ajoutant manuellement dans Redis la clé `"temporary-storage:revoked-user-access:<userId>:<sessionId>"`).
Vérifier qu'on se fait bien déconnecter.

Vérifier que cela fonctionne également avec `"temporary-storage:revoked-user-access:<userId>:all"`.

Vérifier que cela ne fonctionne pas avec l'ancien format `"temporary-storage:revoked-user-access:<userId>"`.

Désactiver le FT, et faire de la non régression sur le comportement actuel.