### PR TITLE
[TECH] Surcharger le schedule de Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>1024pix/renovate-config:js-project"],
-  "enabled": true
+  "enabled": true,
+  "schedule": ["* * * * 1-5"]
 }


### PR DESCRIPTION
## ☀️ Problème
Le schedule renovate par défaut est "une fois par jour" alors qu'on souhaite avoir, comme avant, un schedule à "une fois par heure" pour le monorepo

## ⛱️ Proposition
Surcharger le schedule de Renovate