### PR TITLE
[BUGFIX] rendre obligatoire le taux de réussite requis pour créer un schéma de parcours combiné avec des sujets cappés (PIX-24026)

### DIFF
--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -32,7 +32,7 @@ export default class CombinedCourseBlueprintForm extends Component {
   @tracked itemToAdd = null;
   @tracked hasUniqueCappedTubesSubset = false;
   @tracked hasMultipleCappedTubeSubsets = false;
-  @tracked cappedTubeRequirements = [{}];
+  @tracked cappedTubeRequirements = [];
   @tracked areas;
 
   constructor() {
@@ -207,9 +207,6 @@ export default class CombinedCourseBlueprintForm extends Component {
     if (requirements.length === 0) {
       return [];
     }
-    if (requirements.length === 1 && Object.keys(requirements[0]).length === 0) {
-      return [];
-    }
 
     let errors = [];
     for (const requirement of requirements) {
@@ -261,18 +258,6 @@ export default class CombinedCourseBlueprintForm extends Component {
   }
 
   @action
-  hasUniqueCappedTubesSubsetChange(e) {
-    this.hasUniqueCappedTubesSubset = e.target.checked;
-    this.hasMultipleCappedTubeSubsets = false;
-  }
-
-  @action
-  hasMultipleCappedTubeSubsetsChange(e) {
-    this.hasMultipleCappedTubeSubsets = e.target.checked;
-    this.hasUniqueCappedTubesSubset = false;
-  }
-
-  @action
   addCappedTubeSubset() {
     this.cappedTubeRequirements = [...this.cappedTubeRequirements, {}];
   }
@@ -321,10 +306,6 @@ export default class CombinedCourseBlueprintForm extends Component {
           @onCappedTubesSelectionChange={{this.onCappedTubesSelectionChange}}
           @removeCappedTubeCriterion={{this.removeCappedTubeCriterion}}
           @cappedTubeRequirements={{this.cappedTubeRequirements}}
-          @hasMultipleCappedTubeSubsets={{this.hasMultipleCappedTubeSubsets}}
-          @hasMultipleCappedTubeSubsetsChange={{this.hasMultipleCappedTubeSubsetsChange}}
-          @hasUniqueCappedTubesSubset={{this.hasUniqueCappedTubesSubset}}
-          @hasUniqueCappedTubesSubsetChange={{this.hasUniqueCappedTubesSubsetChange}}
           @addCappedTubeSubset={{this.addCappedTubeSubset}}
         />
       {{/if}}
@@ -565,27 +546,6 @@ const RewardRequirementsSection = <template>
 
     {{#unless @updateMode}}
       {{#if @blueprint.rewardId}}
-        <fieldset class="badge-form-criteria-choice">
-          <p>{{t "components.combined-course-blueprints.labels.reward-requirements.reward-criteria-choice"}}</p>
-          <PixRadioButton
-            name="subsetNumberChoice"
-            @checked={{@hasUniqueCappedTubesSubset}}
-            {{on "change" @hasUniqueCappedTubesSubsetChange}}
-          >
-            <:label>{{t "components.combined-course-blueprints.labels.reward-requirements.one-subset-option"}}</:label>
-          </PixRadioButton>
-          <PixRadioButton
-            name="subsetNumberChoice"
-            @checked={{@hasMultipleCappedTubeSubsets}}
-            {{on "change" @hasMultipleCappedTubeSubsetsChange}}
-          >
-            <:label>{{t
-                "components.combined-course-blueprints.labels.reward-requirements.multiple-subsets-option"
-              }}</:label>
-          </PixRadioButton>
-        </fieldset>
-
-        {{#if (or @hasMultipleCappedTubeSubsets @hasUniqueCappedTubesSubset)}}
           {{#each @cappedTubeRequirements as |criterion index|}}
             <CappedTubesCriterion
               @id={{concat "cappedTubeCriterion" index}}
@@ -596,18 +556,16 @@ const RewardRequirementsSection = <template>
               @remove={{fn @removeCappedTubeCriterion index}}
             />
           {{/each}}
-          {{#if @hasMultipleCappedTubeSubsets}}
-            <PixButton
-              class="badge-form-criterion__add"
-              @variant="primary"
-              @size="small"
-              @triggerAction={{@addCappedTubeSubset}}
-              @iconBefore="add"
-            >
-              {{t "components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection"}}
-            </PixButton>
-          {{/if}}
-        {{/if}}
+          <br/>
+          <PixButton
+            class="badge-form-criterion__add"
+            @variant="primary"
+            @size="small"
+            @triggerAction={{@addCappedTubeSubset}}
+            @iconBefore="add"
+          >
+            {{t "components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection"}}
+          </PixButton>
       {{/if}}
     {{/unless}}
   </Card>

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -107,6 +107,13 @@ export default class CombinedCourseBlueprintForm extends Component {
 
   @action
   async save() {
+    if (this.cappedTubesRequirementsErrors.length) {
+      this.cappedTubesRequirementsErrors.forEach((error) => {
+        this.pixToast.sendErrorNotification({ message: error });
+      });
+      return;
+    }
+
     try {
       await this.blueprint.save({
         adapterOptions: this.validCappedTubeRequirements.length
@@ -193,6 +200,28 @@ export default class CombinedCourseBlueprintForm extends Component {
     );
 
     this.areas = areasByFramework.flat();
+  }
+
+  get cappedTubesRequirementsErrors() {
+    const requirements = this.cappedTubeRequirements;
+    if (requirements.length === 0) {
+      return [];
+    }
+    if (requirements.length === 1 && Object.keys(requirements[0]).length === 0) {
+      return [];
+    }
+
+    let errors = [];
+    for (const requirement of requirements) {
+      if (!requirement.threshold) {
+        errors.push(this.intl.t('components.combined-course-blueprints.reward-requirements.errors.threshold-required'));
+      }
+      if (!requirement.tubes || requirement.tubes.length < 1) {
+        errors.push(this.intl.t('components.combined-course-blueprints.reward-requirements.errors.tubes-required'));
+      }
+    }
+
+    return errors;
   }
 
   get validCappedTubeRequirements() {

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -187,7 +187,8 @@ export default class CombinedCourseBlueprintForm extends Component {
 
   async refreshAreas() {
     const frameworks = this.args.model.frameworks.filter(
-      (framework) => framework.name === 'Pix' || framework.name === 'Pix 6e' || framework.name === 'Numérique Responsable',
+      (framework) =>
+        framework.name === 'Pix' || framework.name === 'Pix 6e' || framework.name === 'Numérique Responsable',
     );
 
     const areasByFramework = await Promise.all(
@@ -208,7 +209,7 @@ export default class CombinedCourseBlueprintForm extends Component {
       return [];
     }
 
-    let errors = [];
+    const errors = [];
     for (const requirement of requirements) {
       if (!requirement.threshold) {
         errors.push(this.intl.t('components.combined-course-blueprints.reward-requirements.errors.threshold-required'));
@@ -274,7 +275,6 @@ export default class CombinedCourseBlueprintForm extends Component {
       <GeneralInfoSection
         @blueprint={{this.blueprint}}
         @setData={{this.setData}}
-        @setAttestation={{this.setAttestation}}
         @updateMode={{@updateMode}}
         @model={{@model}}
       />
@@ -295,20 +295,20 @@ export default class CombinedCourseBlueprintForm extends Component {
         />
       {{/unless}}
 
-      {{#if (or (and (not @updateMode) this.blueprint.rewardId) (and @updateMode this.blueprint.attestationLabel))}}
-        <RewardRequirementsSection
-          @blueprint={{this.blueprint}}
-          @setData={{this.setData}}
-          @updateMode={{@updateMode}}
-          @areas={{this.areas}}
-          @onCappedTubesThresholdChange={{this.onCappedTubesThresholdChange}}
-          @onCappedTubesNameChange={{this.onCappedTubesNameChange}}
-          @onCappedTubesSelectionChange={{this.onCappedTubesSelectionChange}}
-          @removeCappedTubeCriterion={{this.removeCappedTubeCriterion}}
-          @cappedTubeRequirements={{this.cappedTubeRequirements}}
-          @addCappedTubeSubset={{this.addCappedTubeSubset}}
-        />
-      {{/if}}
+      <RewardRequirementsSection
+        @model={{@model}}
+        @blueprint={{this.blueprint}}
+        @setAttestation={{this.setAttestation}}
+        @setData={{this.setData}}
+        @updateMode={{@updateMode}}
+        @areas={{this.areas}}
+        @onCappedTubesThresholdChange={{this.onCappedTubesThresholdChange}}
+        @onCappedTubesNameChange={{this.onCappedTubesNameChange}}
+        @onCappedTubesSelectionChange={{this.onCappedTubesSelectionChange}}
+        @removeCappedTubeCriterion={{this.removeCappedTubeCriterion}}
+        @cappedTubeRequirements={{this.cappedTubeRequirements}}
+        @addCappedTubeSubset={{this.addCappedTubeSubset}}
+      />
 
       <fieldset class="controls">
         <PixButton
@@ -390,13 +390,6 @@ const GeneralInfoSection = <template>
         {{t "components.combined-course-blueprints.labels.survey-link"}}
       </:label>
     </PixInput>
-    {{#unless @updateMode}}
-      <SelectAttestation
-        @attestations={{@model.attestations}}
-        @value={{@blueprint.rewardId}}
-        @onChange={{@setAttestation}}
-      />
-    {{/unless}}
 
   </Card>
 </template>;
@@ -533,40 +526,47 @@ const RewardRequirementsSection = <template>
     class="combined-course-blueprint-form__card"
     @title={{t "components.combined-course-blueprints.create.attestations"}}
   >
-    <PixTextarea
-      @id="reward-requirements"
-      @value={{@blueprint.rewardRequirementsDescription}}
-      {{on "change" (fn @setData "rewardRequirementsDescription")}}
-      rows="10"
-    >
-      <:label>
-        {{t "components.combined-course-blueprints.labels.reward-requirements.description"}}
-      </:label>
-    </PixTextarea>
-
     {{#unless @updateMode}}
-      {{#if @blueprint.rewardId}}
-          {{#each @cappedTubeRequirements as |criterion index|}}
-            <CappedTubesCriterion
-              @id={{concat "cappedTubeCriterion" index}}
-              @areas={{@areas}}
-              @onThresholdChange={{fn @onCappedTubesThresholdChange criterion}}
-              @onNameChange={{fn @onCappedTubesNameChange criterion}}
-              @onTubesSelectionChange={{fn @onCappedTubesSelectionChange criterion}}
-              @remove={{fn @removeCappedTubeCriterion index}}
-            />
-          {{/each}}
-          <br/>
-          <PixButton
-            class="badge-form-criterion__add"
-            @variant="primary"
-            @size="small"
-            @triggerAction={{@addCappedTubeSubset}}
-            @iconBefore="add"
-          >
-            {{t "components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection"}}
-          </PixButton>
-      {{/if}}
+      <SelectAttestation
+        @attestations={{@model.attestations}}
+        @value={{@blueprint.rewardId}}
+        @onChange={{@setAttestation}}
+      />
     {{/unless}}
+    {{#if (or (and (not @updateMode) @blueprint.rewardId) (and @updateMode @blueprint.attestationLabel))}}
+      <PixTextarea
+        @id="reward-requirements"
+        @value={{@blueprint.rewardRequirementsDescription}}
+        {{on "change" (fn @setData "rewardRequirementsDescription")}}
+        rows="10"
+      >
+        <:label>
+          {{t "components.combined-course-blueprints.labels.reward-requirements.description"}}
+        </:label>
+      </PixTextarea>
+
+      {{#unless @updateMode}}
+        {{#each @cappedTubeRequirements as |criterion index|}}
+          <CappedTubesCriterion
+            @id={{concat "cappedTubeCriterion" index}}
+            @areas={{@areas}}
+            @onThresholdChange={{fn @onCappedTubesThresholdChange criterion}}
+            @onNameChange={{fn @onCappedTubesNameChange criterion}}
+            @onTubesSelectionChange={{fn @onCappedTubesSelectionChange criterion}}
+            @remove={{fn @removeCappedTubeCriterion index}}
+          />
+        {{/each}}
+        <br />
+        <PixButton
+          class="badge-form-criterion__add"
+          @variant="primary"
+          @size="small"
+          @triggerAction={{@addCappedTubeSubset}}
+          @iconBefore="add"
+        >
+          {{t "components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection"}}
+        </PixButton>
+      {{/unless}}
+    {{/if}}
   </Card>
 </template>;

--- a/admin/app/components/combined-course-blueprints/form.gjs
+++ b/admin/app/components/combined-course-blueprints/form.gjs
@@ -187,7 +187,7 @@ export default class CombinedCourseBlueprintForm extends Component {
 
   async refreshAreas() {
     const frameworks = this.args.model.frameworks.filter(
-      (framework) => framework.name === 'Pix' || framework.name === 'Pix 6e',
+      (framework) => framework.name === 'Pix' || framework.name === 'Pix 6e' || framework.name === 'Numérique Responsable',
     );
 
     const areasByFramework = await Promise.all(

--- a/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
+++ b/admin/tests/acceptance/authenticated/combined-course-blueprints/create-combined-course-blueprint-test.js
@@ -66,8 +66,8 @@ module('Acceptance | Combined course blueprint | New', function (hooks) {
     await click(screen.getByRole('option', { name: 'Parentalite' }));
 
     await click(
-      screen.getByRole('radio', {
-        name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
+      screen.getByRole('button', {
+        name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
       }),
     );
 

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -294,43 +294,71 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
       test('it should display tubes from multiple frameworks', async function (assert) {
         // given
-        const tube3 = store.createRecord('tube', {
+        // Framework Pix6e
+        const tubePix6e = store.createRecord('tube', {
           id: 'tubeId3',
           name: '@tubeName3',
           practicalTitle: 'Tube 3',
           skills: [],
           level: 8,
         });
-
-        const thematic2 = store.createRecord('thematic', {
+        const thematicPix6e = store.createRecord('thematic', {
           id: 'thematicId2',
           name: 'Thématique 2',
-          tubes: [tube3],
+          tubes: [tubePix6e],
         });
-
-        const competence2 = store.createRecord('competence', {
+        const competencePix6e = store.createRecord('competence', {
           id: 'competenceId2',
           index: '2',
           name: 'Titre competence 2',
-          thematics: [thematic2],
+          thematics: [thematicPix6e],
         });
-
-        const area2 = store.createRecord('area', {
+        const areaPix6e = store.createRecord('area', {
           id: 'areaId2',
           title: 'Titre domaine 2',
           code: 2,
-          competences: [competence2],
+          competences: [competencePix6e],
         });
-
-        const framework2 = store.createRecord('framework', {
+        const frameworkPix6e = store.createRecord('framework', {
           id: 'frameworkId2',
           name: 'Pix 6e',
-          areas: [area2],
+          areas: [areaPix6e],
+        });
+
+        // Framework Numérique Responsable
+        const tubeNumeriqueResponsable = store.createRecord('tube', {
+          id: 'tubeId4',
+          name: '@tubeName4',
+          practicalTitle: 'Tube 4',
+          skills: [],
+          level: 8,
+        });
+        const thematicNumeriqueResponsable = store.createRecord('thematic', {
+          id: 'thematicId3',
+          name: 'Thématique 3',
+          tubes: [tubeNumeriqueResponsable],
+        });
+        const competenceNumeriqueResponsable = store.createRecord('competence', {
+          id: 'competenceId3',
+          index: '3',
+          name: 'Titre competence 3',
+          thematics: [thematicNumeriqueResponsable],
+        });
+        const areaNumeriqueResponsable = store.createRecord('area', {
+          id: 'areaId3',
+          title: 'Titre domaine 3',
+          code: 2,
+          competences: [competenceNumeriqueResponsable],
+        });
+        const frameworkNumeriqueResponsable = store.createRecord('framework', {
+          id: 'frameworkId3',
+          name: 'NumeriqueResponsable',
+          areas: [areaNumeriqueResponsable],
         });
 
         const model = {
           attestations,
-          frameworks: [framework, framework2],
+          frameworks: [framework, frameworkPix6e, frameworkNumeriqueResponsable],
           blueprint,
         };
 

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -251,6 +251,16 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         const screen = await render(<template><CombinedCourseBlueprintForm @model={{model}} /></template>);
 
         //then
+        assert.ok(
+          await screen.getByRole('heading', {
+            name: t('components.combined-course-blueprints.create.attestations'),
+          }),
+        );
+        assert.notOk(
+          await screen.queryByRole('textbox', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.description'),
+          }),
+        );
         assert.notOk(
           await screen.queryByRole('button', {
             name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),

--- a/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
+++ b/admin/tests/integration/components/combined-course-blueprints/form-test.gjs
@@ -232,7 +232,7 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         });
       });
 
-      test('it should display tubes selection component only if the user selects an attestation and chooses type of selection', async function (assert) {
+      test('it should display tubes selection component only if the user selects an attestation and add capped tubes requirements', async function (assert) {
         //given
         const frameworks = [
           {
@@ -252,13 +252,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
         //then
         assert.notOk(
-          await screen.queryByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
-          }),
-        );
-        assert.notOk(
-          await screen.queryByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.multiple-subsets-option'),
+          await screen.queryByRole('button', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
           }),
         );
         assert.notOk(
@@ -275,8 +270,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
 
         await click(screen.getByRole('option', { name: 'Parentalite' }));
         await click(
-          screen.getByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.multiple-subsets-option'),
+          screen.getByRole('button', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
           }),
         );
 
@@ -347,12 +342,12 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         const areaNumeriqueResponsable = store.createRecord('area', {
           id: 'areaId3',
           title: 'Titre domaine 3',
-          code: 2,
+          code: 3,
           competences: [competenceNumeriqueResponsable],
         });
         const frameworkNumeriqueResponsable = store.createRecord('framework', {
           id: 'frameworkId3',
-          name: 'NumeriqueResponsable',
+          name: 'Numérique Responsable',
           areas: [areaNumeriqueResponsable],
         });
 
@@ -371,14 +366,15 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         await screen.findByRole('listbox');
         await click(screen.getByRole('option', { name: 'Parentalite' }));
         await click(
-          screen.getByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
+          screen.getByRole('button', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
           }),
         );
 
         //then
         assert.ok(screen.getByText('1 · Titre domaine'));
         assert.ok(screen.getByText('2 · Titre domaine 2'));
+        assert.ok(screen.getByText('3 · Titre domaine 3'));
       });
 
       test('it should not include tubes from unexpected frameworks', async function (assert) {
@@ -424,14 +420,14 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         await screen.findByRole('listbox');
         await click(screen.getByRole('option', { name: 'Parentalite' }));
         await click(
-          screen.getByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
+          screen.getByRole('button', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
           }),
         );
 
         //then
         assert.ok(screen.getByText('1 · Titre domaine'));
-        assert.notOk(screen.queryByText('3 · Other Framework'));
+        assert.notOk(screen.queryByText('3 · Area'));
       });
 
       test('it should save blueprint with selected tubes requirements when they are selected', async function (assert) {
@@ -449,8 +445,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         await screen.findByRole('listbox');
         await click(screen.getByRole('option', { name: 'Parentalite' }));
         await click(
-          screen.getByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.one-subset-option'),
+          screen.getByRole('button', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
           }),
         );
 
@@ -502,8 +498,8 @@ module('Integration | Component | CombinedCourseBlueprints::form', function (hoo
         await click(screen.getByRole('option', { name: 'Parentalite' }));
 
         await click(
-          screen.getByRole('radio', {
-            name: t('components.combined-course-blueprints.labels.reward-requirements.multiple-subsets-option'),
+          screen.getByRole('button', {
+            name: t('components.combined-course-blueprints.labels.reward-requirements.add-new-tubes-selection'),
           }),
         );
         assert.ok(

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -849,6 +849,10 @@
         "detach-organization-success": "Blueprint is not shared with organization {name} anymore."
       },
       "reward-requirements": {
+        "errors": {
+          "threshold-required": "The threshold must be defined",
+          "tubes-required": "The requirement group must contain at least one element"
+        },
         "levels": "Levels",
         "requirements-group-name": "Requirements group",
         "thematics": "Thematics",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -854,6 +854,10 @@
         "detach-organization-success": "Le schéma de parcours n'est plus partagé avec l'organisation {name}."
       },
       "reward-requirements": {
+        "errors": {
+          "threshold-required": "Le taux de réussite doit être renseigné",
+          "tubes-required": "Le critère d'obtention doit contenir au moins un sujet"
+        },
         "levels": "Niveaux",
         "requirements-group-name": "Groupe de critères",
         "thematics": "Thématiques",


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
On a remarqué que, lors de la création d’un parcours avec attestation et avec des capped tubes sélectionnés, rien n’empêche la soumission du form si on n’a pas renseigné de threshold.

Dans ce cas, le blueprint est créé correctement mais les capped tubes sont complètement ignorés.

Le souci : dans le composant form, au save, on n’ajoute l’adapter option pour les capped tubes que si on a un threshold.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Ajout d'une validation dans la méthode save() avant de d'appeler l'adapter permettant d'avertir l'utilisateur d'un champ manquant

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Vu avec Gégé -> suppression des radio buttons permettant de choisir entre 1 seul ensemble de sujets capés et plusieurs sous-ensembles.
Ajout du référentiel Numérique Responsable dans la liste des frameworks.
Déplacement de la liste de sélection 'une attestation dans la section "Les Attestations".

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
- Dans Pix Admin, créer un schéma de parcours combiné avec 1 attestation, ajouter des critères de sélection, sélectionner des sujets avec leur niveau, **sans renseigner de Taux de reussite requis**.
- Soumettre le formulaire -> La création est refusée, un toast affiche l'erreur (threshold manquant)
- Renseigner le Taux de reussite requis
- Soumettre le formulaire
- Le schéma de parcours ets créé avec succès.
