### PR TITLE
[FEATURE] Tagger les contenus formatifs que l'on veut mettre en avant (PIX-24005)

### DIFF
--- a/api/db/seeds/data/common/tooling/campaign-tooling.js
+++ b/api/db/seeds/data/common/tooling/campaign-tooling.js
@@ -44,6 +44,7 @@ export { createAssessmentCampaign, createProfilesCollectionCampaign };
  * @param {string} customResultPageButtonUrl
  * @param {boolean} multipleSendings
  * @param {string} assessmentMethod
+ * @param {number[]} highlightedTrainingIds
  * @param configCampaign
  * {
  *  participantCount: number,
@@ -84,6 +85,7 @@ async function createAssessmentCampaign({
   assessmentMethod,
   configCampaign,
   recommendationEngine,
+  highlightedTrainingIds,
 }) {
   const { realCampaignId, realOrganizationId, realCreatedAt } = _buildCampaign({
     databaseBuilder,
@@ -111,6 +113,7 @@ async function createAssessmentCampaign({
     multipleSendings,
     assessmentMethod,
     recommendationEngine,
+    highlightedTrainingIds,
   });
 
   const campaignSkills = await _buildCampaignSkills({
@@ -459,6 +462,7 @@ function _buildCampaign({
   multipleSendings,
   assessmentMethod,
   recommendationEngine,
+  highlightedTrainingIds,
 }) {
   const {
     id: realCampaignId,
@@ -502,6 +506,7 @@ function _buildCampaign({
     databaseBuilder.factory.buildCampaignFeature({
       campaignId: realCampaignId,
       featureId: FEATURE_CAMPAIGN_RECOMMENDATION_ENGINE_ID,
+      params: highlightedTrainingIds ? { highlightedTrainingIds } : undefined,
     });
   }
   return { realCampaignId, realOrganizationId, realCreatedAt };

--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -29,11 +29,13 @@ async function _createScoCampaigns(databaseBuilder, trainingIds, participantCoun
     targetProfileId: PIX_EDU_SMALL_TARGET_PROFILE_ID,
     configCampaign: {
       participantCount,
-      completionDistribution: { started: participantCount },
+      completionDistribution: { shared: participantCount },
       profileDistribution: { beginner: 1, perfect: 1, blank: 1 },
       recommendedTrainingsIds: trainingIds,
     },
     recommendationEngine: true,
+    // trainingIds[9] is frFrTrainingId2 (DEVCOMP_BASE_TRAINING_ID + 9), built by buildTrainings.
+    highlightedTrainingIds: [trainingIds[9]],
   });
 }
 

--- a/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
+++ b/api/src/devcomp/domain/read-models/UserRecommendedTraining.js
@@ -14,6 +14,7 @@ class UserRecommendedTraining {
     objectives,
     description,
     isRelevant,
+    isHighlighted,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -25,6 +26,9 @@ class UserRecommendedTraining {
     this.editorLogoUrl = editorLogoUrl;
     this.deliveryMode = deliveryMode;
     this.isRelevant = isRelevant;
+    if (isHighlighted !== undefined) {
+      this.isHighlighted = isHighlighted;
+    }
     this.registrationRequired = registrationRequired;
     this.program = program;
     this.objectives = objectives;

--- a/api/src/devcomp/domain/usecases/find-campaign-participation-trainings.js
+++ b/api/src/devcomp/domain/usecases/find-campaign-participation-trainings.js
@@ -1,4 +1,5 @@
 import { UserNotAuthorizedToFindTrainings } from '../errors.js';
+import { UserRecommendedTraining } from '../read-models/UserRecommendedTraining.js';
 
 const findCampaignParticipationTrainings = async function ({
   userId,
@@ -6,6 +7,7 @@ const findCampaignParticipationTrainings = async function ({
   campaignParticipationId,
   campaignParticipationRepository,
   userRecommendedTrainingRepository,
+  campaignFeatureRepository,
 }) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
@@ -13,7 +15,15 @@ const findCampaignParticipationTrainings = async function ({
     throw new UserNotAuthorizedToFindTrainings();
   }
 
-  return userRecommendedTrainingRepository.findByCampaignParticipationId({ campaignParticipationId, locale });
+  const [trainings, highlightedTrainingIds] = await Promise.all([
+    userRecommendedTrainingRepository.findByCampaignParticipationId({ campaignParticipationId, locale }),
+    campaignFeatureRepository.getHighlightedTrainingsForCampaign({ campaignId: campaignParticipation.campaignId }),
+  ]);
+
+  return trainings.map(
+    (training) =>
+      new UserRecommendedTraining({ ...training, isHighlighted: highlightedTrainingIds.includes(training.id) }),
+  );
 };
 
 export { findCampaignParticipationTrainings };

--- a/api/src/devcomp/infrastructure/repositories/campaign-feature-repository.js
+++ b/api/src/devcomp/infrastructure/repositories/campaign-feature-repository.js
@@ -1,0 +1,14 @@
+import { CAMPAIGN_FEATURES } from '../../../shared/constants.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+const getHighlightedTrainingsForCampaign = async function ({ campaignId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const campaignFeature = await knexConn('campaign-features')
+    .select('params')
+    .join('features', 'features.id', 'campaign-features.featureId')
+    .where({ campaignId, 'features.key': CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE.key })
+    .first();
+  return campaignFeature?.params?.highlightedTrainingIds ?? [];
+};
+
+export { getHighlightedTrainingsForCampaign };

--- a/api/src/devcomp/infrastructure/repositories/index.js
+++ b/api/src/devcomp/infrastructure/repositories/index.js
@@ -1,6 +1,7 @@
 import { injectDependencies } from '../../../shared/infrastructure/utils/dependency-injection.js';
 import boundedContext from '../../dependencies.json' with { type: 'json' };
 import moduleDatasource from '../datasources/learning-content/module-datasource.js';
+import * as campaignFeatureRepository from './campaign-feature-repository.js';
 import * as elementAnswerRepository from './element-answer-repository.js';
 import * as elementRepository from './element-repository.js';
 import * as moduleMetadataRepository from './module-metadata-repository.js';
@@ -16,6 +17,7 @@ import * as userRecommendedTrainingRepository from './user-recommended-training-
 import * as userSavedTutorialRepository from './user-saved-tutorial-repository.js';
 
 const repositoriesWithoutInjectedDependencies = {
+  campaignFeatureRepository,
   elementAnswerRepository,
   elementRepository,
   moduleRepository,

--- a/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js
@@ -108,6 +108,7 @@ const serialize = function (training = {}, meta) {
       'objectives',
       'description',
       'isRelevant',
+      'isHighlighted',
     ],
     targetProfileSummaries: {
       ref: 'id',

--- a/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/devcomp/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { Training } from '../../../../../src/devcomp/domain/models/Training.js';
+import { CAMPAIGN_FEATURES } from '../../../../../src/shared/constants.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { getServer } from '../../../../tooling/server/shared-server.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
@@ -14,7 +15,7 @@ describe('Acceptance | API | Campaign Participations', function () {
   });
 
   describe('GET /api/campaign-participations/{id}/trainings', function () {
-    it('should return the campaign-participation trainings', async function () {
+    it('should return the campaign-participation trainings with isHighlighted set to false by default', async function () {
       // given
       const training = databaseBuilder.factory.buildTraining();
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
@@ -49,10 +50,74 @@ describe('Acceptance | API | Campaign Participations', function () {
         'delivery-mode': Training.modes.HYBRID,
         'registration-required': false,
         'is-relevant': null,
+        'is-highlighted': false,
         program: 'Programme du contenu formatif',
         objectives: [],
         description: "<p>Voici la description d'un contenu formatif</p>",
       });
+    });
+
+    it('should return isHighlighted set to true when the training is in the campaign highlightedTrainingIds', async function () {
+      // given
+      const training = databaseBuilder.factory.buildTraining();
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId: campaignParticipation.userId,
+        trainingId: training.id,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      const feature = databaseBuilder.factory.buildFeature(CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE);
+      databaseBuilder.factory.buildCampaignFeature({
+        campaignId: campaignParticipation.campaignId,
+        featureId: feature.id,
+        params: { highlightedTrainingIds: [training.id] },
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/campaign-participations/${campaignParticipation.id}/trainings`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].attributes['is-highlighted']).to.equal(true);
+    });
+
+    it('should return isHighlighted set to false when no training in the campaign highlightedTrainingIds', async function () {
+      // given
+      const training = databaseBuilder.factory.buildTraining();
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+        userId: user.id,
+      });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId: campaignParticipation.userId,
+        trainingId: training.id,
+        campaignParticipationId: campaignParticipation.id,
+      });
+      const feature = databaseBuilder.factory.buildFeature(CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE);
+      databaseBuilder.factory.buildCampaignFeature({
+        campaignId: campaignParticipation.campaignId,
+        featureId: feature.id,
+      });
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/campaign-participations/${campaignParticipation.id}/trainings`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: user.id }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].attributes['is-highlighted']).to.equal(false);
     });
   });
 

--- a/api/tests/devcomp/integration/infrastructure/repositories/campaign-feature-repository_test.js
+++ b/api/tests/devcomp/integration/infrastructure/repositories/campaign-feature-repository_test.js
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+
+import * as campaignFeatureRepository from '../../../../../src/devcomp/infrastructure/repositories/campaign-feature-repository.js';
+import { CAMPAIGN_FEATURES } from '../../../../../src/shared/constants.js';
+import { databaseBuilder } from '../../../../tooling/databases.js';
+
+describe('Integration | DevComp | Repositories | CampaignFeatureRepository', function () {
+  describe('when the campaign has no RECOMMENDATION_ENGINE featur', function () {
+    it('should return an empty array', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      await databaseBuilder.commit();
+
+      // when
+      const highlightedTrainingIds = await campaignFeatureRepository.getHighlightedTrainingsForCampaign({
+        campaignId,
+      });
+
+      // then
+      expect(highlightedTrainingIds).to.deep.equal([]);
+    });
+
+    it('should return an empty array when the RECOMMENDATION_ENGINE feature has no highlightedTrainingIds param', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      const feature = databaseBuilder.factory.buildFeature(CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE);
+      databaseBuilder.factory.buildCampaignFeature({ campaignId, featureId: feature.id });
+      await databaseBuilder.commit();
+
+      // when
+      const highlightedTrainingIds = await campaignFeatureRepository.getHighlightedTrainingsForCampaign({
+        campaignId,
+      });
+
+      // then
+      expect(highlightedTrainingIds).to.deep.equal([]);
+    });
+
+    it('should return the highlightedTrainingIds stored in the RECOMMENDATION_ENGINE feature params', async function () {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign().id;
+      const feature = databaseBuilder.factory.buildFeature(CAMPAIGN_FEATURES.RECOMMENDATION_ENGINE);
+      databaseBuilder.factory.buildCampaignFeature({
+        campaignId,
+        featureId: feature.id,
+        params: { highlightedTrainingIds: [123, 456] },
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const highlightedTrainingIds = await campaignFeatureRepository.getHighlightedTrainingsForCampaign({
+        campaignId,
+      });
+
+      // then
+      expect(highlightedTrainingIds).to.deep.equal([123, 456]);
+    });
+  });
+});

--- a/api/tests/devcomp/unit/domain/usecases/find-campaign-participation-trainings_test.js
+++ b/api/tests/devcomp/unit/domain/usecases/find-campaign-participation-trainings_test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { UserNotAuthorizedToFindTrainings } from '../../../../../src/devcomp/domain/errors.js';
+import { UserRecommendedTraining } from '../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import { findCampaignParticipationTrainings } from '../../../../../src/devcomp/domain/usecases/find-campaign-participation-trainings.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
@@ -9,10 +10,12 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 describe('Unit | Devcomp | Domain | UseCases | find-campaign-participation-trainings', function () {
   let campaignParticipationRepository;
   let userRecommendedTrainingRepository;
+  let campaignFeatureRepository;
 
   beforeEach(function () {
     campaignParticipationRepository = { get: sinon.stub() };
     userRecommendedTrainingRepository = { findByCampaignParticipationId: sinon.stub() };
+    campaignFeatureRepository = { getHighlightedTrainingsForCampaign: sinon.stub() };
   });
 
   context('when authenticated user is not the campaign participation owner', function () {
@@ -32,6 +35,7 @@ describe('Unit | Devcomp | Domain | UseCases | find-campaign-participation-train
         campaignParticipationId: campaignParticipation.id,
         campaignParticipationRepository,
         userRecommendedTrainingRepository,
+        campaignFeatureRepository,
       });
 
       // then
@@ -40,13 +44,15 @@ describe('Unit | Devcomp | Domain | UseCases | find-campaign-participation-train
   });
 
   context('when authenticated user is the campaign participation owner', function () {
-    it('should return array of recommended trainings', async function () {
+    it('should return trainings with isHighlighted set to true for highlighted trainings', async function () {
       // given
       const userId = 123;
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId });
       campaignParticipationRepository.get.resolves(campaignParticipation);
-      const trainings = Symbol('trainings');
-      userRecommendedTrainingRepository.findByCampaignParticipationId.resolves(trainings);
+      const highlightedTraining = new UserRecommendedTraining({ id: 1 });
+      const otherTraining = new UserRecommendedTraining({ id: 2 });
+      userRecommendedTrainingRepository.findByCampaignParticipationId.resolves([highlightedTraining, otherTraining]);
+      campaignFeatureRepository.getHighlightedTrainingsForCampaign.resolves([1]);
 
       // when
       const result = await findCampaignParticipationTrainings({
@@ -55,13 +61,18 @@ describe('Unit | Devcomp | Domain | UseCases | find-campaign-participation-train
         locale: 'fr-fr',
         campaignParticipationRepository,
         userRecommendedTrainingRepository,
+        campaignFeatureRepository,
       });
 
       // then
-      expect(result).to.deep.equal(trainings);
+      expect(result.find((training) => training.id === 1).isHighlighted).to.equal(true);
+      expect(result.find((training) => training.id === 2).isHighlighted).to.equal(false);
       expect(userRecommendedTrainingRepository.findByCampaignParticipationId).to.have.been.calledWithExactly({
         campaignParticipationId: campaignParticipation.id,
         locale: 'fr-fr',
+      });
+      expect(campaignFeatureRepository.getHighlightedTrainingsForCampaign).to.have.been.calledWithExactly({
+        campaignId: campaignParticipation.campaignId,
       });
     });
   });

--- a/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/devcomp/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { Training } from '../../../../../../src/devcomp/domain/models/Training.js';
+import { UserRecommendedTraining } from '../../../../../../src/devcomp/domain/read-models/UserRecommendedTraining.js';
 import { trainingSerializer } from '../../../../../../src/devcomp/infrastructure/serializers/jsonapi/training-serializer.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -438,6 +439,33 @@ describe('Unit | DevComp | Infrastructure | Serializers | Jsonapi | training-ser
 
       // then
       expect(json).to.deep.equal(expectedSerializedTraining);
+    });
+
+    it('should serialize the isHighlighted attribute', function () {
+      // given
+      const training = new UserRecommendedTraining({
+        id: 1,
+        title: 'Training 1',
+        link: 'https://example.net',
+        type: 'webinar',
+        duration: { hours: 5 },
+        locales: ['fr-fr'],
+        editorName: 'Ministère education nationale',
+        editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/editor_logo_url.svg',
+        deliveryMode: Training.modes.REMOTE,
+        registrationRequired: false,
+        program: 'training program',
+        objectives: ['objective 1'],
+        description: 'description',
+        isRelevant: true,
+        isHighlighted: true,
+      });
+
+      // when
+      const json = trainingSerializer.serialize(training);
+
+      // then
+      expect(json.data.attributes['is-highlighted']).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## Problème

Aujourd'hui, il n'est pas possible d'indiquer qu'un contenu formatif doit être mis en avant sur la page de résultats de fin de campagne. Or, on veut pouvoir indiquer qu'un contenu formatif doit être mis en avant sur la page de résultats de fin de campagne. C'est un problème.

## Solution

La solution : permettre d'indiquer qu'un contenu formatif doit être mis en avant sur la page de résultats de fin campagne via l'ajout de paramètres au feature flag de la campagne qui sert déjà à signaler qu'elle utilise le moteur de recommandation et renvoyer cette information dans la route trainings.

## Remarques

Un nouveau repository dans le domaine devcomp appelle directement la table campaign-features 
=> utiliser une API interne pour cela. Ticket créé [ici](https://1024pix.atlassian.net/browse/PIX-24089?atlOrigin=eyJpIjoiZWVjMjExNmQ2MjNjNGIzN2IxYWFhZDZhYzA1ZDMwNDkiLCJwIjoiaiJ9)

## Comment tester

1. Se connecter avec dave-comp@example.net / pix123
2. Entrer le code de campagne EDUMULTIP
3. Passer les questions
4. Sur la page de fin de campagne, ouvrir les devtools onglet "Network" et constater que la route trainings renvoie un contenu formatif highlighted, et l'autre non.