### PR TITLE
[TECH] Intégrer les retours des partenaires sur les fichiers de traduction 'de' et 'it' (PIX-24037)

### DIFF
--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -303,16 +303,16 @@
       "start-landing-page": {
         "steps": {
           "step1": {
-            "description": "Beantworte Fragen, die an dein Niveau angepasst sind.",
-            "title": "Teste dich selbst"
+            "description": "Beantworte die Fragen, die an dein Können angepasst sind",
+            "title": "Ermittle deine digitale Einstufung"
           },
           "step2": {
-            "description": "Analysiere deine Stärken und Verbesserungsmöglichkeiten",
-            "title": "Entdecke deine Punktzahl"
+            "description": "Analysiere deine Stärken und Verbesserungspotenziale",
+            "title": "Ermittle dein Ergebnis"
           },
           "step3": {
-            "description": "Zugang zu Übungen, die auf deine Ergebnisse zugeschnitten sind",
-            "title": "Fortschritt"
+            "description": "Erhalte Zugang auf deine Ergebnisse und verbessere dein Wissen über Lernpfade",
+            "title": "Erziele Fortschritte"
           }
         }
       }
@@ -590,8 +590,8 @@
     },
     "campaign-landing": {
       "assessment": {
-        "action": "Ich beginne",
-        "announcement": "Registriere dich oder logge dich auf der Pix-Plattform ein und starte deinen Test.",
+        "action": "Jetzt starten",
+        "announcement": "Registriere dich bzw. melde dich auf der Pix-Plattform an und starte dein Assessment.",
         "certify": {
           "description": "Je nach deiner Situation und unter bestimmten Bedingungen kannst du Zugang zu der in der Berufswelt anerkannten Pix-Zertifizierung erhalten, mit der du deine digitalen Kompetenzen aufwerten kannst. Für weitere Informationen erkundige dich bitte bei dem Organisator des Bildungsgangs.",
           "title": "Die in diesem Lernpfad validierten Antworten tragen dazu bei, dein persönliches Profil der digitalen Kompetenzen auf Pix zu erweitern."
@@ -606,8 +606,8 @@
           "title": "Miss deine digitalen Kompetenzen mit spielerischen und lernenden Herausforderungen, die sich an deinen Kenntnisstand anpassen (über einen adaptiven Algorithmus)."
         },
         "exam-notice": "Während dieses Tests wird dein Kompetenzprofil weder berücksichtigt noch verändert. Deine Antworten haben keinen Einfluss auf deine Stufen oder deine Gesamt-Pix-Punktzahl.",
-        "legal": "Wenn du auf \"Beginnen\" klickst, werden die Informationen über deinen Fortschritt auf dem Pfad an den Organisator der Pfade weitergeleitet, damit er dich begleiten kann. Am Ende des Lernpfads werden deine Ergebnisse automatisch an den Organisator weitergeleitet.",
-        "title": "Beginne deinen Pix-Lernpfad",
+        "legal": "Per Klick auf „Jetzt starten“ werden Informationen zu deinem Fortschritt an den Organisator übermittelt, damit du unterstützt werden kannst. Nach dem Assessment werden deine Ergebnisse automatisch an den Organisator gesendet.",
+        "title": "Starte deine Pix-Erfahrung",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' bereit, deine digitalen Kompetenzen zu bewerten?"
       },
       "profiles-collection": {
@@ -1670,7 +1670,7 @@
             "no": "Nein",
             "yes": "Ja!"
           },
-          "nextCard": "Weiter zu",
+          "nextCard": "Weiter",
           "retry": "Erneut versuchen",
           "seeAgain": "Überarbeiten",
           "seeAnswer": "Siehe die Antwort",
@@ -1700,7 +1700,7 @@
           "next": {
             "ariaLabel": "Zum nächsten Schritt gehen",
             "horizontal": {
-              "name": "Weiter zu"
+              "name": "Weiter"
             },
             "vertical": {
               "name": "Mehr lesen"
@@ -2174,7 +2174,7 @@
         }
       },
       "first-title": "Anmelden",
-      "save-progress-message": "Um deinen Fortschritt zu behalten und dich weiterhin zu bewerten, melde dich bei Pix an!",
+      "save-progress-message": "Damit du deinen Fortschritt behalten und dich weiterhin selbst testen kannst, melde dich bei Pix an!",
       "title": "Anmeldung"
     },
     "sitemap": {
@@ -2234,7 +2234,7 @@
         },
         "see-my-recommendations": "Meine Empfehlungen ansehen",
         "see-trainings": "Übung ansehen",
-        "shared-message": "Deine Ergebnisse wurden am {date} an {time} gesendet.",
+        "shared-message": "Deine Ergebnisse wurden um {date} an {time} gesendet.",
         "staged-message": {
           "show-less": "Einklappen",
           "show-more": "Mehr anzeigen"
@@ -2335,10 +2335,13 @@
           }
         },
         "trainings": {
+          "carousel-roledescription": "Karussell",
           "description": "Die unten aufgeführten Lösungen werden dir basierend auf deinem Niveau empfohlen.",
           "next-button-aria-label": "Nächste Weiterbildungen anzeigen",
           "pagination-announcement": "Weiterbildungen {from} bis {to} von {total} angezeigt",
           "previous-button-aria-label": "Vorherige Weiterbildungen anzeigen",
+          "slide-aria-label": "{position} von {total}",
+          "slide-role-description": "Rutsche",
           "title": "Gehen Sie noch einen Schritt weiter – ganz in Ihrem eigenen Tempo."
         }
       },
@@ -2365,9 +2368,9 @@
         "caption": "Details zu deinen Ergebnissen in Form von Prozenten und Sternen auf der Grundlage von Kompetenzen",
         "masteryPercentage": "{rate, number, ::percent} des Erfolgs",
         "recommendedEngine": {
-          "starsAcquired": "{acquired}/{total, plural, =0 {Stern} =1 {# Stern} other {# Sterne}}"
+          "starsAcquired": "{acquired}/{total, plural, =0 {Stern} =1 {# Stern} other {# Sternen}}"
         },
-        "starsAcquired": "{acquired, plural, =0 {kein Stern erworben} =1 {# Stern erworben} other {# Sterne erworben}} auf {total}.",
+        "starsAcquired": "{acquired} von {total} {acquired, plural, =0 {Stern erhalten} =1 {Stern erhalten} other {Sternen erhalten}}.",
         "title": "Details zu Kompetenzen"
       },
       "tabs": {
@@ -2438,7 +2441,7 @@
       "dot-action-description": "Gehe zu Schritt {stepNumber} von {stepsCount}.",
       "dot-action-title": "Schritt {stepNumber} von {stepsCount}.",
       "dots-nav-label": "Schritte im Lernprogramm",
-      "next": "Weiter zu",
+      "next": "Weiter",
       "next-title": "Nächsten Schritt anzeigen",
       "pages": {
         "page0": {
@@ -2446,7 +2449,7 @@
           "title": "Du kannst im Internet suchen ..."
         },
         "page1": {
-          "explanation": "Wenn dieses Bild angezeigt wird, verwende nur dein eigenes Wissen!\n Du darfst weder das Internet noch andere Programme verwenden.",
+          "explanation": "Wenn dieses Bild angezeigt wird, darfst du nur dein eigenes Wissen verwenden.\nDas Internet oder andere Programme als Hilfe sind dabei nicht erlaubt.",
           "title": "... außer bei bestimmten Fragen"
         },
         "page2": {
@@ -2458,13 +2461,13 @@
           "title": "Tutorials zum Lernen"
         },
         "page4": {
-          "explanation": "Abhängig von deinen Antworten,\nPix passt den Schwierigkeitsgrad der Fragen an.",
+          "explanation": "Abhängig von deinen Antworten passt Pix\nden Schwierigkeitsgrad der Fragen an.",
           "title": "Ein angepasster Schwierigkeitsgrad"
         }
       },
       "pass": "Ignorieren",
       "pass-title": "Das Tutorial ignorieren und meinen Kurs starten",
-      "start": "Meinen Kurs starten",
+      "start": "Test starten",
       "title": "Tutorial zur Kampagne"
     },
     "tutorial-panel": {

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -303,16 +303,16 @@
       "start-landing-page": {
         "steps": {
           "step1": {
-            "description": "Rispondere a domande adeguate al proprio livello",
-            "title": "Valutati"
+            "description": "Rispondi a domande adattate al tuo livello",
+            "title": "Mettiti alla prova"
           },
           "step2": {
-            "description": "Analizzare i propri punti di forza e le aree di miglioramento",
+            "description": "Analizza i tuoi punti di forza e le aree di miglioramento",
             "title": "Scopri il tuo punteggio"
           },
           "step3": {
-            "description": "Accesso a una formazione personalizzata in base ai tuoi risultati",
-            "title": "Progredisci"
+            "description": "Accedi a percorsi formativi personalizzati in base ai tuoi risultati",
+            "title": "Migliora progressivamente"
           }
         }
       }
@@ -591,7 +591,7 @@
     "campaign-landing": {
       "assessment": {
         "action": "Inizia",
-        "announcement": "Registrati o accedi alla piattaforma Pix e iniziate il tuo test.",
+        "announcement": "Registrati o accedi alla piattaforma Pix e inizia il test.",
         "certify": {
           "description": "A seconda della tua situazione e a determinate condizioni, puoi accedere alla certificazione Pix, riconosciuta dal mondo professionale e che ti permette di migliorare le tue competenze digitali. Per ulteriori informazioni, contattare l'organizzatore del percorso.",
           "title": "Le risposte convalidate in questo percorso contribuiranno al tuo profilo personale di competenze digitali su Pix."
@@ -606,7 +606,7 @@
           "title": "Misurate le tue competenze digitali con sfide di apprendimento divertenti che si adattano al tuo livello di competenza (utilizzando un algoritmo adattivo)."
         },
         "exam-notice": "Durante questo percorso, il Suo profilo di competenze non verrà preso in considerazione né modificato. Le Sue risposte non avranno alcun impatto sui Suoi livelli di competenze né sul Suo punteggio Pix complessivo.",
-        "legal": "Cliccando su \"Sto iniziando\", le informazioni sui tuoi progressi nel percorso saranno inviate all'organizzatore del percorso in modo che possa supportarvi. Al termine del percorso, i risultati saranno inviati automaticamente all'organizzatore.",
+        "legal": "Cliccando su \"Inizia\", le informazioni sui tuoi progressi saranno condivise con la tua organizzazione, così che potrà fornirti supporto se necessario. Al termine del test, i tuoi risultati saranno condivisi automaticamente con la tua organizzazione.",
         "title": "Inizia il tuo viaggio Pix",
         "title-with-username": "'<span>'{userFirstName}'</span>','<br>' pronti a valutare le tue competenze digitali?"
       },
@@ -1281,8 +1281,8 @@
         "title": "Congratulazioni! Hai finito!"
       },
       "content": {
-        "resume-button": "Continua il mio viaggio",
-        "start-button": "Inizia il mio percorso",
+        "resume-button": "Continua il test personalizzato",
+        "start-button": "Inizia il test personalizzato",
         "step": "Fase {stepNumber}"
       },
       "errors": {
@@ -1564,7 +1564,7 @@
       "verify": "Controlla il certificato"
     },
     "fill-in-participant-external-id": {
-      "announcement": "L'organizzatore ha bisogno delle seguenti informazioni per potervi accompagnare:",
+      "announcement": "Per poterti aiutare, l'organizzatore ha bisogno delle seguenti informazioni:",
       "buttons": {
         "cancel": "Annulla",
         "continue": "Continua"
@@ -2335,10 +2335,13 @@
           }
         },
         "trainings": {
+          "carousel-roledescription": "cargiola",
           "description": "Le soluzioni elencate qui sotto ti vengono consigliate in base al tuo livello.",
           "next-button-aria-label": "Vedi le formazioni successive",
           "pagination-announcement": "Formazioni da {from} a {to} su {total} visualizzate",
           "previous-button-aria-label": "Vedi le formazioni precedenti",
+          "slide-aria-label": "{position} di {total}",
+          "slide-roledescription": "slide",
           "title": "Andate oltre, al vostro ritmo."
         }
       },
@@ -2442,29 +2445,29 @@
       "next-title": "Mostra il passo successivo",
       "pages": {
         "page0": {
-          "explanation": "Se non conoscete la risposta\nprobabilmente si trova su Internet.",
+          "explanation": "Se non conosci la risposta ad una domanda,\nprobabilmente puoi trovarla su Internet.",
           "title": "Puoi cercare su Internet..."
         },
         "page1": {
-          "explanation": "Se viene visualizzata questa immagine, utilizzare solo ciò che si conosce!\n Non dovete usare Internet o il tuo software.",
+          "explanation": "Se vedi questa immagine, usa solo le tue conoscenze!\nNon cercare su Internet e non utilizzare altri strumenti.",
           "title": "... tranne che per alcune domande"
         },
         "page2": {
-          "explanation": "Prendi tutto il tempo necessario per completare il percorso.\nSe una domanda è a tempo, ciò sarà indicato.",
-          "title": "Senza limiti di tempo!"
+          "explanation": "Prenditi tutto il tempo necessario per completare il tuo test personalizzato.\nSe una domanda è a tempo, te lo segnaleremo.",
+          "title": "Non c’è un limite di tempo!"
         },
         "page3": {
-          "explanation": "Accedere alle esercitazioni per saperne di più\nper saperne di più su ogni domanda e progredire.",
+          "explanation": "Accedi ai tutorial per saperne di più\nsu ogni domanda e migliorare.",
           "title": "Tutorial per l'apprendimento"
         },
         "page4": {
           "explanation": "In base alle tue risposte,\nPix adatta la difficoltà delle domande.",
-          "title": "Il giusto livello di difficoltà"
+          "title": "Livelli di difficoltà adattivi"
         }
       },
       "pass": "Salta",
-      "pass-title": "Salta il tutorial e inizia il mio percorso",
-      "start": "Inizia il mio percorso",
+      "pass-title": "Salta il tutorial e inizia il test personalizzato",
+      "start": "Inizia il test personalizzato",
       "title": "Tutorial della campagna"
     },
     "tutorial-panel": {


### PR DESCRIPTION
## ☀️ Problème

Dans le cadre de Digiclass, les partenaires ont retourné des traductions imprécises dans les locale 'de' et 'it'.

## ⛱️ Proposition

Implémentation des retours dans les fichiers concernés.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

Les pages Pix App (.org) concernées par ces changements sont principalement les pages de lancement d'une campagne.

1. Accéder à https://app-pr17323.review.pix.org/campagnes?locale=de ou https://app-pr17323.review.pix.org/campagnes?locale=it
2. Renseigner un code campagne existant en RA (par ex `CODE123`)
3. Constater les modifications des chaînes de traduction