### PR TITLE
[TECH] Déplacer la logique de formattage des areas du usecase vers le repository (PIX-24072)

### DIFF
--- a/api/src/quest/domain/models/combined-course-blueprints/value-objects/AreaForCappedTubes.js
+++ b/api/src/quest/domain/models/combined-course-blueprints/value-objects/AreaForCappedTubes.js
@@ -1,0 +1,9 @@
+export class AreaForCappedTubes {
+  constructor({ id, title, code, color, competences }) {
+    this.id = id;
+    this.title = title;
+    this.code = code;
+    this.color = color;
+    this.competences = competences;
+  }
+}

--- a/api/src/quest/domain/models/combined-course-blueprints/value-objects/FrameworkForCappedTubes.js
+++ b/api/src/quest/domain/models/combined-course-blueprints/value-objects/FrameworkForCappedTubes.js
@@ -1,6 +1,0 @@
-export class FrameworkForCappedTubes {
-  constructor({ name, areas }) {
-    this.name = name;
-    this.areas = areas;
-  }
-}

--- a/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
+++ b/api/src/quest/domain/usecases/get-combined-course-blueprint-by-id.js
@@ -28,42 +28,14 @@ export const getCombinedCourseBlueprintById = async ({
     combinedCourseBlueprint.rewardRequirements.map(async (requirements, index) => {
       const threshold = requirements?.threshold;
       const name = requirements?.name;
-      const cappedTubeRequirementIds = requirements.cappedTubes.map((cappedTube) => cappedTube.tubeId);
-      const cappedTubesLevelById = new Map(requirements.cappedTubes.map(({ tubeId, level }) => [tubeId, level]));
+      const cappedTubesLevelById = requirements.cappedTubes.map(({ tubeId, level }) => [tubeId, level]);
 
-      const frameworks = await learningContentRepository.findByTubeIds({
-        tubeIds: cappedTubeRequirementIds,
-        locale: 'fr-fr',
+      const formattedAreas = await learningContentRepository.findAreasForTubeIds({
+        tubesWithLevel: cappedTubesLevelById,
       });
 
-      let formattedAreas;
-
-      if (!frameworks.length) {
+      if (!formattedAreas.length) {
         throw new FrameworkNotFoundError();
-      } else {
-        formattedAreas = frameworks.flatMap((framework) =>
-          framework.areas.map((area) => ({
-            ...area,
-            competences: area.competences.map((competence) => ({
-              id: competence.id,
-              name: competence.name,
-              index: competence.index,
-              thematics: competence.thematics.map((thematic) => ({
-                id: thematic.id,
-                name: thematic.name,
-                index: thematic.index,
-                tubes: thematic.tubes
-                  .filter((tube) => cappedTubesLevelById.has(tube.id))
-                  .map((tube) => ({
-                    id: tube.id,
-                    level: cappedTubesLevelById.get(tube.id),
-                    name: tube.name,
-                    practicalTitle: tube.practicalTitle,
-                  })),
-              })),
-            })),
-          })),
-        );
       }
 
       return {

--- a/api/src/quest/infrastructure/repositories/learning-content-repository.js
+++ b/api/src/quest/infrastructure/repositories/learning-content-repository.js
@@ -1,29 +1,59 @@
-import { FrameworkForCappedTubes } from '../../domain/models/combined-course-blueprints/value-objects/FrameworkForCappedTubes.js';
+import { AreaForCappedTubes } from '../../domain/models/combined-course-blueprints/value-objects/AreaForCappedTubes.js';
 
-export const findByTubeIds = async ({ tubeIds, learningContentApi }) => {
+export const findAreasForTubeIds = async ({ tubesWithLevel, learningContentApi }) => {
+  const levelByTubeId = new Map(tubesWithLevel);
+  const tubeIds = [...levelByTubeId.keys()];
+
   const learningContent = await learningContentApi.findByTubeIds({ tubeIds, locale: 'fr-fr' });
-  return toDomain(learningContent);
+  const frameworks = learningContent.learningContentDTO.frameworkDTOs;
+
+  if (!frameworks.length) {
+    return [];
+  }
+
+  const formattedAreas = frameworks.flatMap((framework) =>
+    framework.areaDTOs.map((area) => ({
+      ...area,
+      competences: area.competenceDTOs.map((competence) => ({
+        id: competence.id,
+        name: competence.name,
+        index: competence.index,
+        thematics: competence.thematicDTOs.map((thematic) => ({
+          id: thematic.id,
+          name: thematic.name,
+          index: thematic.index,
+          tubes: thematic.tubeDTOs
+            .filter((tube) => levelByTubeId.has(tube.id))
+            .map((tube) => ({
+              id: tube.id,
+              level: levelByTubeId.get(tube.id),
+              name: tube.name,
+              practicalTitle: tube.practicalTitle,
+            })),
+        })),
+      })),
+    })),
+  );
+
+  return toDomain(formattedAreas);
 };
-const toDomain = (learningContent) => {
-  return learningContent.learningContentDTO.frameworkDTOs.map((framework) => {
-    return new FrameworkForCappedTubes({
-      id: framework.id,
-      name: framework.name,
-      areas: framework.areaDTOs.map((areaDTO) => ({
-        id: areaDTO.id,
-        title: areaDTO.title,
-        code: areaDTO.code,
-        color: areaDTO.color,
-        competences: areaDTO.competenceDTOs.map((competenceDTO) => ({
-          id: competenceDTO.id,
-          name: competenceDTO.name,
-          index: competenceDTO.index,
-          thematics: competenceDTO.thematicDTOs.map((thematicDTO) => ({
-            id: thematicDTO.id,
-            name: thematicDTO.name,
-            index: thematicDTO.index,
-            tubes: thematicDTO.tubeDTOs,
-          })),
+
+const toDomain = (formattedAreas) => {
+  return formattedAreas.map((area) => {
+    return new AreaForCappedTubes({
+      id: area.id,
+      title: area.title,
+      code: area.code,
+      color: area.color,
+      competences: area.competences.map((competence) => ({
+        id: competence.id,
+        name: competence.name,
+        index: competence.index,
+        thematics: competence.thematics.map((thematic) => ({
+          id: thematic.id,
+          name: thematic.name,
+          index: thematic.index,
+          tubes: thematic.tubes,
         })),
       })),
     });

--- a/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
+++ b/api/tests/quest/integration/domain/usecases/get-combined-course-blueprint-by-id_test.js
@@ -12,9 +12,14 @@ import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 describe('Integration | Quest | Domain | UseCases | get-combined-course-blueprint-by-id', function () {
   const now = new Date('2022-11-28T12:00:00Z');
+  let clock;
 
   beforeEach(async function () {
-    sinon.useFakeTimers({ now, toFake: ['Date'] });
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
   });
 
   it('should return a combined course blueprint for a given id', async function () {

--- a/api/tests/quest/unit/infrastructure/repositories/learning-content-repository_test.js
+++ b/api/tests/quest/unit/infrastructure/repositories/learning-content-repository_test.js
@@ -1,14 +1,15 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { FrameworkForCappedTubes } from '../../../../../src/quest/domain/models/combined-course-blueprints/value-objects/FrameworkForCappedTubes.js';
+import { AreaForCappedTubes } from '../../../../../src/quest/domain/models/combined-course-blueprints/value-objects/AreaForCappedTubes.js';
 import * as learningContentRepository from '../../../../../src/quest/infrastructure/repositories/learning-content-repository.js';
 
 describe('Unit | Repositories | Learning Content Repository', function () {
-  describe('#findByTubeIds', function () {
-    it('should call findByTubeIds from learningContentApi', async function () {
+  describe('#findAreasForTubeIds', function () {
+    it('should return formatted Areas from learning content', async function () {
       // given
       const tubeIds = ['tubeId1'];
+      const tubesWithLevel = [['tubeId1', 3]];
       const learningContent = {
         learningContentDTO: {
           frameworkDTOs: [
@@ -24,7 +25,14 @@ describe('Unit | Repositories | Learning Content Repository', function () {
                       id: 'competenceId',
                       index: 'index',
                       name: 'name',
-                      thematicDTOs: [{ id: 'thematicId', index: 'index', name: 'name', tubeDTOs: [{ id: 'tubeId1' }] }],
+                      thematicDTOs: [
+                        {
+                          id: 'thematicId',
+                          index: 'index',
+                          name: 'name',
+                          tubeDTOs: [{ id: 'tubeId1', name: 'name', practicalTitle: 'practicalTitle' }],
+                        },
+                      ],
                     },
                   ],
                 },
@@ -45,7 +53,14 @@ describe('Unit | Repositories | Learning Content Repository', function () {
               id: 'competenceId',
               index: 'index',
               name: 'name',
-              thematics: [{ id: 'thematicId', index: 'index', name: 'name', tubes: [{ id: 'tubeId1' }] }],
+              thematics: [
+                {
+                  id: 'thematicId',
+                  index: 'index',
+                  name: 'name',
+                  tubes: [{ id: 'tubeId1', level: 3, name: 'name', practicalTitle: 'practicalTitle' }],
+                },
+              ],
             },
           ],
         },
@@ -56,18 +71,15 @@ describe('Unit | Repositories | Learning Content Repository', function () {
       };
 
       // when
-      const result = await learningContentRepository.findByTubeIds({
-        tubeIds,
+      const result = await learningContentRepository.findAreasForTubeIds({
+        tubesWithLevel,
         learningContentApi: learningContentApiStub,
       });
 
       // then
-      expect(learningContentApiStub.findByTubeIds).called;
       expect(result.length).to.equal(1);
-      expect(result[0]).to.be.instanceOf(FrameworkForCappedTubes);
-
-      //then
-      expect(result[0].areas).to.deep.equal(expectedAreas);
+      expect(result[0]).to.be.instanceOf(AreaForCappedTubes);
+      expect(result).to.deep.equal(expectedAreas);
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème
Le usecase `getCombinedCourseBlueprintById` fait beaucoup de choses. On aimerait formater les données depuis la méthode de repository qui remonte l'arbre des tubes pour une liste de tube ids donnés, et non pas dans le usecase comme c'est fait actuellement.

## ⛱️ Proposition

## 🧴 Remarques
Certains tests cassaient avec les lanceurs de test en local (notamment avec l'utilisation de clock, qu'il convient de "restore" dans un hook "afterEach"). 

## 🏊 Pour tester
Dans PixAdmin, aller sur la page de détails d'un schéma de parcours combiné avec des rewardRequirements de type capped tubes configurés et vérifier que l'affichage est correct.