### PR TITLE
[TECH] La dépendance eslint 9 doit être surchargée

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -118,6 +118,7 @@
     "xss": "^1.0.15"
   },
   "overrides": {
+    "eslint": "$eslint",
     "@xmldom/xmldom": ">=0.8.13",
     "braces": ">=3.0.3",
     "flatted": ">=3.4.2"

--- a/api/package.json
+++ b/api/package.json
@@ -196,6 +196,7 @@
   },
   "overrides": {
     "@datadog/datadog-api-client": "1.60.0",
+    "eslint": "$eslint",
     "handlebars": ">=4.7.9",
     "hapi-swagger": {
       "joi": "$joi"

--- a/audit-logger/package.json
+++ b/audit-logger/package.json
@@ -76,5 +76,8 @@
     "pg": "^8.16.3",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.3"
+  },
+  "overrides": {
+    "eslint": "$eslint"
   }
 }

--- a/certif/package.json
+++ b/certif/package.json
@@ -40,15 +40,6 @@
     "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },
-  "overrides": {
-    "@xmldom/xmldom": ">=0.8.13",
-    "ember-dayjs": {
-      "ember-source": "$ember-source"
-    },
-    "flatted": ">=3.4.2",
-    "handlebars": ">=4.7.9",
-    "braces": ">=3.0.3"
-  },
   "devDependencies": {
     "@1024pix/ember-api-actions": "^1.1.0",
     "@1024pix/ember-testing-library": "^3.0.44",
@@ -124,6 +115,16 @@
     "sinon": "^22.0.0",
     "stylelint": "^17.4.0",
     "webpack": "^5.99.8"
+  },
+  "overrides": {
+    "eslint": "$eslint",
+    "@xmldom/xmldom": ">=0.8.13",
+    "ember-dayjs": {
+      "ember-source": "$ember-source"
+    },
+    "flatted": ">=3.4.2",
+    "handlebars": ">=4.7.9",
+    "braces": ">=3.0.3"
   },
   "exports": {
     "./tests/*": "./tests/*",

--- a/high-level-tests/e2e-playwright/package.json
+++ b/high-level-tests/e2e-playwright/package.json
@@ -61,6 +61,7 @@
     "csv-parse": "^7.0.0"
   },
   "overrides": {
+    "eslint": "$eslint",
     "flatted": ">=3.4.2"
   }
 }

--- a/junior/package.json
+++ b/junior/package.json
@@ -107,6 +107,7 @@
     "xss": "^1.0.15"
   },
   "overrides": {
+    "eslint": "$eslint",
     "@xmldom/xmldom": ">=0.9.10",
     "flatted": ">=3.4.2",
     "braces": ">=3.0.3"

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -133,6 +133,7 @@
     "xss": "^1.0.15"
   },
   "overrides": {
+    "eslint": "$eslint",
     "@xmldom/xmldom": ">=0.9.10",
     "ember-dayjs": {
       "ember-source": "$ember-source"

--- a/orga/package.json
+++ b/orga/package.json
@@ -123,6 +123,7 @@
     "xss": "^1.0.15"
   },
   "overrides": {
+    "eslint": "$eslint",
     "@xmldom/xmldom": ">=0.9.10",
     "braces": ">=3.0.3",
     "ember-dayjs": {


### PR DESCRIPTION
## ☀️ Problème

L'action `security.yml` échoue sur la branche `dev`, car la commande utilisée `npm ls --all` retourne une erreur sur la déduplication de la version d'eslint

Exemple:
```
npm error code ELSPROBLEMS
npm error invalid: eslint@9.39.5 /Users/benjamin_petetot/dev/work/pix/high-level-tests/e2e-playwright/node_modules/eslint
npm error A complete log of this run can be found in: /Users/benjamin_petetot/.npm/_logs/2026-08-31T12_22_45_156Z-debug-0.log
```

## ⛱️ Proposition

Le problème est causé par une dépendance transitive `eslint@10` depuis la version 3.0.44 de `@1024pix/eslint-plugin`.

Les projets dépendants de `eslint@9` doivent surcharger la version d'eslint pour imposer la déduplication.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Le linting doit passer.
