### PR TITLE
[FEATURE] Permettre l'activation en deux temps d'une version Pix+ (PIX-23963)

### DIFF
--- a/admin/app/adapters/certification-version.js
+++ b/admin/app/adapters/certification-version.js
@@ -9,6 +9,11 @@ export default class CertificationVersionAdapter extends ApplicationAdapter {
       return this.ajax(`${url}/activation`, 'PATCH');
     }
 
+    if (snapshot.adapterOptions?.saveScoring) {
+      const data = this.serialize(snapshot, { includeId: true });
+      return this.ajax(`${url}/scoring`, 'PATCH', { data });
+    }
+
     let patchUrl = url;
     const changedAttributeKeys = Object.keys(snapshot.changedAttributes());
     if (changedAttributeKeys.length === 1 && changedAttributeKeys.at(0) === 'comments') {

--- a/admin/app/components/certification-frameworks/certification-framework/framework-history.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/framework-history.gjs
@@ -12,7 +12,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 import formatDate from 'ember-intl/helpers/format-date';
-import { eq, not } from 'ember-truth-helpers';
+import { eq, not, or } from 'ember-truth-helpers';
 import { formatMinutes } from 'pix-admin/utils/date';
 
 import CertificationVersionDetailModal from './modal/certification-version-detail-modal';
@@ -81,11 +81,16 @@ export default class FrameworkHistory extends Component {
   }
 
   @action
-  editVersion(versionId) {
-    this.router.transitionTo(
-      'authenticated.certification-frameworks.certification-framework.versions.version.edit',
-      versionId,
-    );
+  isPixPlusActiveWithoutScoring(version) {
+    return this.args.frameworkKey !== 'CORE' && version.isActive && !version.hasGlobalScoring;
+  }
+
+  @action
+  editVersion(version) {
+    const route = this.isPixPlusActiveWithoutScoring(version)
+      ? 'authenticated.certification-frameworks.certification-framework.versions.version.scoring'
+      : 'authenticated.certification-frameworks.certification-framework.versions.version.edit';
+    this.router.transitionTo(route, version.id);
   }
 
   <template>
@@ -171,13 +176,13 @@ export default class FrameworkHistory extends Component {
                 @iconName="eye"
               />
               <PixIconButton
-                @triggerAction={{fn this.editVersion version.id}}
+                @triggerAction={{fn this.editVersion version}}
                 @ariaLabel={{t
                   "components.certification-frameworks.certification-framework.history.table.actions.edit"
                   id=version.id
                 }}
                 @iconName="edit"
-                @isDisabled={{not (eq version.status "draft")}}
+                @isDisabled={{not (or version.isDraft (this.isPixPlusActiveWithoutScoring version))}}
               />
               <PixIconButton
                 @triggerAction={{fn this.showDeleteVersionModal version.id}}

--- a/admin/app/components/certification-frameworks/certification-framework/header.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/header.gjs
@@ -15,7 +15,7 @@ export default class Header extends Component {
   }
 
   get canCreateVersion() {
-    return this.args.certificationFramework.hasDraft;
+    return this.args.certificationFramework.hasDraft || this.args.certificationFramework.hasPixPlusActiveWithoutScoring;
   }
 
   get activeCertificationVersionId() {

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-report.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-report.gjs
@@ -1,5 +1,4 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-report.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-calibration-report.gjs
@@ -185,14 +185,5 @@ export default class CertificationVersionCalibrationReport extends Component {
         </p>
       {{/if}}
     </Card>
-    <section class="actions-container">
-      <PixButtonLink
-        @route="authenticated.certification-frameworks.certification-framework.versions.version.scoring"
-        @variant="primary"
-        @isDisabled={{this.hasHighAlert}}
-      >
-        {{t "common.actions.next"}}
-      </PixButtonLink>
-    </section>
   </template>
 }

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-competences-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-competences-scoring-form.gjs
@@ -14,7 +14,7 @@ export default class CompetencesScoringForm extends Component {
   @tracked activeTab = 0;
 
   get sortedAreas() {
-    return [...this.args.draftVersion.areas].sort((a, b) => Number(a.code) - Number(b.code));
+    return [...this.args.editVersion.areas].sort((a, b) => Number(a.code) - Number(b.code));
   }
 
   @action

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
@@ -15,7 +15,7 @@ export default class GlobalScoringForm extends Component {
     const savedConfiguration = this.args.editVersion.globalScoringConfiguration;
     return savedConfiguration?.length
       ? savedConfiguration
-      : this.args.calibrationScoringConfiguration.globalScoringConfiguration;
+      : (this.args.calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
   }
 
   get previousVersionConfiguration() {

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
@@ -12,14 +12,14 @@ export default class GlobalScoringForm extends Component {
   @service intl;
 
   get globalScoringConfiguration() {
-    const savedConfiguration = this.args.draftVersion.globalScoringConfiguration;
+    const savedConfiguration = this.args.editVersion.globalScoringConfiguration;
     return savedConfiguration?.length
       ? savedConfiguration
       : this.args.calibrationScoringConfiguration.globalScoringConfiguration;
   }
 
-  get activeVersionConfiguration() {
-    return this.args.activeVersion?.globalScoringConfiguration ?? [];
+  get previousVersionConfiguration() {
+    return this.args.previousVersion?.globalScoringConfiguration ?? [];
   }
 
   @action
@@ -31,7 +31,7 @@ export default class GlobalScoringForm extends Component {
     if (isMax && newArray.at(index + 1)) {
       newArray.at(index + 1).bounds.min = Number(event.target.value);
     }
-    this.args.draftVersion.globalScoringConfiguration = newArray;
+    this.args.editVersion.globalScoringConfiguration = newArray;
   }
 
   @action
@@ -55,8 +55,8 @@ export default class GlobalScoringForm extends Component {
   }
 
   @action
-  activeVersionBound(meshLevel, name) {
-    const bounds = this.activeVersionConfiguration.find((mesh) => mesh.meshLevel === meshLevel)?.bounds;
+  previousVersionBound(meshLevel, name) {
+    const bounds = this.previousVersionConfiguration.find((mesh) => mesh.meshLevel === meshLevel)?.bounds;
     return bounds ? bounds[name] : '—';
   }
 
@@ -85,7 +85,7 @@ export default class GlobalScoringForm extends Component {
             >
               <:label>{{t
                   "components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity"
-                  previousVersionCapacity=(this.activeVersionBound mesh.meshLevel "min")
+                  previousVersionCapacity=(this.previousVersionBound mesh.meshLevel "min")
                 }}</:label>
             </PixInput>
 
@@ -103,7 +103,7 @@ export default class GlobalScoringForm extends Component {
             >
               <:label>{{t
                   "components.certification-frameworks.certification-framework.versions.scoring.previous-version-capacity"
-                  previousVersionCapacity=(this.activeVersionBound mesh.meshLevel "max")
+                  previousVersionCapacity=(this.previousVersionBound mesh.meshLevel "max")
                 }}</:label>
             </PixInput>
           </section>

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
@@ -9,21 +9,13 @@ export default class VersionController extends Controller {
   @service store;
 
   @action
-  async activateVersion(draftVersion, calibrationScoringConfiguration) {
+  async activateVersion(draftVersion) {
     try {
-      draftVersion.globalScoringConfiguration = draftVersion.globalScoringConfiguration?.length
-        ? [...draftVersion.globalScoringConfiguration]
-        : (calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
-      draftVersion.competencesScoringConfiguration =
-        calibrationScoringConfiguration?.competencesScoringConfiguration ?? [];
-      await draftVersion.save();
       await draftVersion.save({ adapterOptions: { activate: true } });
       this.pixToast.sendSuccessNotification({
         message: this.intl.t(
           'components.certification-frameworks.certification-framework.versions.activate-version.success',
-          {
-            versionId: draftVersion.id,
-          },
+          { versionId: draftVersion.id },
         ),
       });
       await this.store.findAll('certification-framework', { reload: true });
@@ -32,9 +24,7 @@ export default class VersionController extends Controller {
       this.pixToast.sendErrorNotification({
         message: this.intl.t(
           'components.certification-frameworks.certification-framework.versions.activate-version.error',
-          {
-            versionId: draftVersion.id,
-          },
+          { versionId: draftVersion.id },
         ),
       });
     }

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
@@ -13,8 +13,7 @@ export default class VersionController extends Controller {
     version.globalScoringConfiguration = version.globalScoringConfiguration?.length
       ? [...version.globalScoringConfiguration]
       : (calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
-    version.competencesScoringConfiguration =
-      calibrationScoringConfiguration?.competencesScoringConfiguration ?? [];
+    version.competencesScoringConfiguration = calibrationScoringConfiguration?.competencesScoringConfiguration ?? [];
     await version.save({ adapterOptions: { saveScoring: true } });
   }
 

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version.js
@@ -9,6 +9,16 @@ export default class VersionController extends Controller {
   @service store;
 
   @action
+  async saveScoring(version, calibrationScoringConfiguration) {
+    version.globalScoringConfiguration = version.globalScoringConfiguration?.length
+      ? [...version.globalScoringConfiguration]
+      : (calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
+    version.competencesScoringConfiguration =
+      calibrationScoringConfiguration?.competencesScoringConfiguration ?? [];
+    await version.save({ adapterOptions: { saveScoring: true } });
+  }
+
+  @action
   async activateVersion(draftVersion) {
     try {
       await draftVersion.save({ adapterOptions: { activate: true } });

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration.js
@@ -1,0 +1,28 @@
+import Controller from '@ember/controller';
+import { inject as controller } from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class CalibrationController extends Controller {
+  @controller('authenticated.certification-frameworks.certification-framework.versions.version')
+  versionController;
+  @tracked isConfirmationModalOpen = false;
+
+  @action
+  toggleConfirmationModal() {
+    this.isConfirmationModalOpen = !this.isConfirmationModalOpen;
+  }
+
+  get hasNoExternalCalibrationId() {
+    return !this.model.draftVersion.externalCalibrationId;
+  }
+
+  get isPixPlusScope() {
+    return this.model.draftVersion.scope !== 'CORE';
+  }
+
+  @action
+  activateVersion() {
+    return this.versionController.activateVersion(this.model.draftVersion, this.model.calibrationScoringConfiguration);
+  }
+}

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration.js
@@ -13,16 +13,8 @@ export default class CalibrationController extends Controller {
     this.isConfirmationModalOpen = !this.isConfirmationModalOpen;
   }
 
-  get hasNoExternalCalibrationId() {
-    return !this.model.draftVersion.externalCalibrationId;
-  }
-
-  get isPixPlusScope() {
-    return this.model.draftVersion.scope !== 'CORE';
-  }
-
   @action
   activateVersion() {
-    return this.versionController.activateVersion(this.model.draftVersion, this.model.calibrationScoringConfiguration);
+    return this.versionController.activateVersion(this.model.draftVersion);
   }
 }

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -6,11 +6,11 @@ import { tracked } from '@glimmer/tracking';
 export default class ScoringController extends Controller {
   @controller('authenticated.certification-frameworks.certification-framework.versions.version')
   versionController;
-  @tracked isConfirmationModalOpen = false;
+  @tracked isActivationModalOpen = false;
 
   @action
-  toggleConfirmationModal() {
-    this.isConfirmationModalOpen = !this.isConfirmationModalOpen;
+  toggleActivationModal() {
+    this.isActivationModalOpen = !this.isActivationModalOpen;
   }
 
   get hasGlobalScoringError() {
@@ -23,6 +23,6 @@ export default class ScoringController extends Controller {
 
   @action
   activateVersion() {
-    return this.versionController.activateVersion(this.model.editVersion, this.model.calibrationScoringConfiguration);
+    return this.versionController.activateVersion(this.model.editVersion);
   }
 }

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -1,16 +1,27 @@
 import Controller from '@ember/controller';
 import { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ScoringController extends Controller {
   @controller('authenticated.certification-frameworks.certification-framework.versions.version')
   versionController;
+  @service pixToast;
+  @service intl;
+  @service router;
+  @service store;
   @tracked isActivationModalOpen = false;
+  @tracked isSaveScoringModalOpen = false;
 
   @action
   toggleActivationModal() {
     this.isActivationModalOpen = !this.isActivationModalOpen;
+  }
+
+  @action
+  toggleSaveScoringModal() {
+    this.isSaveScoringModalOpen = !this.isSaveScoringModalOpen;
   }
 
   get hasGlobalScoringError() {
@@ -22,7 +33,37 @@ export default class ScoringController extends Controller {
   }
 
   @action
-  activateVersion() {
-    return this.versionController.activateVersion(this.model.editVersion);
+  async saveScoring() {
+    try {
+      await this.versionController.saveScoring(this.model.editVersion, this.model.calibrationScoringConfiguration);
+      this.isSaveScoringModalOpen = false;
+      this.pixToast.sendSuccessNotification({
+        message: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.scoring.success-notification',
+        ),
+      });
+      await this.store.findAll('certification-framework', { reload: true });
+      await this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.scoring.save-error',
+        ),
+      });
+    }
+  }
+
+  @action
+  async saveScoringAndActivate() {
+    try {
+      await this.versionController.saveScoring(this.model.editVersion, this.model.calibrationScoringConfiguration);
+      await this.versionController.activateVersion(this.model.editVersion);
+    } catch {
+      this.pixToast.sendErrorNotification({
+        message: this.intl.t(
+          'components.certification-frameworks.certification-framework.versions.scoring.save-error',
+        ),
+      });
+    }
   }
 }

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -14,15 +14,15 @@ export default class ScoringController extends Controller {
   }
 
   get hasGlobalScoringError() {
-    const draftVersion = this.model.draftVersion;
-    const config = draftVersion.globalScoringConfiguration?.length
-      ? draftVersion.globalScoringConfiguration
+    const editVersion = this.model.editVersion;
+    const config = editVersion.globalScoringConfiguration?.length
+      ? editVersion.globalScoringConfiguration
       : (this.model.calibrationScoringConfiguration?.globalScoringConfiguration ?? []);
     return config.some(({ bounds }) => bounds.max <= bounds.min);
   }
 
   @action
   activateVersion() {
-    return this.versionController.activateVersion(this.model.draftVersion, this.model.calibrationScoringConfiguration);
+    return this.versionController.activateVersion(this.model.editVersion, this.model.calibrationScoringConfiguration);
   }
 }

--- a/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -46,9 +46,7 @@ export default class ScoringController extends Controller {
       await this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
     } catch {
       this.pixToast.sendErrorNotification({
-        message: this.intl.t(
-          'components.certification-frameworks.certification-framework.versions.scoring.save-error',
-        ),
+        message: this.intl.t('components.certification-frameworks.certification-framework.versions.scoring.save-error'),
       });
     }
   }
@@ -60,9 +58,7 @@ export default class ScoringController extends Controller {
       await this.versionController.activateVersion(this.model.editVersion);
     } catch {
       this.pixToast.sendErrorNotification({
-        message: this.intl.t(
-          'components.certification-frameworks.certification-framework.versions.scoring.save-error',
-        ),
+        message: this.intl.t('components.certification-frameworks.certification-framework.versions.scoring.save-error'),
       });
     }
   }

--- a/admin/app/models/certification-framework.js
+++ b/admin/app/models/certification-framework.js
@@ -18,6 +18,13 @@ export default class CertificationFramework extends Model {
     return this.versionSummaries.some((versionSummary) => versionSummary.isDraft);
   }
 
+  get hasPixPlusActiveWithoutScoring() {
+    return (
+      this.scope !== 'CORE' &&
+      this.versionSummaries.some((versionSummary) => versionSummary.isActive && !versionSummary.hasGlobalScoring)
+    );
+  }
+
   get hasTargetProfilesHistory() {
     return this.belongsTo('complementaryCertification').id() !== null;
   }

--- a/admin/app/models/certification-version-summary.js
+++ b/admin/app/models/certification-version-summary.js
@@ -6,6 +6,7 @@ export default class CertificationVersionSummary extends Model {
   @attr('number') assessmentDuration;
   @attr('number') maximumAssessmentLength;
   @attr('string') status;
+  @attr('boolean') hasGlobalScoring;
 
   get isActive() {
     return this.status === 'active';

--- a/admin/app/models/certification-version.js
+++ b/admin/app/models/certification-version.js
@@ -21,6 +21,10 @@ export default class CertificationVersion extends Model {
 
   @hasMany('area', { async: false, inverse: null }) areas;
 
+  get hasExternalCalibrationId() {
+    return !!this.externalCalibrationId;
+  }
+
   get isDraft() {
     return this.status === 'draft';
   }

--- a/admin/app/models/certification-version.js
+++ b/admin/app/models/certification-version.js
@@ -29,6 +29,10 @@ export default class CertificationVersion extends Model {
     return this.status === 'draft';
   }
 
+  get isActive() {
+    return this.status === 'active';
+  }
+
   get isCoreScope() {
     return this.scope === 'CORE';
   }

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/calibration.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/calibration.js
@@ -34,8 +34,11 @@ export default class CalibrationRoute extends Route {
   }
 
   resetController(controller, isExiting) {
-    if (isExiting && controller.model.draftVersion.hasDirtyAttributes) {
-      controller.model.draftVersion.rollbackAttributes();
+    if (isExiting) {
+      controller.isConfirmationModalOpen = false;
+      if (controller.model.draftVersion.hasDirtyAttributes) {
+        controller.model.draftVersion.rollbackAttributes();
+      }
     }
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -11,21 +11,21 @@ export default class ScoringRoute extends Route {
     const { version_id: versionId } = this.paramsFor(
       'authenticated.certification-frameworks.certification-framework.versions.version',
     );
-    const draftVersion = await this.store.findRecord('certification-version', versionId);
+    const editVersion = await this.store.findRecord('certification-version', versionId);
 
     return {
-      activeVersion,
-      draftVersion,
-      calibrationScoringConfiguration: await this.loadCalibrationScoringConfiguration(draftVersion),
+      previousVersion: activeVersion,
+      editVersion,
+      calibrationScoringConfiguration: await this.loadCalibrationScoringConfiguration(editVersion),
     };
   }
 
-  async loadCalibrationScoringConfiguration(draftVersion) {
-    if (!draftVersion.externalCalibrationId) return null;
+  async loadCalibrationScoringConfiguration(editVersion) {
+    if (!editVersion.externalCalibrationId) return null;
 
     try {
       return await this.store.queryRecord('calibration-scoring-configuration', {
-        calibrationId: draftVersion.externalCalibrationId,
+        calibrationId: editVersion.externalCalibrationId,
       });
     } catch {
       return null;
@@ -33,14 +33,14 @@ export default class ScoringRoute extends Route {
   }
 
   afterModel(model) {
-    if (!model.draftVersion.isDraft || !model.calibrationScoringConfiguration?.globalScoringConfiguration?.length) {
+    if (!model.editVersion.isDraft || !model.calibrationScoringConfiguration?.globalScoringConfiguration?.length) {
       this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
     }
   }
 
   resetController(controller, isExiting) {
-    if (isExiting && controller.model.draftVersion.hasDirtyAttributes) {
-      controller.model.draftVersion.rollbackAttributes();
+    if (isExiting && controller.model.editVersion.hasDirtyAttributes) {
+      controller.model.editVersion.rollbackAttributes();
     }
   }
 }

--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/version/scoring.js
@@ -6,7 +6,9 @@ export default class ScoringRoute extends Route {
   @service router;
 
   async model() {
-    const { activeVersion } = this.modelFor('authenticated.certification-frameworks.certification-framework.versions');
+    const { activeVersion, certificationFramework } = this.modelFor(
+      'authenticated.certification-frameworks.certification-framework.versions',
+    );
 
     const { version_id: versionId } = this.paramsFor(
       'authenticated.certification-frameworks.certification-framework.versions.version',
@@ -14,10 +16,20 @@ export default class ScoringRoute extends Route {
     const editVersion = await this.store.findRecord('certification-version', versionId);
 
     return {
-      previousVersion: activeVersion,
+      previousVersion: await this.#resolvePreviousVersion(editVersion, activeVersion, certificationFramework),
       editVersion,
       calibrationScoringConfiguration: await this.loadCalibrationScoringConfiguration(editVersion),
     };
+  }
+
+  async #resolvePreviousVersion(editVersion, activeVersion, certificationFramework) {
+    if (editVersion.isDraft) return activeVersion;
+
+    const mostRecentArchived = certificationFramework.versionSummaries
+      .filter((s) => s.isArchived)
+      .sort((a, b) => b.expirationDate - a.expirationDate)[0];
+
+    return mostRecentArchived ? this.store.findRecord('certification-version', mostRecentArchived.id) : null;
   }
 
   async loadCalibrationScoringConfiguration(editVersion) {
@@ -33,14 +45,23 @@ export default class ScoringRoute extends Route {
   }
 
   afterModel(model) {
-    if (!model.editVersion.isDraft || !model.calibrationScoringConfiguration?.globalScoringConfiguration?.length) {
+    const { editVersion, calibrationScoringConfiguration } = model;
+    const hasCalibrationScoring = calibrationScoringConfiguration?.globalScoringConfiguration?.length;
+    const canAccessScoring =
+      (editVersion.isDraft && hasCalibrationScoring) || (editVersion.isActive && !editVersion.isCoreScope);
+
+    if (!canAccessScoring) {
       this.router.transitionTo('authenticated.certification-frameworks.certification-framework');
     }
   }
 
   resetController(controller, isExiting) {
-    if (isExiting && controller.model.editVersion.hasDirtyAttributes) {
-      controller.model.editVersion.rollbackAttributes();
+    if (isExiting) {
+      controller.isActivationModalOpen = false;
+      controller.isSaveScoringModalOpen = false;
+      if (controller.model.editVersion.hasDirtyAttributes) {
+        controller.model.editVersion.rollbackAttributes();
+      }
     }
   }
 }

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/calibration.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/calibration.gjs
@@ -2,6 +2,7 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { t } from 'ember-intl';
+import { not } from 'ember-truth-helpers';
 import CertificationVersionCalibrationReport from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-calibration-report';
 
 <template>
@@ -13,20 +14,20 @@ import CertificationVersionCalibrationReport from 'pix-admin/components/certific
     <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
       {{t "common.actions.cancel"}}
     </PixButtonLink>
-    {{#if @controller.isPixPlusScope}}
+    {{#unless @model.draftVersion.isCoreScope}}
       <PixButton
         id="activate-version"
         @variant="primary-bis"
-        @isDisabled={{@controller.hasNoExternalCalibrationId}}
+        @isDisabled={{not @model.draftVersion.hasExternalCalibrationId}}
         @triggerAction={{@controller.toggleConfirmationModal}}
       >
         {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
       </PixButton>
-    {{/if}}
+    {{/unless}}
     <PixButtonLink
       @route="authenticated.certification-frameworks.certification-framework.versions.version.scoring"
       @variant="primary"
-      @isDisabled={{@controller.hasNoExternalCalibrationId}}
+      @isDisabled={{not @model.draftVersion.hasExternalCalibrationId}}
     >
       {{t "common.actions.next"}}
     </PixButtonLink>

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/calibration.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/calibration.gjs
@@ -36,15 +36,15 @@ import CertificationVersionCalibrationReport from 'pix-admin/components/certific
   {{#if @controller.isConfirmationModalOpen}}
     <PixModal
       @title={{t
-      "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.title"
-    }}
+        "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.title"
+      }}
       @showModal={{@controller.isConfirmationModalOpen}}
       @onCloseButtonClick={{@controller.toggleConfirmationModal}}
     >
       <:content>
         <p>{{t
-          "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.content"
-        }}</p>
+            "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.content"
+          }}</p>
       </:content>
       <:footer>
         <PixButton @triggerAction={{@controller.toggleConfirmationModal}} @size="small" @variant="secondary">

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/calibration.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/calibration.gjs
@@ -1,3 +1,7 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
+import { t } from 'ember-intl';
 import CertificationVersionCalibrationReport from 'pix-admin/components/certification-frameworks/certification-framework/versions/certification-version-calibration-report';
 
 <template>
@@ -5,4 +9,50 @@ import CertificationVersionCalibrationReport from 'pix-admin/components/certific
     @draftVersion={{@model.draftVersion}}
     @calibrationReport={{@model.calibrationReport}}
   />
+  <section class="actions-container">
+    <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
+      {{t "common.actions.cancel"}}
+    </PixButtonLink>
+    {{#if @controller.isPixPlusScope}}
+      <PixButton
+        id="activate-version"
+        @variant="primary-bis"
+        @isDisabled={{@controller.hasNoExternalCalibrationId}}
+        @triggerAction={{@controller.toggleConfirmationModal}}
+      >
+        {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
+      </PixButton>
+    {{/if}}
+    <PixButtonLink
+      @route="authenticated.certification-frameworks.certification-framework.versions.version.scoring"
+      @variant="primary"
+      @isDisabled={{@controller.hasNoExternalCalibrationId}}
+    >
+      {{t "common.actions.next"}}
+    </PixButtonLink>
+  </section>
+
+  {{#if @controller.isConfirmationModalOpen}}
+    <PixModal
+      @title={{t
+      "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.title"
+    }}
+      @showModal={{@controller.isConfirmationModalOpen}}
+      @onCloseButtonClick={{@controller.toggleConfirmationModal}}
+    >
+      <:content>
+        <p>{{t
+          "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.content"
+        }}</p>
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{@controller.toggleConfirmationModal}} @size="small" @variant="secondary">
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @triggerAction={{@controller.activateVersion}} @size="small">
+          {{t "common.actions.confirm"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  {{/if}}
 </template>

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -25,19 +25,19 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
       id="activate-version"
       @variant="primary-bis"
       @isDisabled={{@controller.hasGlobalScoringError}}
-      @triggerAction={{@controller.toggleConfirmationModal}}
+      @triggerAction={{@controller.toggleActivationModal}}
     >
       {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
     </PixButton>
   </section>
 
-  {{#if @controller.isConfirmationModalOpen}}
+  {{#if @controller.isActivationModalOpen}}
     <PixModal
       @title={{t
         "components.certification-frameworks.certification-framework.versions.activate-version.confirmation-modal.title"
       }}
-      @showModal={{@controller.isConfirmationModalOpen}}
-      @onCloseButtonClick={{@controller.toggleConfirmationModal}}
+      @showModal={{@controller.isActivationModalOpen}}
+      @onCloseButtonClick={{@controller.toggleActivationModal}}
     >
       <:content>
         <p>{{t
@@ -45,7 +45,7 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
           }}</p>
       </:content>
       <:footer>
-        <PixButton @triggerAction={{@controller.toggleConfirmationModal}} @size="small" @variant="secondary">
+        <PixButton @triggerAction={{@controller.toggleActivationModal}} @size="small" @variant="secondary">
           {{t "common.actions.cancel"}}
         </PixButton>
         <PixButton @triggerAction={{@controller.activateVersion}} @size="small">

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -21,15 +21,50 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
     <PixButtonLink @route="authenticated.certification-frameworks.certification-framework" @variant="secondary">
       {{t "common.actions.cancel"}}
     </PixButtonLink>
-    <PixButton
-      id="activate-version"
-      @variant="primary-bis"
-      @isDisabled={{@controller.hasGlobalScoringError}}
-      @triggerAction={{@controller.toggleActivationModal}}
-    >
-      {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
-    </PixButton>
+    {{#if @model.editVersion.isActive}}
+      <PixButton
+        id="save-scoring"
+        @variant="primary-bis"
+        @isDisabled={{@controller.hasGlobalScoringError}}
+        @triggerAction={{@controller.toggleSaveScoringModal}}
+      >
+        {{t "components.certification-frameworks.certification-framework.versions.scoring.save-scoring-button"}}
+      </PixButton>
+    {{else}}
+      <PixButton
+        id="activate-version"
+        @variant="primary-bis"
+        @isDisabled={{@controller.hasGlobalScoringError}}
+        @triggerAction={{@controller.toggleActivationModal}}
+      >
+        {{t "components.certification-frameworks.certification-framework.versions.activate-version.button-label"}}
+      </PixButton>
+    {{/if}}
   </section>
+
+  {{#if @controller.isSaveScoringModalOpen}}
+    <PixModal
+      @title={{t
+        "components.certification-frameworks.certification-framework.versions.scoring.save-scoring-modal.title"
+      }}
+      @showModal={{@controller.isSaveScoringModalOpen}}
+      @onCloseButtonClick={{@controller.toggleSaveScoringModal}}
+    >
+      <:content>
+        <p>{{t
+            "components.certification-frameworks.certification-framework.versions.scoring.save-scoring-modal.content"
+          }}</p>
+      </:content>
+      <:footer>
+        <PixButton @triggerAction={{@controller.toggleSaveScoringModal}} @size="small" @variant="secondary">
+          {{t "common.actions.cancel"}}
+        </PixButton>
+        <PixButton @triggerAction={{@controller.saveScoring}} @size="small">
+          {{t "common.actions.confirm"}}
+        </PixButton>
+      </:footer>
+    </PixModal>
+  {{/if}}
 
   {{#if @controller.isActivationModalOpen}}
     <PixModal
@@ -48,7 +83,7 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
         <PixButton @triggerAction={{@controller.toggleActivationModal}} @size="small" @variant="secondary">
           {{t "common.actions.cancel"}}
         </PixButton>
-        <PixButton @triggerAction={{@controller.activateVersion}} @size="small">
+        <PixButton @triggerAction={{@controller.saveScoringAndActivate}} @size="small">
           {{t "common.actions.confirm"}}
         </PixButton>
       </:footer>

--- a/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
+++ b/admin/app/templates/authenticated/certification-frameworks/certification-framework/versions/version/scoring.gjs
@@ -7,13 +7,13 @@ import GlobalScoringForm from 'pix-admin/components/certification-frameworks/cer
 
 <template>
   <GlobalScoringForm
-    @draftVersion={{@model.draftVersion}}
-    @activeVersion={{@model.activeVersion}}
+    @editVersion={{@model.editVersion}}
+    @previousVersion={{@model.previousVersion}}
     @calibrationScoringConfiguration={{@model.calibrationScoringConfiguration}}
   />
-  {{#if @model.draftVersion.isCoreScope}}
+  {{#if @model.editVersion.isCoreScope}}
     <CompetencesScoringForm
-      @draftVersion={{@model.draftVersion}}
+      @editVersion={{@model.editVersion}}
       @calibrationScoringConfiguration={{@model.calibrationScoringConfiguration}}
     />
   {{/if}}

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework-test.js
@@ -104,6 +104,7 @@ module('Acceptance | Certification Frameworks | certification-framework', functi
         assessmentDuration: 90,
         maximumAssessmentLength: 32,
         status: 'active',
+        hasGlobalScoring: true,
       }),
       server.create('certification-version-summary', {
         id: 14,

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/new-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/new-test.js
@@ -55,6 +55,7 @@ module('Acceptance | Certification Framework | item | Framework | new', function
       assessmentDuration: 90,
       maximumAssessmentLength: 32,
       status: 'active',
+      hasGlobalScoring: true,
     });
     server.schema.certificationVersions.find(versionSummaryDroit.id).update({ areas });
     server.create('certification-framework', { id: 'DROIT', versionSummaries: [versionSummaryDroit] });

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -16,7 +16,6 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     versionSummaries.push(
       server.create('certification-version-summary', {
         id: 13,
-        scope: 'CORE',
         startDate: new Date('2023-10-10'),
         expirationDate: null,
         assessmentDuration: 90,
@@ -27,7 +26,6 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     versionSummaries.push(
       server.create('certification-version-summary', {
         id: 14,
-        scope: 'CORE',
         startDate: null,
         expirationDate: null,
         assessmentDuration: 66,
@@ -38,7 +36,6 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     versionSummaries.push(
       server.create('certification-version-summary', {
         id: 15,
-        scope: 'CORE',
         startDate: new Date('2020-01-01'),
         expirationDate: new Date('2021-01-01'),
         assessmentDuration: 90,
@@ -49,6 +46,7 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
     server.create('certification-framework', { id: 'CORE', versionSummaries });
     server.create('certification-version', {
       id: 13,
+      scope: 'CORE',
       status: 'active',
       globalScoringConfiguration: [{ bounds: { min: -4, max: 2 }, meshLevel: 0 }],
     });
@@ -70,14 +68,34 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
 
   module('when admin member has role "SUPER ADMIN"', function () {
     module('when trying to load scoring for a non-draft version', function () {
-      test('redirects to versions list', async function (assert) {
+      test('redirects to framework page for a CORE active version', async function (assert) {
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
         await visit(`/certification-frameworks/CORE/versions/13/scoring`);
         assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+      });
+
+      test('redirects to framework page for an archived version', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
         await visit(`/certification-frameworks/CORE/versions/15/scoring`);
         assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+      });
+
+      test('allows access for a Pix+ active version without scoring', async function (assert) {
+        server.create('certification-version-summary', { id: 20, status: 'active' });
+        server.create('certification-framework', { id: 'DROIT', versionSummaries: [] });
+        server.create('certification-version', {
+          id: 20,
+          scope: 'DROIT',
+          status: 'active',
+          globalScoringConfiguration: [],
+        });
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        await visit(`/certification-frameworks/DROIT/versions/20/scoring`);
+
+        assert.strictEqual(currentURL(), '/certification-frameworks/DROIT/versions/20/scoring');
       });
     });
 
@@ -153,6 +171,60 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
         await visit(`/certification-frameworks/CORE/versions/14/scoring`);
 
         assert.strictEqual(currentURL(), '/certification-frameworks/CORE');
+      });
+    });
+
+    module('action buttons', function () {
+      test('shows the "Activer" button for a draft version', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/CORE/versions/14/scoring`);
+
+        assert
+          .dom(
+            screen.getByText(
+              t('components.certification-frameworks.certification-framework.versions.activate-version.button-label'),
+            ),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.queryByText(
+              t('components.certification-frameworks.certification-framework.versions.scoring.save-scoring-button'),
+            ),
+          )
+          .doesNotExist();
+      });
+
+      test('shows the "Enregistrer le scoring" button for an active Pix+ version', async function (assert) {
+        server.create('certification-version-summary', { id: 20, status: 'active' });
+        server.create('certification-framework', { id: 'DROIT', versionSummaries: [] });
+        server.create('certification-version', {
+          id: 20,
+          scope: 'DROIT',
+          status: 'active',
+          globalScoringConfiguration: [],
+        });
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+        const screen = await visit(`/certification-frameworks/DROIT/versions/20/scoring`);
+
+        assert
+          .dom(
+            screen.getByText(
+              t('components.certification-frameworks.certification-framework.versions.scoring.save-scoring-button'),
+            ),
+          )
+          .exists();
+        assert
+          .dom(
+            screen.queryByText(
+              t(
+                'components.certification-frameworks.certification-framework.versions.activate-version.button-label',
+              ),
+            ),
+          )
+          .doesNotExist();
       });
     });
 

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/scoring-test.js
@@ -219,9 +219,7 @@ module('Acceptance | Certification Framework | item | Framework | scoring', func
         assert
           .dom(
             screen.queryByText(
-              t(
-                'components.certification-frameworks.certification-framework.versions.activate-version.button-label',
-              ),
+              t('components.certification-frameworks.certification-framework.versions.activate-version.button-label'),
             ),
           )
           .doesNotExist();

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-competences-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-competences-scoring-form-test.gjs
@@ -61,7 +61,7 @@ module(
         const screen = await render(
           <template>
             <CompetencesScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -86,7 +86,7 @@ module(
         const screen = await render(
           <template>
             <CompetencesScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -118,7 +118,7 @@ module(
         const screen = await render(
           <template>
             <CompetencesScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -157,7 +157,7 @@ module(
         const screen = await render(
           <template>
             <CompetencesScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -194,7 +194,7 @@ module(
         const screen = await render(
           <template>
             <CompetencesScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,

--- a/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form-test.gjs
+++ b/admin/tests/integration/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form-test.gjs
@@ -63,7 +63,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -92,7 +92,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -132,8 +132,8 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
-              @activeVersion={{activeVersion}}
+              @editVersion={{draftVersion}}
+              @previousVersion={{activeVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -162,7 +162,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -188,7 +188,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -215,7 +215,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -242,7 +242,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,
@@ -276,7 +276,7 @@ module(
         const screen = await render(
           <template>
             <GlobalScoringForm
-              @draftVersion={{draftVersion}}
+              @editVersion={{draftVersion}}
               @calibrationScoringConfiguration={{calibrationScoringConfiguration}}
             />
           </template>,

--- a/admin/tests/unit/adapters/certification-version-test.js
+++ b/admin/tests/unit/adapters/certification-version-test.js
@@ -62,5 +62,25 @@ module('Unit | Adapters | certification-version', function (hooks) {
         assert.ok(true);
       });
     });
+
+    module('when the saveScoring adapterOption is set', function () {
+      test('calls PATCH on the /scoring sub-route with serialized data', async function (assert) {
+        const serializedData = {
+          data: {
+            type: 'certification-versions',
+            id: '456',
+            attributes: { 'global-scoring-configuration': [] },
+          },
+        };
+        sinon.stub(adapter, 'serialize').returns(serializedData);
+        const snapshot = { id: '456', adapterOptions: { saveScoring: true } };
+
+        await adapter.updateRecord(null, null, snapshot);
+
+        const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-versions/456/scoring`;
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH', { data: serializedData });
+        assert.ok(true);
+      });
+    });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
@@ -34,7 +34,10 @@ module(
           competencesScoringConfiguration: null,
           save: sinon.stub().resolves(),
         };
-        const calibrationScoringConfiguration = { globalScoringConfiguration: calibrationConfig, competencesScoringConfiguration: [] };
+        const calibrationScoringConfiguration = {
+          globalScoringConfiguration: calibrationConfig,
+          competencesScoringConfiguration: [],
+        };
 
         await controller.saveScoring(version, calibrationScoringConfiguration);
 

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
@@ -27,29 +27,20 @@ module(
     });
 
     module('#activateVersion', function () {
-      test('saves the draft version data and activates the version', async function (assert) {
-        const draftVersion = {
-          id: 42,
-          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -8, max: -2 } }],
-          competencesScoringConfiguration: null,
-          save: sinon.stub().resolves(),
-        };
+      test('activates the version', async function (assert) {
+        const draftVersion = { id: 42, save: sinon.stub().resolves() };
 
-        await controller.activateVersion(draftVersion, null);
+        await controller.activateVersion(draftVersion);
 
-        assert.strictEqual(draftVersion.save.callCount, 2);
-        sinon.assert.calledWith(draftVersion.save.secondCall, { adapterOptions: { activate: true } });
+        sinon.assert.calledWithExactly(draftVersion.save, { adapterOptions: { activate: true } });
+        assert.ok(true);
       });
 
       test('shows a success notification and redirects after activation', async function (assert) {
-        const draftVersion = {
-          id: 42,
-          globalScoringConfiguration: [],
-          competencesScoringConfiguration: null,
-          save: sinon.stub().resolves(),
-        };
+        const draftVersion = { id: 42, save: sinon.stub().resolves() };
 
-        await controller.activateVersion(draftVersion, null);
+        await controller.activateVersion(draftVersion);
+
         sinon.assert.calledOnce(controller.pixToast.sendSuccessNotification);
         sinon.assert.calledWith(
           controller.router.transitionTo,
@@ -58,15 +49,10 @@ module(
         assert.ok(true);
       });
 
-      test('shows an error notification when the save fails', async function (assert) {
-        const draftVersion = {
-          id: 42,
-          globalScoringConfiguration: [],
-          competencesScoringConfiguration: null,
-          save: sinon.stub().rejects(new Error('network error')),
-        };
+      test('shows an error notification when activation fails', async function (assert) {
+        const draftVersion = { id: 42, save: sinon.stub().rejects(new Error('network error')) };
 
-        await controller.activateVersion(draftVersion, null);
+        await controller.activateVersion(draftVersion);
 
         sinon.assert.calledOnce(controller.pixToast.sendErrorNotification);
         sinon.assert.notCalled(controller.router.transitionTo);

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version-test.js
@@ -26,6 +26,40 @@ module(
       };
     });
 
+    module('#saveScoring', function () {
+      test('sets globalScoringConfiguration from calibration when version has none and saves', async function (assert) {
+        const calibrationConfig = [{ meshLevel: 0, bounds: { min: -4, max: -1 } }];
+        const version = {
+          globalScoringConfiguration: [],
+          competencesScoringConfiguration: null,
+          save: sinon.stub().resolves(),
+        };
+        const calibrationScoringConfiguration = { globalScoringConfiguration: calibrationConfig, competencesScoringConfiguration: [] };
+
+        await controller.saveScoring(version, calibrationScoringConfiguration);
+
+        assert.deepEqual(version.globalScoringConfiguration, calibrationConfig);
+        sinon.assert.calledOnce(version.save);
+      });
+
+      test('keeps existing globalScoringConfiguration when version already has one', async function (assert) {
+        const existingConfig = [{ meshLevel: 0, bounds: { min: -8, max: -2 } }];
+        const version = {
+          globalScoringConfiguration: existingConfig,
+          competencesScoringConfiguration: null,
+          save: sinon.stub().resolves(),
+        };
+        const calibrationScoringConfiguration = {
+          globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: -4, max: -1 } }],
+          competencesScoringConfiguration: [],
+        };
+
+        await controller.saveScoring(version, calibrationScoringConfiguration);
+
+        assert.deepEqual(version.globalScoringConfiguration, existingConfig);
+      });
+    });
+
     module('#activateVersion', function () {
       test('activates the version', async function (assert) {
         const draftVersion = { id: 42, save: sinon.stub().resolves() };

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration-test.js
@@ -32,46 +32,17 @@ module(
       });
     });
 
-    module('#hasNoExternalCalibrationId', function () {
-      test('returns true when externalCalibrationId is null', function (assert) {
-        controller.model = { draftVersion: { externalCalibrationId: null } };
-
-        assert.true(controller.hasNoExternalCalibrationId);
-      });
-
-      test('returns false when externalCalibrationId is set', function (assert) {
-        controller.model = { draftVersion: { externalCalibrationId: 42 } };
-
-        assert.false(controller.hasNoExternalCalibrationId);
-      });
-    });
-
-    module('#isPixPlusScope', function () {
-      test('returns true when scope is not CORE', function (assert) {
-        controller.model = { draftVersion: { scope: 'PIX_PLUS_EDU_2ND_DEGRE' } };
-
-        assert.true(controller.isPixPlusScope);
-      });
-
-      test('returns false when scope is CORE', function (assert) {
-        controller.model = { draftVersion: { scope: 'CORE' } };
-
-        assert.false(controller.isPixPlusScope);
-      });
-    });
-
     module('#activateVersion', function () {
-      test('delegates to versionController.activateVersion with draftVersion and calibrationScoringConfiguration', function (assert) {
+      test('delegates to versionController.activateVersion with draftVersion only', function (assert) {
         const draftVersion = { id: 1 };
-        const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
-        controller.model = { draftVersion, calibrationScoringConfiguration };
+        controller.model = { draftVersion };
 
         const activateVersionStub = sinon.stub();
         controller.versionController = { activateVersion: activateVersionStub };
 
         controller.activateVersion();
 
-        sinon.assert.calledWithExactly(activateVersionStub, draftVersion, calibrationScoringConfiguration);
+        sinon.assert.calledWithExactly(activateVersionStub, draftVersion);
         assert.ok(true);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/calibration-test.js
@@ -1,0 +1,79 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module(
+  'Unit | Controller | authenticated/certification-frameworks/certification-framework/versions/version/calibration',
+  function (hooks) {
+    setupTest(hooks);
+
+    let controller;
+
+    hooks.beforeEach(function () {
+      controller = this.owner.lookup(
+        'controller:authenticated/certification-frameworks/certification-framework/versions/version/calibration',
+      );
+    });
+
+    module('#toggleConfirmationModal', function () {
+      test('opens the modal when called once', function (assert) {
+        assert.false(controller.isConfirmationModalOpen);
+
+        controller.toggleConfirmationModal();
+
+        assert.true(controller.isConfirmationModalOpen);
+      });
+
+      test('closes the modal when called twice', function (assert) {
+        controller.toggleConfirmationModal();
+        controller.toggleConfirmationModal();
+
+        assert.false(controller.isConfirmationModalOpen);
+      });
+    });
+
+    module('#hasNoExternalCalibrationId', function () {
+      test('returns true when externalCalibrationId is null', function (assert) {
+        controller.model = { draftVersion: { externalCalibrationId: null } };
+
+        assert.true(controller.hasNoExternalCalibrationId);
+      });
+
+      test('returns false when externalCalibrationId is set', function (assert) {
+        controller.model = { draftVersion: { externalCalibrationId: 42 } };
+
+        assert.false(controller.hasNoExternalCalibrationId);
+      });
+    });
+
+    module('#isPixPlusScope', function () {
+      test('returns true when scope is not CORE', function (assert) {
+        controller.model = { draftVersion: { scope: 'PIX_PLUS_EDU_2ND_DEGRE' } };
+
+        assert.true(controller.isPixPlusScope);
+      });
+
+      test('returns false when scope is CORE', function (assert) {
+        controller.model = { draftVersion: { scope: 'CORE' } };
+
+        assert.false(controller.isPixPlusScope);
+      });
+    });
+
+    module('#activateVersion', function () {
+      test('delegates to versionController.activateVersion with draftVersion and calibrationScoringConfiguration', function (assert) {
+        const draftVersion = { id: 1 };
+        const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
+        controller.model = { draftVersion, calibrationScoringConfiguration };
+
+        const activateVersionStub = sinon.stub();
+        controller.versionController = { activateVersion: activateVersionStub };
+
+        controller.activateVersion();
+
+        sinon.assert.calledWithExactly(activateVersionStub, draftVersion, calibrationScoringConfiguration);
+        assert.ok(true);
+      });
+    });
+  },
+);

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
@@ -35,7 +35,7 @@ module(
     module('#hasGlobalScoringError', function () {
       test('returns false when all bounds are valid', function (assert) {
         controller.model = {
-          draftVersion: {
+          editVersion: {
             globalScoringConfiguration: [
               { meshLevel: 0, bounds: { min: -4, max: -1 } },
               { meshLevel: 1, bounds: { min: -1, max: 2 } },
@@ -49,7 +49,7 @@ module(
 
       test('returns true when at least one bound has max <= min', function (assert) {
         controller.model = {
-          draftVersion: {
+          editVersion: {
             globalScoringConfiguration: [
               { meshLevel: 0, bounds: { min: -4, max: -1 } },
               { meshLevel: 1, bounds: { min: 2, max: 1 } },
@@ -61,9 +61,9 @@ module(
         assert.true(controller.hasGlobalScoringError);
       });
 
-      test('falls back to calibrationScoringConfiguration when draftVersion has no configuration', function (assert) {
+      test('falls back to calibrationScoringConfiguration when editVersion has no configuration', function (assert) {
         controller.model = {
-          draftVersion: { globalScoringConfiguration: null },
+          editVersion: { globalScoringConfiguration: null },
           calibrationScoringConfiguration: {
             globalScoringConfiguration: [{ meshLevel: 0, bounds: { min: 1, max: 0 } }],
           },
@@ -74,17 +74,17 @@ module(
     });
 
     module('#activateVersion', function () {
-      test('delegates to versionController.activateVersion with draftVersion and calibrationScoringConfiguration', function (assert) {
-        const draftVersion = { id: 1 };
+      test('delegates to versionController.activateVersion with editVersion and calibrationScoringConfiguration', function (assert) {
+        const editVersion = { id: 1 };
         const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
-        controller.model = { draftVersion, calibrationScoringConfiguration };
+        controller.model = { editVersion, calibrationScoringConfiguration };
 
         const activateVersionStub = sinon.stub();
         controller.versionController = { activateVersion: activateVersionStub };
 
         controller.activateVersion();
 
-        sinon.assert.calledWithExactly(activateVersionStub, draftVersion, calibrationScoringConfiguration);
+        sinon.assert.calledWithExactly(activateVersionStub, editVersion, calibrationScoringConfiguration);
         assert.ok(true);
       });
     });

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
@@ -1,6 +1,5 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 module(
   'Unit | Controller | authenticated/certification-frameworks/certification-framework/versions/version/scoring',
@@ -15,20 +14,20 @@ module(
       );
     });
 
-    module('#toggleConfirmationModal', function () {
+    module('#toggleActivationModal', function () {
       test('opens the modal when called once', function (assert) {
-        assert.false(controller.isConfirmationModalOpen);
+        assert.false(controller.isActivationModalOpen);
 
-        controller.toggleConfirmationModal();
+        controller.toggleActivationModal();
 
-        assert.true(controller.isConfirmationModalOpen);
+        assert.true(controller.isActivationModalOpen);
       });
 
       test('closes the modal when called twice', function (assert) {
-        controller.toggleConfirmationModal();
-        controller.toggleConfirmationModal();
+        controller.toggleActivationModal();
+        controller.toggleActivationModal();
 
-        assert.false(controller.isConfirmationModalOpen);
+        assert.false(controller.isActivationModalOpen);
       });
     });
 
@@ -70,22 +69,6 @@ module(
         };
 
         assert.true(controller.hasGlobalScoringError);
-      });
-    });
-
-    module('#activateVersion', function () {
-      test('delegates to versionController.activateVersion with editVersion and calibrationScoringConfiguration', function (assert) {
-        const editVersion = { id: 1 };
-        const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
-        controller.model = { editVersion, calibrationScoringConfiguration };
-
-        const activateVersionStub = sinon.stub();
-        controller.versionController = { activateVersion: activateVersionStub };
-
-        controller.activateVersion();
-
-        sinon.assert.calledWithExactly(activateVersionStub, editVersion, calibrationScoringConfiguration);
-        assert.ok(true);
       });
     });
   },

--- a/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-frameworks/certification-framework/versions/version/scoring-test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module(
   'Unit | Controller | authenticated/certification-frameworks/certification-framework/versions/version/scoring',
@@ -12,6 +13,13 @@ module(
       controller = this.owner.lookup(
         'controller:authenticated/certification-frameworks/certification-framework/versions/version/scoring',
       );
+      controller.pixToast = {
+        sendSuccessNotification: sinon.stub(),
+        sendErrorNotification: sinon.stub(),
+      };
+      controller.intl = { t: sinon.stub().returns('') };
+      controller.router = { transitionTo: sinon.stub().resolves() };
+      controller.store = { findAll: sinon.stub().resolves() };
     });
 
     module('#toggleActivationModal', function () {
@@ -69,6 +77,68 @@ module(
         };
 
         assert.true(controller.hasGlobalScoringError);
+      });
+    });
+
+    module('#saveScoring', function () {
+      test('delegates to versionController.saveScoring and shows a success toast', async function (assert) {
+        const editVersion = { id: 1 };
+        const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
+        controller.model = { editVersion, calibrationScoringConfiguration };
+
+        const saveScoringStub = sinon.stub().resolves();
+        controller.versionController = { saveScoring: saveScoringStub };
+
+        await controller.saveScoring();
+
+        sinon.assert.calledWithExactly(saveScoringStub, editVersion, calibrationScoringConfiguration);
+        sinon.assert.calledOnce(controller.pixToast.sendSuccessNotification);
+        assert.ok(true);
+      });
+
+      test('shows an error toast when saveScoring fails', async function (assert) {
+        controller.model = {
+          editVersion: { id: 1 },
+          calibrationScoringConfiguration: null,
+        };
+        controller.versionController = { saveScoring: sinon.stub().rejects(new Error('fail')) };
+
+        await controller.saveScoring();
+
+        sinon.assert.calledOnce(controller.pixToast.sendErrorNotification);
+        assert.ok(true);
+      });
+    });
+
+    module('#saveScoringAndActivate', function () {
+      test('delegates saveScoring then activateVersion to versionController', async function (assert) {
+        const editVersion = { id: 1 };
+        const calibrationScoringConfiguration = { globalScoringConfiguration: [] };
+        controller.model = { editVersion, calibrationScoringConfiguration };
+
+        const saveScoringStub = sinon.stub().resolves();
+        const activateVersionStub = sinon.stub().resolves();
+        controller.versionController = { saveScoring: saveScoringStub, activateVersion: activateVersionStub };
+
+        await controller.saveScoringAndActivate();
+
+        sinon.assert.calledWithExactly(saveScoringStub, editVersion, calibrationScoringConfiguration);
+        sinon.assert.calledWithExactly(activateVersionStub, editVersion);
+        assert.ok(true);
+      });
+
+      test('shows an error toast when saveScoring fails', async function (assert) {
+        controller.model = { editVersion: { id: 1 }, calibrationScoringConfiguration: null };
+        controller.versionController = {
+          saveScoring: sinon.stub().rejects(new Error('fail')),
+          activateVersion: sinon.stub(),
+        };
+
+        await controller.saveScoringAndActivate();
+
+        sinon.assert.calledOnce(controller.pixToast.sendErrorNotification);
+        sinon.assert.notCalled(controller.versionController.activateVersion);
+        assert.ok(true);
       });
     });
   },

--- a/admin/tests/unit/models/certification-framework-test.js
+++ b/admin/tests/unit/models/certification-framework-test.js
@@ -116,4 +116,51 @@ module('Unit | Model | certification-framework', function (hooks) {
       assert.false(certificationFramework.hasDraft);
     });
   });
+
+  module('#get hasPixPlusActiveWithoutScoring', function () {
+    test('returns true when a Pix+ active version has no scoring', function (assert) {
+      const certificationFramework = store.createRecord('certification-framework', {
+        id: 'DROIT',
+        scope: 'DROIT',
+        versionSummaries: [
+          store.createRecord('certification-version-summary', {
+            id: 1,
+            status: 'active',
+            hasGlobalScoring: false,
+          }),
+        ],
+      });
+      assert.true(certificationFramework.hasPixPlusActiveWithoutScoring);
+    });
+
+    test('returns false when the framework is CORE', function (assert) {
+      const certificationFramework = store.createRecord('certification-framework', {
+        id: 'CORE',
+        scope: 'CORE',
+        versionSummaries: [
+          store.createRecord('certification-version-summary', {
+            id: 1,
+            status: 'active',
+            hasGlobalScoring: false,
+          }),
+        ],
+      });
+      assert.false(certificationFramework.hasPixPlusActiveWithoutScoring);
+    });
+
+    test('returns false when the Pix+ active version has scoring', function (assert) {
+      const certificationFramework = store.createRecord('certification-framework', {
+        id: 'DROIT',
+        scope: 'DROIT',
+        versionSummaries: [
+          store.createRecord('certification-version-summary', {
+            id: 1,
+            status: 'active',
+            hasGlobalScoring: true,
+          }),
+        ],
+      });
+      assert.false(certificationFramework.hasPixPlusActiveWithoutScoring);
+    });
+  });
 });

--- a/admin/tests/unit/models/certification-version-test.js
+++ b/admin/tests/unit/models/certification-version-test.js
@@ -1,0 +1,24 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | certification-version', function (hooks) {
+  setupTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#get hasExternalCalibrationId', function () {
+    test('returns true when externalCalibrationId is set', function (assert) {
+      const version = store.createRecord('certification-version', { externalCalibrationId: 42 });
+      assert.true(version.hasExternalCalibrationId);
+    });
+
+    test('returns false when externalCalibrationId is null', function (assert) {
+      const version = store.createRecord('certification-version', { externalCalibrationId: null });
+      assert.false(version.hasExternalCalibrationId);
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -655,6 +655,11 @@
             "level": "Level {index}",
             "previous-version-capacity": "Previous value: {previousVersionCapacity}",
             "save-error": "An error occurred while saving the scoring.",
+            "save-scoring-button": "Save scoring",
+            "save-scoring-modal": {
+              "content": "This action will save the scoring configuration on the active version.",
+              "title": "Confirm scoring save"
+            },
             "success-notification": "The scoring has been successfully updated",
             "title": "Bounds of capacity by mesh"
           },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -654,6 +654,7 @@
             },
             "level": "Level {index}",
             "previous-version-capacity": "Previous value: {previousVersionCapacity}",
+            "save-error": "An error occurred while saving the scoring.",
             "success-notification": "The scoring has been successfully updated",
             "title": "Bounds of capacity by mesh"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -655,10 +655,12 @@
             "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
             "competences": {
               "level": "Niveau",
+              "no-configuration": "Aucune configuration disponible pour cette compétence.",
               "title": "Bornes de capacités par compétences"
             },
             "level": "Niveau {index}",
             "previous-version-capacity": "Ancienne valeur : {previousVersionCapacity}",
+            "save-error": "Une erreur s'est produite lors de l'enregistrement du scoring.",
             "success-notification": "Le scoring a bien été mis à jour",
             "title": "Bornes de capacités par mailles"
           },

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -661,6 +661,11 @@
             "level": "Niveau {index}",
             "previous-version-capacity": "Ancienne valeur : {previousVersionCapacity}",
             "save-error": "Une erreur s'est produite lors de l'enregistrement du scoring.",
+            "save-scoring-button": "Enregistrer le scoring",
+            "save-scoring-modal": {
+              "content": "Cette action va enregistrer la configuration de scoring sur la version active.",
+              "title": "Confirmation de l'enregistrement du scoring"
+            },
             "success-notification": "Le scoring a bien été mis à jour",
             "title": "Bornes de capacités par mailles"
           },

--- a/api/src/certification/configuration/application/certification-version-controller.js
+++ b/api/src/certification/configuration/application/certification-version-controller.js
@@ -74,6 +74,13 @@ async function activateVersion(request, h) {
   return h.response().code(204);
 }
 
+async function saveScoringConfiguration(request, h) {
+  const id = request.params.certificationVersionId;
+  const { globalScoringConfiguration, competencesScoringConfiguration } = await deserialize(request.payload);
+  await usecases.saveScoringConfiguration({ id, globalScoringConfiguration, competencesScoringConfiguration });
+  return h.response().code(204);
+}
+
 async function getInfo(request) {
   const framework = request.params.framework;
 
@@ -91,6 +98,7 @@ export const certificationVersionController = {
   deleteCertificationVersion,
   update,
   updateComments,
+  saveScoringConfiguration,
   getInfo,
   generateCalibrationReport,
   getCalibrationScoringConfiguration,

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -145,6 +145,56 @@ async function register(server) {
     },
     {
       method: 'PATCH',
+      path: '/api/admin/certification-versions/{certificationVersionId}/scoring',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.hasAtLeastOneAccessOf([securityPreHandlers.checkAdminMemberHasRoleSuperAdmin])(
+                request,
+                h,
+              ),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationVersionId: identifiersType.certificationVersionId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              id: Joi.number(),
+              attributes: Joi.object({
+                'global-scoring-configuration': Joi.array()
+                  .items(
+                    Joi.object({
+                      bounds: Joi.object({
+                        min: Joi.number().required(),
+                        max: Joi.number().required(),
+                      }),
+                      meshLevel: Joi.number().required(),
+                    }),
+                  )
+                  .required(),
+                'competences-scoring-configuration': Joi.array().allow(null).optional(),
+              })
+                .required()
+                .unknown(true),
+              type: Joi.string(),
+              relationships: Joi.object().optional(),
+            }),
+          }),
+        },
+        handler: certificationVersionController.saveScoringConfiguration,
+        tags: ['api', 'admin'],
+        notes: [
+          'Cette route est restreinte au SUPER ADMIN',
+          "Elle permet de configurer le scoring d'une version active (Pix+ uniquement)",
+        ],
+      },
+    },
+    {
+      method: 'PATCH',
       path: '/api/admin/certification-versions/{certificationVersionId}/comments',
       config: {
         pre: [

--- a/api/src/certification/configuration/application/http-error-mapper-configuration.js
+++ b/api/src/certification/configuration/application/http-error-mapper-configuration.js
@@ -7,6 +7,7 @@ import {
 import {
   ActiveCertificationInfoNotFound,
   CertificationVersionDraftAlreadyExistError,
+  CoreVersionRequiresScoringError,
   InvalidScoWhitelistError,
   VersionNotDraftError,
 } from '../domain/errors.js';
@@ -26,6 +27,10 @@ export const configurationDomainErrorMappingConfiguration = [
   },
   {
     name: VersionNotDraftError.name,
+    httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
+  },
+  {
+    name: CoreVersionRequiresScoringError.name,
     httpErrorFn: (error) => new ConflictError(error.message, error.code, error.meta),
   },
 ];

--- a/api/src/certification/configuration/domain/errors.js
+++ b/api/src/certification/configuration/domain/errors.js
@@ -36,3 +36,10 @@ export class VersionNotDraftError extends DomainError {
     super("Impossible de modifier une version qui ne soit pas en cours d'édition");
   }
 }
+
+export class CoreVersionRequiresScoringError extends DomainError {
+  constructor() {
+    super("Impossible d'activer une version CORE sans configuration de scoring");
+    this.code = 'CORE_VERSION_REQUIRES_SCORING';
+  }
+}

--- a/api/src/certification/configuration/domain/read-models/VersionSummary.js
+++ b/api/src/certification/configuration/domain/read-models/VersionSummary.js
@@ -1,5 +1,13 @@
 export class VersionSummary {
-  constructor({ id, startDate, expirationDate, assessmentDuration, maximumAssessmentLength, status, hasGlobalScoring }) {
+  constructor({
+    id,
+    startDate,
+    expirationDate,
+    assessmentDuration,
+    maximumAssessmentLength,
+    status,
+    hasGlobalScoring,
+  }) {
     this.id = id;
     this.startDate = startDate ?? null;
     this.expirationDate = expirationDate ?? null;

--- a/api/src/certification/configuration/domain/read-models/VersionSummary.js
+++ b/api/src/certification/configuration/domain/read-models/VersionSummary.js
@@ -1,10 +1,11 @@
 export class VersionSummary {
-  constructor({ id, startDate, expirationDate, assessmentDuration, maximumAssessmentLength, status }) {
+  constructor({ id, startDate, expirationDate, assessmentDuration, maximumAssessmentLength, status, hasGlobalScoring }) {
     this.id = id;
     this.startDate = startDate ?? null;
     this.expirationDate = expirationDate ?? null;
     this.assessmentDuration = assessmentDuration;
     this.maximumAssessmentLength = maximumAssessmentLength;
     this.status = status;
+    this.hasGlobalScoring = hasGlobalScoring ?? false;
   }
 }

--- a/api/src/certification/configuration/domain/usecases/activate-version.js
+++ b/api/src/certification/configuration/domain/usecases/activate-version.js
@@ -1,5 +1,6 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
-import { VersionNotDraftError } from '../errors.js';
+import { SCOPES } from '../../../shared/domain/models/Scopes.js';
+import { CoreVersionRequiresScoringError, VersionNotDraftError } from '../errors.js';
 
 /**
  * @param {object} params
@@ -19,6 +20,13 @@ export async function activateVersion({
   if (!draftVersion) throw new NotFoundError(`No certification version found for id: ${id}`);
 
   if (!draftVersion.isDraft) throw new VersionNotDraftError();
+
+  if (
+    draftVersion.scope === SCOPES.CORE &&
+    (!draftVersion.globalScoringConfiguration?.length || !draftVersion.competencesScoringConfiguration?.length)
+  ) {
+    throw new CoreVersionRequiresScoringError();
+  }
 
   const calibration = await calibrationRepository.find(draftVersion.externalCalibrationId);
   if (!calibration) {

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -28,10 +28,10 @@ import { getInfo } from './get-info.js';
 import { getScoBlockedAccessDates } from './get-sco-blocked-access-dates.js';
 import { getVersionById } from './get-version-by-id.js';
 import { importScoWhitelist } from './import-sco-whitelist.js';
+import { saveScoringConfiguration } from './save-scoring-configuration.js';
 import { searchAttachableTargetProfiles } from './search-attachable-target-profiles.js';
 import { sendTargetProfileNotifications } from './send-target-profile-notifications.js';
 import { updateScoBlockedAccessDate } from './update-sco-blocked-access-date.js';
-import { saveScoringConfiguration } from './save-scoring-configuration.js';
 import { updateVersion } from './update-version.js';
 import { updateVersionComment } from './update-version-comment.js';
 

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -31,6 +31,7 @@ import { importScoWhitelist } from './import-sco-whitelist.js';
 import { searchAttachableTargetProfiles } from './search-attachable-target-profiles.js';
 import { sendTargetProfileNotifications } from './send-target-profile-notifications.js';
 import { updateScoBlockedAccessDate } from './update-sco-blocked-access-date.js';
+import { saveScoringConfiguration } from './save-scoring-configuration.js';
 import { updateVersion } from './update-version.js';
 import { updateVersionComment } from './update-version-comment.js';
 
@@ -86,6 +87,7 @@ const usecasesWithoutInjectedDependencies = {
   searchAttachableTargetProfiles,
   sendTargetProfileNotifications,
   updateScoBlockedAccessDate,
+  saveScoringConfiguration,
   updateVersion,
   updateVersionComment,
   generateCalibrationReportCheck,

--- a/api/src/certification/configuration/domain/usecases/save-scoring-configuration.js
+++ b/api/src/certification/configuration/domain/usecases/save-scoring-configuration.js
@@ -1,0 +1,23 @@
+import { NotFoundError } from '../../../../shared/domain/errors.js';
+
+/**
+ * @param {object} params
+ * @param {number} params.id
+ * @param {Array} params.globalScoringConfiguration
+ * @param {Array|null} params.competencesScoringConfiguration
+ * @param {object} params.versionRepository
+ */
+export async function saveScoringConfiguration({
+  id,
+  globalScoringConfiguration,
+  competencesScoringConfiguration,
+  versionRepository,
+}) {
+  const version = await versionRepository.getById({ id });
+
+  if (!version) {
+    throw new NotFoundError(`No certification version found for id: ${id}`);
+  }
+
+  await versionRepository.updateScoring({ id, globalScoringConfiguration, competencesScoringConfiguration });
+}

--- a/api/src/certification/configuration/infrastructure/repositories/framework-info-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/framework-info-repository.js
@@ -42,6 +42,11 @@ function baseQuery() {
     maximumAssessmentLength: knexConn.raw(
       'certification_versions."challengesConfiguration"->\'maximumAssessmentLength\'',
     ),
+    hasGlobalScoring: knexConn.raw(
+      `CASE WHEN certification_versions."globalScoringConfiguration" IS NOT NULL
+            AND jsonb_array_length(certification_versions."globalScoringConfiguration") > 0
+       THEN true ELSE false END`,
+    ),
   });
 }
 

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -105,6 +105,16 @@ export async function updateComments({ id, comments }) {
   });
 }
 
+export async function updateScoring({ id, globalScoringConfiguration, competencesScoringConfiguration }) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('certification_versions').where({ id }).update({
+    globalScoringConfiguration: JSON.stringify(globalScoringConfiguration),
+    competencesScoringConfiguration: competencesScoringConfiguration
+      ? JSON.stringify(competencesScoringConfiguration)
+      : null,
+  });
+}
+
 function buildBaseQuery() {
   const knexConn = DomainTransaction.getConnection();
 

--- a/api/src/certification/configuration/infrastructure/repositories/version-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/version-repository.js
@@ -107,12 +107,14 @@ export async function updateComments({ id, comments }) {
 
 export async function updateScoring({ id, globalScoringConfiguration, competencesScoringConfiguration }) {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn('certification_versions').where({ id }).update({
-    globalScoringConfiguration: JSON.stringify(globalScoringConfiguration),
-    competencesScoringConfiguration: competencesScoringConfiguration
-      ? JSON.stringify(competencesScoringConfiguration)
-      : null,
-  });
+  await knexConn('certification_versions')
+    .where({ id })
+    .update({
+      globalScoringConfiguration: JSON.stringify(globalScoringConfiguration),
+      competencesScoringConfiguration: competencesScoringConfiguration
+        ? JSON.stringify(competencesScoringConfiguration)
+        : null,
+    });
 }
 
 function buildBaseQuery() {

--- a/api/src/certification/configuration/infrastructure/serializers/framework-info-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/framework-info-serializer.js
@@ -11,7 +11,7 @@ export function serialize(frameworkInfo) {
     versionSummaries: {
       included: true,
       ref: 'id',
-      attributes: ['startDate', 'expirationDate', 'assessmentDuration', 'maximumAssessmentLength', 'status'],
+      attributes: ['startDate', 'expirationDate', 'assessmentDuration', 'maximumAssessmentLength', 'status', 'hasGlobalScoring'],
     },
     complementaryCertification: {
       ref: 'id',

--- a/api/src/certification/configuration/infrastructure/serializers/framework-info-serializer.js
+++ b/api/src/certification/configuration/infrastructure/serializers/framework-info-serializer.js
@@ -11,7 +11,14 @@ export function serialize(frameworkInfo) {
     versionSummaries: {
       included: true,
       ref: 'id',
-      attributes: ['startDate', 'expirationDate', 'assessmentDuration', 'maximumAssessmentLength', 'status', 'hasGlobalScoring'],
+      attributes: [
+        'startDate',
+        'expirationDate',
+        'assessmentDuration',
+        'maximumAssessmentLength',
+        'status',
+        'hasGlobalScoring',
+      ],
     },
     complementaryCertification: {
       ref: 'id',

--- a/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-framework-route_test.js
@@ -231,6 +231,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
             attributes: {
               'assessment-duration': 1,
               'expiration-date': null,
+              'has-global-scoring': true,
               'maximum-assessment-length': 1,
               'start-date': new Date('2021-01-01'),
               status: VERSION_STATUSES.ACTIVE,
@@ -242,6 +243,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
             attributes: {
               'assessment-duration': 4,
               'expiration-date': null,
+              'has-global-scoring': false,
               'maximum-assessment-length': 4,
               'start-date': new Date('2024-02-02'),
               status: VERSION_STATUSES.DRAFT,
@@ -253,6 +255,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
             attributes: {
               'assessment-duration': 2,
               'expiration-date': null,
+              'has-global-scoring': true,
               'maximum-assessment-length': 2,
               'start-date': new Date('2022-02-02'),
               status: VERSION_STATUSES.ACTIVE,
@@ -264,6 +267,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
             attributes: {
               'assessment-duration': 3,
               'expiration-date': new Date('2022-02-02'),
+              'has-global-scoring': true,
               'maximum-assessment-length': 3,
               'start-date': new Date('2022-01-01'),
               status: VERSION_STATUSES.ARCHIVED,
@@ -340,6 +344,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
             attributes: {
               'assessment-duration': 2,
               'expiration-date': null,
+              'has-global-scoring': true,
               'maximum-assessment-length': 2,
               'start-date': new Date('2022-02-02'),
               status: VERSION_STATUSES.ACTIVE,
@@ -351,6 +356,7 @@ describe('Acceptance | Application | Certification | Configuration | certificati
             attributes: {
               'assessment-duration': 3,
               'expiration-date': new Date('2022-02-02'),
+              'has-global-scoring': true,
               'maximum-assessment-length': 3,
               'start-date': new Date('2022-01-01'),
               status: VERSION_STATUSES.ARCHIVED,

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -2,6 +2,10 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
+  defaultCompetencesScoringConfiguration,
+  defaultGlobalScoringConfiguration,
+} from '../../../../../db/database-builder/factory/build-certification-version.js';
+import {
   CALIBRATION_SCOPES,
   CALIBRATION_STATUSES,
 } from '../../../../../src/certification/configuration/domain/models/Calibration.js';
@@ -17,7 +21,7 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 import { getServer } from '../../../../tooling/server/shared-server.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
-describe('Acceptance | Certification | Configuration | API | certification-version-route', function () {
+describe.only('Acceptance | Certification | Configuration | API | certification-version-route', function () {
   let server;
   let superAdmin;
 
@@ -933,7 +937,12 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       domainBuilder.certification.configuration
         .versionBuilder()
         .asActive()
-        .withParameters({ id: 42, scope: SCOPES.PIX_PLUS_DROIT, globalScoringConfiguration: [], competencesScoringConfiguration: null })
+        .withParameters({
+          id: 42,
+          scope: SCOPES.PIX_PLUS_DROIT,
+          globalScoringConfiguration: [],
+          competencesScoringConfiguration: null,
+        })
         .insertToDB({ databaseBuilder });
       await databaseBuilder.commit();
 
@@ -960,7 +969,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       // then
       expect(response.statusCode).to.equal(204);
       const updatedVersion = await knex('certification_versions').where({ id: 42 }).first();
-      expect(JSON.parse(updatedVersion.globalScoringConfiguration)).to.deep.equal(globalScoringConfiguration);
+      expect(updatedVersion.globalScoringConfiguration).to.deep.equal(globalScoringConfiguration);
     });
 
     it('returns 403 when the user is not a super admin', async function () {
@@ -1000,7 +1009,14 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       const draftVersion = domainBuilder.certification.configuration
         .versionBuilder()
         .asDraft({ startDate: new Date('2025-01-01') })
-        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 11, externalCalibrationId: 2 })
+        .withParameters({
+          scope: SCOPES.CORE,
+          tubeIds: ['tubeA'],
+          id: 11,
+          externalCalibrationId: 2,
+          globalScoringConfiguration: defaultGlobalScoringConfiguration,
+          competencesScoringConfiguration: defaultCompetencesScoringConfiguration,
+        })
         .insertToDB({ databaseBuilder });
 
       await domainBuilder.certification.configuration

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -927,6 +927,68 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
     });
   });
 
+  describe('PATCH /api/admin/certification-versions/{certificationVersionId}/scoring', function () {
+    it('updates the scoring configuration of a version', async function () {
+      // given
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({ id: 42, scope: SCOPES.PIX_PLUS_DROIT, globalScoringConfiguration: [], competencesScoringConfiguration: null })
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      const globalScoringConfiguration = [{ meshLevel: 1, bounds: { min: -2, max: 3 } }];
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/certification-versions/42/scoring`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: superAdmin.id }),
+        payload: {
+          data: {
+            id: 42,
+            attributes: {
+              'global-scoring-configuration': globalScoringConfiguration,
+            },
+            type: 'certification-versions',
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const updatedVersion = await knex('certification_versions').where({ id: 42 }).first();
+      expect(JSON.parse(updatedVersion.globalScoringConfiguration)).to.deep.equal(globalScoringConfiguration);
+    });
+
+    it('returns 403 when the user is not a super admin', async function () {
+      // given
+      const certifUser = databaseBuilder.factory.buildUser.withRole({ role: 'CERTIF' });
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/certification-versions/42/scoring`,
+        headers: generateAuthenticatedUserRequestHeaders({ userId: certifUser.id }),
+        payload: {
+          data: {
+            id: 42,
+            attributes: { 'global-scoring-configuration': [] },
+            type: 'certification-versions',
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
   describe('PATCH /api/admin/certification-versions/{certificationVersionId}/activation', function () {
     it('activates the draft version, archives the active one, and persists calibrated challenges', async function () {
       // given

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -21,7 +21,7 @@ import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder
 import { getServer } from '../../../../tooling/server/shared-server.js';
 import { generateAuthenticatedUserRequestHeaders } from '../../../../tooling/test-utils/http-server.js';
 
-describe.only('Acceptance | Certification | Configuration | API | certification-version-route', function () {
+describe('Acceptance | Certification | Configuration | API | certification-version-route', function () {
   let server;
   let superAdmin;
 

--- a/api/tests/certification/configuration/integration/domain/usecases/save-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/save-scoring-configuration_test.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+
+import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
+import * as versionRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Configuration | Integration | Domain | UseCase | save-scoring-configuration', function () {
+  it('updates globalScoringConfiguration and competencesScoringConfiguration on an active version', async function () {
+    // given
+    domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive()
+      .withParameters({
+        id: 123,
+        scope: SCOPES.PIX_PLUS_DROIT,
+        globalScoringConfiguration: [],
+        competencesScoringConfiguration: null,
+      })
+      .insertToDB({ databaseBuilder });
+    await databaseBuilder.commit();
+
+    const globalScoringConfiguration = [{ meshLevel: 1, bounds: { min: 0, max: 100 } }];
+
+    // when
+    await usecases.saveScoringConfiguration({
+      id: 123,
+      globalScoringConfiguration,
+      competencesScoringConfiguration: null,
+    });
+
+    // then
+    const updatedVersion = await versionRepository.getById({ id: 123 });
+    expect(updatedVersion.globalScoringConfiguration).to.deep.equal(globalScoringConfiguration);
+    expect(updatedVersion.competencesScoringConfiguration).to.be.null;
+  });
+});

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/framework-info-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/framework-info-repository_test.js
@@ -77,6 +77,26 @@ describe('Certification | Configuration | Integration | Repository | FrameworkIn
     });
   });
 
+  describe('#findAll — hasGlobalScoring', function () {
+    it('returns hasGlobalScoring=false for an active version with empty scoring configuration', async function () {
+      // given
+      const frameworkInfo = domainBuilder.certification.configuration
+        .frameworkInfoBuilder()
+        .withActiveVersion({ hasScoring: false })
+        .withParameters({ scope: SCOPES.PIX_PLUS_DROIT })
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await frameworkInfoRepository.findAll();
+      const droitInfo = result.find((f) => f.scope === SCOPES.PIX_PLUS_DROIT);
+
+      // then
+      expect(droitInfo.versionSummaries[0].hasGlobalScoring).to.be.false;
+      expect(droitInfo).to.deepEqualInstance(frameworkInfo);
+    });
+  });
+
   describe('#find', function () {
     context('when no info found for framework name', function () {
       it('return null', async function () {

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/version-repository_test.js
@@ -436,4 +436,35 @@ describe('Certification | Configuration | Integration | Repository | Version', f
       expect(result).to.be.null;
     });
   });
+
+  describe('#updateScoring', function () {
+    it('updates only the scoring fields of the version', async function () {
+      // given
+      domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({
+          id: 77,
+          globalScoringConfiguration: [],
+          competencesScoringConfiguration: null,
+          tubeIds: ['rec1'],
+        })
+        .insertToDB({ databaseBuilder });
+      await databaseBuilder.commit();
+
+      const globalScoringConfiguration = [{ meshLevel: 1, bounds: { min: -2, max: 3 } }];
+
+      // when
+      await versionRepository.updateScoring({
+        id: 77,
+        globalScoringConfiguration,
+        competencesScoringConfiguration: null,
+      });
+
+      // then
+      const updatedVersion = await versionRepository.getById({ id: 77 });
+      expect(updatedVersion.globalScoringConfiguration).to.deep.equal(globalScoringConfiguration);
+      expect(updatedVersion.competencesScoringConfiguration).to.be.null;
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -405,7 +405,11 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/scoring`, validPayload);
+        const response = await httpTestServer.request(
+          'PATCH',
+          `/api/admin/certification-versions/1/scoring`,
+          validPayload,
+        );
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -424,7 +428,11 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/scoring`, validPayload);
+        const response = await httpTestServer.request(
+          'PATCH',
+          `/api/admin/certification-versions/1/scoring`,
+          validPayload,
+        );
 
         // then
         expect(response.statusCode).to.equal(204);
@@ -441,7 +449,11 @@ describe('Unit | Certification | Configuration | Application | Router | certific
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/NOT_AN_ID/scoring`, validPayload);
+        const response = await httpTestServer.request(
+          'PATCH',
+          `/api/admin/certification-versions/NOT_AN_ID/scoring`,
+          validPayload,
+        );
 
         // then
         expect(response.statusCode).to.equal(400);

--- a/api/tests/certification/configuration/unit/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/unit/application/certification-version-route_test.js
@@ -382,4 +382,90 @@ describe('Unit | Certification | Configuration | Application | Router | certific
       });
     });
   });
+
+  describe('PATCH /api/admin/certification-versions/{certificationVersionId}/scoring', function () {
+    const validPayload = {
+      data: {
+        id: '1',
+        attributes: {
+          'global-scoring-configuration': [{ meshLevel: 1, bounds: { min: 0, max: 100 } }],
+        },
+        type: 'certification-versions',
+      },
+    };
+
+    context('when the user has no role', function () {
+      it('should return 403 HTTP status code', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'hasAtLeastOneAccessOf')
+          .returns((request, h) => h.response().code(403).takeover());
+        sinon.stub(certificationVersionController, 'saveScoringConfiguration').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/scoring`, validPayload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(certificationVersionController.saveScoringConfiguration);
+      });
+    });
+
+    context('when the user is super admin', function () {
+      it('should return 204 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon
+          .stub(certificationVersionController, 'saveScoringConfiguration')
+          .callsFake((request, h) => h.response().code(204));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/scoring`, validPayload);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+        sinon.assert.calledOnce(certificationVersionController.saveScoringConfiguration);
+      });
+    });
+
+    context('when the version id is not valid', function () {
+      it('should return 400 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon.stub(certificationVersionController, 'saveScoringConfiguration').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/NOT_AN_ID/scoring`, validPayload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        sinon.assert.notCalled(certificationVersionController.saveScoringConfiguration);
+      });
+    });
+
+    context('when global-scoring-configuration is missing', function () {
+      it('should return 400 HTTP status code', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').returns(true);
+        sinon.stub(certificationVersionController, 'saveScoringConfiguration').returns('ok');
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('PATCH', `/api/admin/certification-versions/1/scoring`, {
+          data: { id: '1', attributes: {}, type: 'certification-versions' },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(400);
+        sinon.assert.notCalled(certificationVersionController.saveScoringConfiguration);
+      });
+    });
+  });
 });

--- a/api/tests/certification/configuration/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/certification/configuration/unit/application/http-error-mapper-configuration_test.js
@@ -4,6 +4,7 @@ import { configurationDomainErrorMappingConfiguration } from '../../../../../src
 import {
   ActiveCertificationInfoNotFound,
   CertificationVersionDraftAlreadyExistError,
+  CoreVersionRequiresScoringError,
   InvalidScoWhitelistError,
   VersionNotDraftError,
 } from '../../../../../src/certification/configuration/domain/errors.js';
@@ -78,6 +79,22 @@ describe('Unit | Certification | Configuration | Application | HttpErrorMapperCo
       //then
       expect(error).to.be.instanceOf(ConflictError);
       expect(error.message).to.equal("Impossible de modifier une version qui ne soit pas en cours d'édition");
+    });
+  });
+
+  context('when mapping "CoreVersionRequiresScoringError"', function () {
+    it('returns an Conflict Http Error', function () {
+      //given
+      const httpErrorMapper = configurationDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === CoreVersionRequiresScoringError.name,
+      );
+
+      //when
+      const error = httpErrorMapper.httpErrorFn(new CoreVersionRequiresScoringError());
+
+      //then
+      expect(error).to.be.instanceOf(ConflictError);
+      expect(error.message).to.equal("Impossible d'activer une version CORE sans configuration de scoring");
     });
   });
 });

--- a/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { VersionNotDraftError } from '../../../../../../src/certification/configuration/domain/errors.js';
+import {
+  CoreVersionRequiresScoringError,
+  VersionNotDraftError,
+} from '../../../../../../src/certification/configuration/domain/errors.js';
 import { VERSION_STATUSES } from '../../../../../../src/certification/configuration/domain/models/Version.js';
 import { activateVersion } from '../../../../../../src/certification/configuration/domain/usecases/activate-version.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
@@ -70,12 +73,39 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
   });
 
   context('when the version is a draft', function () {
+    context('when the version is CORE and does not have scoring configurations', function () {
+      it('throws a CoreVersionRequiresScoringError', async function () {
+        const draftVersion = domainBuilder.certification.configuration
+          .versionBuilder()
+          .asDraft({ startDate: new Date('2025-01-01') })
+          .withParameters({
+            scope: SCOPES.CORE,
+            tubeIds: ['tubeA'],
+            id: 42,
+            externalCalibrationId: 7,
+            globalScoringConfiguration: null,
+            competencesScoringConfiguration: null,
+          })
+          .build();
+        versionRepository.getById.resolves(draftVersion);
+
+        const err = await catchErr(activateVersion)({
+          id: 42,
+          versionRepository,
+          calibrationRepository,
+          calibratedChallengesRepository,
+        });
+
+        expect(err).to.be.instanceOf(CoreVersionRequiresScoringError);
+      });
+    });
     context('when the calibration does not exist', function () {
       it('throws a NotFoundError', async function () {
         const draftVersion = domainBuilder.certification.configuration
           .versionBuilder()
           .asDraft({ startDate: new Date('2025-01-01') })
           .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 42, externalCalibrationId: 7 })
+          .withRealisticScoringConfigurations()
           .build();
         versionRepository.getById.resolves(draftVersion);
         calibrationRepository.find.resolves(null);
@@ -98,6 +128,7 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
         .versionBuilder()
         .asDraft({ startDate: new Date('2025-01-01') })
         .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 42, externalCalibrationId: 7 })
+        .withRealisticScoringConfigurations()
         .build();
       versionRepository.getById.resolves(draftVersion);
       versionRepository.findActiveByScope.resolves(null);
@@ -125,6 +156,7 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
         .versionBuilder()
         .asDraft({ startDate: new Date('2025-01-01') })
         .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'], id: 42, externalCalibrationId: 7 })
+        .withRealisticScoringConfigurations()
         .build();
       versionRepository.getById.resolves(draftVersion);
       versionRepository.findActiveByScope.resolves(null);
@@ -151,6 +183,7 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
           .versionBuilder()
           .asDraft({ startDate: new Date('2025-01-01') })
           .withParameters({ scope: SCOPES.CORE, tubeIds: ['rec1'], id: 42, externalCalibrationId: 7 })
+          .withRealisticScoringConfigurations()
           .build();
         const currentActiveVersion = domainBuilder.certification.configuration
           .versionBuilder()

--- a/api/tests/certification/configuration/unit/domain/usecases/save-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/save-scoring-configuration_test.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { saveScoringConfiguration } from '../../../../../../src/certification/configuration/domain/usecases/save-scoring-configuration.js';
+import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+import { catchErr } from '../../../../../tooling/test-utils/error.js';
+
+describe('Certification | Configuration | Unit | UseCase | save-scoring-configuration', function () {
+  let versionRepository;
+
+  beforeEach(function () {
+    versionRepository = {
+      getById: sinon.stub(),
+      updateScoring: sinon.stub(),
+    };
+  });
+
+  context('when the version does not exist', function () {
+    it('throws a NotFoundError', async function () {
+      // given
+      versionRepository.getById.resolves(null);
+
+      // when
+      const err = await catchErr(saveScoringConfiguration)({
+        id: 99,
+        globalScoringConfiguration: [],
+        competencesScoringConfiguration: null,
+        versionRepository,
+      });
+
+      // then
+      expect(err).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when the version exists', function () {
+    it('calls updateScoring with the right parameters', async function () {
+      // given
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({ id: 42 })
+        .build();
+      versionRepository.getById.resolves(version);
+      versionRepository.updateScoring.resolves();
+
+      const globalScoringConfiguration = [{ meshLevel: 1, bounds: { min: 0, max: 100 } }];
+      const competencesScoringConfiguration = null;
+
+      // when
+      await saveScoringConfiguration({
+        id: 42,
+        globalScoringConfiguration,
+        competencesScoringConfiguration,
+        versionRepository,
+      });
+
+      // then
+      sinon.assert.calledWithExactly(versionRepository.updateScoring, {
+        id: 42,
+        globalScoringConfiguration,
+        competencesScoringConfiguration,
+      });
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/infrastructure/serializers/framework-info-serializer_test.js
+++ b/api/tests/certification/configuration/unit/infrastructure/serializers/framework-info-serializer_test.js
@@ -87,6 +87,7 @@ describe('Certification | Configuration | Unit | Serializer | framework-info-ser
               'assessment-duration': 2,
               'maximum-assessment-length': 2,
               status: VERSION_STATUSES.ACTIVE,
+              'has-global-scoring': true,
             },
           },
           {
@@ -98,6 +99,7 @@ describe('Certification | Configuration | Unit | Serializer | framework-info-ser
               'assessment-duration': 3,
               'maximum-assessment-length': 3,
               status: VERSION_STATUSES.ARCHIVED,
+              'has-global-scoring': true,
             },
           },
           {
@@ -109,6 +111,7 @@ describe('Certification | Configuration | Unit | Serializer | framework-info-ser
               'assessment-duration': 6,
               'maximum-assessment-length': 6,
               status: VERSION_STATUSES.ACTIVE,
+              'has-global-scoring': true,
             },
           },
         ],

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-framework-info.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-framework-info.js
@@ -40,7 +40,7 @@ class FrameworkInfoBuilder {
    * @param {number} [params.maximumAssessmentLength] - defaults to 51
    * @returns {FrameworkInfoBuilder}
    */
-  withActiveVersion({ id, startDate = new Date('2026-01-01'), assessmentDuration = 31, maximumAssessmentLength = 51 }) {
+  withActiveVersion({ id, startDate = new Date('2026-01-01'), assessmentDuration = 31, maximumAssessmentLength = 51, hasScoring = true } = {}) {
     this.versionSummariesData.push({
       id,
       startDate,
@@ -48,6 +48,7 @@ class FrameworkInfoBuilder {
       assessmentDuration,
       maximumAssessmentLength,
       status: VERSION_STATUSES.ACTIVE,
+      hasScoring,
     });
     return this;
   }
@@ -69,7 +70,8 @@ class FrameworkInfoBuilder {
     expirationDate = new Date('2025-02-02'),
     assessmentDuration = 32,
     maximumAssessmentLength = 52,
-  }) {
+    hasScoring = true,
+  } = {}) {
     this.versionSummariesData.push({
       id,
       startDate,
@@ -77,6 +79,7 @@ class FrameworkInfoBuilder {
       assessmentDuration,
       maximumAssessmentLength,
       status: VERSION_STATUSES.ARCHIVED,
+      hasScoring,
     });
     return this;
   }
@@ -91,13 +94,14 @@ class FrameworkInfoBuilder {
    * @param {number} [params.maximumAssessmentLength] - defaults to 53
    * @returns {FrameworkInfoBuilder}
    */
-  withDraftVersion({ id, startDate = new Date('2027-01-01'), assessmentDuration = 33, maximumAssessmentLength = 53 }) {
+  withDraftVersion({ id, startDate = new Date('2027-01-01'), assessmentDuration = 33, maximumAssessmentLength = 53, hasScoring = false } = {}) {
     this.versionSummariesData.push({
       id,
       startDate,
       assessmentDuration,
       maximumAssessmentLength,
       status: VERSION_STATUSES.DRAFT,
+      hasScoring,
     });
     return this;
   }
@@ -129,7 +133,8 @@ class FrameworkInfoBuilder {
   insertToDB({ databaseBuilder }) {
     const frameworkInfo = this.build();
 
-    for (const versionSummary of frameworkInfo.versionSummaries) {
+    for (const [index, versionSummary] of frameworkInfo.versionSummaries.entries()) {
+      const versionSummaryData = this.versionSummariesData[index] ?? {};
       const row = databaseBuilder.factory.buildCertificationVersion({
         id: versionSummary.id,
         scope: frameworkInfo.scope,
@@ -137,8 +142,8 @@ class FrameworkInfoBuilder {
         expirationDate: versionSummary.expirationDate,
         assessmentDuration: versionSummary.assessmentDuration,
         minimumAnswersRequiredToValidateACertification: 123,
-        globalScoringConfiguration: defaultGlobalScoringConfiguration,
-        competencesScoringConfiguration: defaultCompetencesScoringConfiguration,
+        globalScoringConfiguration: versionSummaryData.hasScoring !== false ? defaultGlobalScoringConfiguration : [],
+        competencesScoringConfiguration: versionSummaryData.hasScoring !== false ? defaultCompetencesScoringConfiguration : null,
         challengesConfiguration: {
           ...defaultChallengesConfiguration,
           maximumAssessmentLength: versionSummary.maximumAssessmentLength ?? 40,
@@ -167,6 +172,7 @@ class FrameworkInfoBuilder {
           assessmentDuration: versionSummaryData.assessmentDuration,
           maximumAssessmentLength: versionSummaryData.maximumAssessmentLength,
           status: versionSummaryData.status,
+          hasGlobalScoring: versionSummaryData.hasScoring ?? true,
         }),
     );
 

--- a/api/tests/tooling/domain-builder/factory/certification/configuration/build-framework-info.js
+++ b/api/tests/tooling/domain-builder/factory/certification/configuration/build-framework-info.js
@@ -40,7 +40,13 @@ class FrameworkInfoBuilder {
    * @param {number} [params.maximumAssessmentLength] - defaults to 51
    * @returns {FrameworkInfoBuilder}
    */
-  withActiveVersion({ id, startDate = new Date('2026-01-01'), assessmentDuration = 31, maximumAssessmentLength = 51, hasScoring = true } = {}) {
+  withActiveVersion({
+    id,
+    startDate = new Date('2026-01-01'),
+    assessmentDuration = 31,
+    maximumAssessmentLength = 51,
+    hasScoring = true,
+  } = {}) {
     this.versionSummariesData.push({
       id,
       startDate,
@@ -94,7 +100,13 @@ class FrameworkInfoBuilder {
    * @param {number} [params.maximumAssessmentLength] - defaults to 53
    * @returns {FrameworkInfoBuilder}
    */
-  withDraftVersion({ id, startDate = new Date('2027-01-01'), assessmentDuration = 33, maximumAssessmentLength = 53, hasScoring = false } = {}) {
+  withDraftVersion({
+    id,
+    startDate = new Date('2027-01-01'),
+    assessmentDuration = 33,
+    maximumAssessmentLength = 53,
+    hasScoring = false,
+  } = {}) {
     this.versionSummariesData.push({
       id,
       startDate,
@@ -143,7 +155,8 @@ class FrameworkInfoBuilder {
         assessmentDuration: versionSummary.assessmentDuration,
         minimumAnswersRequiredToValidateACertification: 123,
         globalScoringConfiguration: versionSummaryData.hasScoring !== false ? defaultGlobalScoringConfiguration : [],
-        competencesScoringConfiguration: versionSummaryData.hasScoring !== false ? defaultCompetencesScoringConfiguration : null,
+        competencesScoringConfiguration:
+          versionSummaryData.hasScoring !== false ? defaultCompetencesScoringConfiguration : null,
         challengesConfiguration: {
           ...defaultChallengesConfiguration,
           maximumAssessmentLength: versionSummary.maximumAssessmentLength ?? 40,


### PR DESCRIPTION
## ☀️ Problème

La création d'une nouvelle version de référentiel était gérée manuellement en interne. Pour gagner en autonomie et en efficacité, on featurise ce processus directement depuis l'espace Admin.
Dans le cas particulier de la création d'une version pour un scope Pix+, on veut permettre une activation en deux temps, où le scoring ne viendrait qu'après. Il reste cependant possible d'activer la Pix+ avec sa configuration de scoring directement, comme pour cœur. 

## ⛱️ Proposition

Plusieurs changements fonctionnels sont nécessaires pour permettre ce workflow alternatif : 
- Ajout du bouton “Activer la version” à l'étape 3 (Disabled jusqu'à la vérification d’une calibration)
- À l'étape 4, le bouton “Activer la version” devient un bouton “Activer le scoring”  si la version encore déjà active
	- Comme le bouton “Activer la version”, ce bouton déclenche une pop-in de confirmation
	- L’activation du scoring déclenche également les jobs de scoring des certification déjà passées entre l’activation de la version et de son scoring
- Sur la page avec le tableau des versions, si une version active n’a pas de scoring (par maille), alors le bouton “éditer” est actif, et il dirige directement à l'étape 4 pour une activation éventuelle du scoring. Il n'est pas possible de créer une nouvelle version tant que la version active n'a pas de scoring.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
