### PR TITLE
[FEATURE]  Afficher la date de certificabilité dans la page `Élèves` pour les organisations SCO isManagingStudents  (PIX-22712)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -239,7 +239,6 @@ export default class ScoList extends Component {
               @openEditNameModal={{this.openEditNameModal}}
               @canEditLearnerName={{this.currentUser.canEditLearnerName}}
               @onToggleStudent={{fn withFunction (fn toggleStudent student) stopPropagation}}
-              @hideCertifiableDate={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
             />
           </:columns>
         </PixTable>

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -8,7 +8,7 @@ import { not } from 'ember-truth-helpers';
 
 import { CONNECTION_TYPES } from '../../helpers/connection-types';
 import { USER_ACCOUNT_BLOCKING_TYPES } from '../../helpers/user-account-blocking-types';
-import Cell from '../certificability/cell';
+import CertificabilityCell from '../certificability/cell';
 import Tooltip from '../certificability/tooltip';
 import IconTrigger from '../dropdown/icon-trigger';
 import Item from '../dropdown/item';
@@ -126,11 +126,13 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
       />
     </:header>
     <:cell>
-      <Cell
-        @hideCertifiableDate={{@hideCertifiableDate}}
-        @certifiableAt={{@student.certifiableAt}}
-        @isCertifiable={{@student.isCertifiable}}
-      />
+      <div class="organization-participant__align-element organization-participant__align-element--column">
+        <CertificabilityCell
+          @hideCertifiableDate={{false}}
+          @certifiableAt={{@student.certifiableAt}}
+          @isCertifiable={{@student.isCertifiable}}
+        />
+      </div>
     </:cell>
   </PixTableColumn>
   <PixTableColumn @context={{@context}}>

--- a/orga/app/styles/pages/authenticated/organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/list.scss
@@ -15,6 +15,7 @@ $margin-right: 32px;
     justify-content: center;
 
     &--column {
+      display: flex;
       flex-direction:column;
       align-items: center;
     }

--- a/orga/tests/integration/components/sco-organization-participant/table-row-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/table-row-test.gjs
@@ -9,7 +9,7 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 module('Integration | Component | ScoOrganizationParticipant::TableRow', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when hideCertifiableDate is true', function () {
+  module('when isCertifiable is null', function () {
     test('it should not display certifiableAt date', async function (assert) {
       // given
       const certifiableDate = '10/10/2023';
@@ -21,10 +21,9 @@ module('Integration | Component | ScoOrganizationParticipant::TableRow', functio
         division: '3A',
         authenticationMethods: [],
         participationCount: 1,
-        isCertifiable: true,
-        certifiableAt: new Date(certifiableDate),
+        isCertifiable: null,
+        certifiableAt: null,
       };
-      const hasComputeOrganizationLearnerCertificabilityEnabled = true;
 
       // when
       const screen = await render(
@@ -36,18 +35,58 @@ module('Integration | Component | ScoOrganizationParticipant::TableRow', functio
             @openAuthenticationMethodModal={{noop}}
             @onToggleStudent={{noop}}
             @onClickLearner={{noop}}
-            @hideCertifiableDate={{hasComputeOrganizationLearnerCertificabilityEnabled}}
           />
         </template>,
       );
 
       // then
       assert.dom(screen.queryByText(certifiableDate)).doesNotExist();
+      assert
+        .dom(screen.queryByText(t('pages.sco-organization-participants.table.column.is-certifiable.not-available')))
+        .exists();
     });
   });
 
-  module('when hasComputeOrganizationLearnerCertificabilityEnabled is false', function () {
-    test('it display certifiableAt date', async function (assert) {
+  module('when isCertifiable is false', function () {
+    test('it should display certifiableAt date', async function (assert) {
+      // given
+      const certifiableDate = '10/10/2023';
+      const noop = sinon.stub();
+      const student = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        birthdate: '2020/01/01',
+        division: '3A',
+        authenticationMethods: [],
+        participationCount: 1,
+        isCertifiable: false,
+        certifiableAt: new Date(certifiableDate),
+      };
+
+      // when
+      const screen = await render(
+        <template>
+          <ScoOrganizationParticipantTableRow
+            @showCheckbox={{noop}}
+            @student={{student}}
+            @isStudentSelected={{noop}}
+            @openAuthenticationMethodModal={{noop}}
+            @onToggleStudent={{noop}}
+            @onClickLearner={{noop}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(certifiableDate)).exists();
+      assert
+        .dom(screen.getByText(t('pages.sco-organization-participants.table.column.is-certifiable.non-eligible')))
+        .exists();
+    });
+  });
+
+  module('when isCertifiable is true', function () {
+    test('it should display certifiableAt date', async function (assert) {
       // given
       const certifiableDate = '10/10/2023';
       const noop = sinon.stub();
@@ -61,7 +100,6 @@ module('Integration | Component | ScoOrganizationParticipant::TableRow', functio
         isCertifiable: true,
         certifiableAt: new Date(certifiableDate),
       };
-      const hasComputeOrganizationLearnerCertificabilityEnabled = false;
 
       // when
       const screen = await render(
@@ -73,13 +111,15 @@ module('Integration | Component | ScoOrganizationParticipant::TableRow', functio
             @openAuthenticationMethodModal={{noop}}
             @onToggleStudent={{noop}}
             @onClickLearner={{noop}}
-            @hideCertifiableDate={{hasComputeOrganizationLearnerCertificabilityEnabled}}
           />
         </template>,
       );
 
       // then
       assert.dom(screen.getByText(certifiableDate)).exists();
+      assert
+        .dom(screen.getByText(t('pages.sco-organization-participants.table.column.is-certifiable.eligible')))
+        .exists();
     });
   });
 

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -376,7 +376,7 @@
       "aria-label": "Erläuterung zur Zertifizierbarkeit",
       "content": "Zertifizierbarkeit bedeutet, dass der/die Teilnehmer/in in mindestens fünf verschiedenen Kompetenzen das Niveau 1 erreicht hat.",
       "from-collect-notice": "Die Informationen stammen aus den von ihm durchgeführten Kampagnen zum Sammeln von Profilen. Wenn der Teilnehmer sein Profil bereits versendet hat, werden das Datum sowie der Status der letzten Versendung angezeigt.",
-      "from-compute-certificability": "Dieser Status wird automatisch (alle 24 Stunden) und bei Kampagnen zum Sammeln von Profilen aktualisiert."
+      "from-compute-certificability": "Dieser Status wird automatisch am Tag nach jeder Anmeldung des Teilnehmers und bei Profilerhebungen aktualisiert."
     },
     "cover-rate-gauge": {
       "label": "Bei dieser Kampagne erreichten Ihre Teilnehmer ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel}."

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -374,9 +374,9 @@
     },
     "certificability-tooltip": {
       "aria-label": "How to know if a participant is eligible for certification and what does it mean?",
-      "content": "To be eligible for certification, the participant must have achieved level 1 in at least 5 different competences.",
+      "content": "To be eligible for certification, the participant must have achieved level 1 in at least 5 competences.",
       "from-collect-notice": "their Pix profile needs to be submitted through a profile collection campaign. If the participant has already submitted their profile, the date and status of the last submission are displayed.",
-      "from-compute-certificability": "This status is updated both automatically (every 24 hours) and during profile collection campaigns."
+      "from-compute-certificability": "This status is automatically updated the day after each participant login and during profile collections."
     },
     "cover-rate-gauge": {
       "label": "On this campaign, your participants have achieved a level of {reachedLevel} out of a maximum attainable level of {maxLevel}."

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -374,9 +374,9 @@
     },
     "certificability-tooltip": {
       "aria-label": "Explicación de la certificabilidad",
-      "content": "La certificabilidad significa que el participante ha alcanzado el nivel 1 en al menos 5 competencias diferentes.",
+      "content": "La certificabilidad significa que el participante ha alcanzado el nivel 1 en al menos 5 competencias.",
       "from-collect-notice": "La información procede de las campañas de recogida de perfiles realizadas por el participante. Si el participante ya ha enviado su perfil, se muestran la fecha y el estado del último envío.",
-      "from-compute-certificability": "Este estado se actualiza automáticamente (cada 24 horas) y durante las campañas de recogida de perfiles."
+      "from-compute-certificability": "Este estado se actualiza automáticamente al día siguiente de cada conexión del participante y durante las recopilaciones de perfil."
     },
     "cover-rate-gauge": {
       "label": "En esta campaña, tus participantes alcanzaron un nivel de {reachedLevel} de un nivel máximo alcanzable de {maxLevel}."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -374,9 +374,9 @@
     },
     "certificability-tooltip": {
       "aria-label": "Explication sur la certificabilité",
-      "content": "La certificabilité signifie que le participant a atteint le niveau 1 dans au moins 5 compétences différentes.",
+      "content": "La certificabilité signifie que le participant a atteint le niveau 1 dans au moins 5 compétences.",
       "from-collect-notice": "L'information provient des campagnes de collecte de profil réalisées par ce dernier. Si le participant a déjà envoyé son profil, on affiche la date ainsi que le statut du dernier envoi.",
-      "from-compute-certificability": "Ce statut est mis à jour automatiquement (toutes les 24h) et lors des campagnes de collectes de profils."
+      "from-compute-certificability": "Ce statut est mis à jour automatiquement le lendemain de chaque connexion du participant et lors des collectes de profil."
     },
     "cover-rate-gauge": {
       "label": "Sur cette campagne, vos participants ont obtenu un niveau de {reachedLevel} sur un niveau maximum atteignable de {maxLevel}."

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -376,7 +376,7 @@
       "aria-label": "Spiegazione della certificabilità",
       "content": "La certificabilità significa che il partecipante ha raggiunto il livello 1 in almeno 5 competenze diverse.",
       "from-collect-notice": "Le informazioni provengono dalle campagne di raccolta dei profili effettuate dal partecipante. Se il partecipante ha già inviato il proprio profilo, vengono visualizzati la data e lo stato dell'ultimo invio.",
-      "from-compute-certificability": "Questo stato viene aggiornato automaticamente (ogni 24 ore) e durante le campagne di raccolta dei profili."
+      "from-compute-certificability": "Questo stato viene aggiornato automaticamente il giorno successivo a ogni accesso del partecipante e durante le raccolte dei profili."
     },
     "cover-rate-gauge": {
       "label": "In questa campagna, i partecipanti hanno raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}."

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -376,7 +376,7 @@
       "aria-label": "Uitleg over certificeerbaarheid",
       "content": "Certificeerbaarheid betekent dat de deelnemer niveau 1 heeft bereikt in ten minste 5 verschillende vaardigheden.",
       "from-collect-notice": "De informatie is afkomstig van de profielverzamelingscampagnes die door de deelnemer zijn uitgevoerd. Als de deelnemer zijn profiel al heeft ingestuurd, worden de datum en status van de laatste verzending weergegeven.",
-      "from-compute-certificability": "Deze status wordt automatisch bijgewerkt (elke 24 uur) en tijdens profielverzamelingscampagnes."
+      "from-compute-certificability": "Deze status wordt automatisch bijgewerkt de dag na elke aanmelding van de deelnemer en tijdens profielverzamelingen."
     },
     "cover-rate-gauge": {
       "label": "Op deze campagne hebben je deelnemers een niveau bereikt van {reachedLevel} uit een maximaal haalbaar niveau van {maxLevel}."


### PR DESCRIPTION
## ☀️ Problème
La remontée auto de la certificabilité a lieu le soir de chaque connexion d’un(e) élève, ce fonctionnement crée des incompréhensions si un(e) élève devient certifiable au cours d’un parcours après le premier jour de test, sur le reste de son access token.

## ⛱️ Proposition
- Revoir le wording de la tooltip
- Afficher la date certificabilité 

## 🏊 Pour tester
- Se connecter à Pix Orga avec le compte `admin-orga@example.net`
- Aller sur la page `Élèves` de l'organisation `SCO SIECLE`
- Vérifier le texte de la tooltip de la colonne `Certificabilité`
- Voir qu'une date apparaît en dessous de l'icône `Non Certifiable`/`Certifiable`