### PR TITLE
[BUGFIX] Supprimer les valeurs dupliquées du champ proposals.input dans les QROCM (PIX-24085)

### DIFF
--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/CYMFA_IND.json
@@ -807,10 +807,10 @@
                   },
                   {
                     "type": "select",
-                    "input": "catégorie",
+                    "input": "catégorie2",
                     "display": "inline",
                     "placeholder": "- Sélectionner - ",
-                    "ariaLabel": "catégorie",
+                    "ariaLabel": "catégorie2",
                     "tolerances": [],
                     "options": [
                       {
@@ -840,10 +840,10 @@
                   },
                   {
                     "type": "select",
-                    "input": "catégorie",
+                    "input": "catégorie3",
                     "display": "inline",
                     "placeholder": "- Sélectionner - ",
-                    "ariaLabel": "catégorie",
+                    "ariaLabel": "catégorie3",
                     "tolerances": [],
                     "options": [
                       {
@@ -873,10 +873,10 @@
                   },
                   {
                     "type": "select",
-                    "input": "catégorie",
+                    "input": "catégorie4",
                     "display": "inline",
                     "placeholder": "- Sélectionner - ",
-                    "ariaLabel": "catégorie",
+                    "ariaLabel": "catégorie4",
                     "tolerances": [],
                     "options": [
                       {
@@ -906,10 +906,10 @@
                   },
                   {
                     "type": "select",
-                    "input": "catégorie",
+                    "input": "catégorie5",
                     "display": "inline",
                     "placeholder": "- Sélectionner - ",
-                    "ariaLabel": "catégorie",
+                    "ariaLabel": "catégorie5",
                     "tolerances": [],
                     "options": [
                       {
@@ -939,10 +939,10 @@
                   },
                   {
                     "type": "select",
-                    "input": "catégorie",
+                    "input": "catégorie6",
                     "display": "inline",
                     "placeholder": "- Sélectionner - ",
-                    "ariaLabel": "catégorie",
+                    "ariaLabel": "catégorie6",
                     "tolerances": [],
                     "options": [
                       {

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava.json
@@ -1054,7 +1054,7 @@
                 "proposals": [
                   {
                     "type": "select",
-                    "input": "classementetape6",
+                    "input": "classementetape1",
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava_pro.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/IAGenFonction_Ava_pro.json
@@ -1054,7 +1054,7 @@
                 "proposals": [
                   {
                     "type": "select",
-                    "input": "classementetape6",
+                    "input": "classementetape1",
                     "display": "inline",
                     "placeholder": "- Sélectionner -",
                     "ariaLabel": "- Sélectionner -",


### PR DESCRIPTION
## ☀️ Problème

On nous a remonté un problème dans un module, dans un QROCM avec plusieurs select:
- On sélectionne une option dans le 1er select
- Puis on choisit une option pour le 2e select
=> la sélection dans le 1er select disparaît !

## ⛱️ Proposition

Le problème vient du champ "input" dans les Proposals des QROCM : les selects avaient tous la même valeur renseignée pour le champ "input". Il faut donc modifier la valeur pour certains select pour supprimer le problème.
=> 3 modules ont été mis à jour 

## 🧴 Remarques

- Dans un autre ticket, ajouter une règle de validation sur ce champ `input` des proposals

## 🏊 Pour tester

- Ouvrir le module [Authentification Multifacteur](https://app-pr17333.review.pix.fr/modules/9c41e513/mfa-authentification-multifacteur/passage?grainIndex=15)
- Dans le QROCM avec les facteurs d'authentification, dans le 1er Select, choisir une option au hasard
- Dans le 2ème select, choisir une option au hasard, et ainsi de suite ...
- Constater que les options des Select ne sont pas modifiées ! Youhou

