### PR TITLE
[FEATURE] Pouvoir modifier la categorie d'une organisation côté API (PIX-23564)

### DIFF
--- a/api/src/organizational-entities/application/http-error-mapper-configuration.js
+++ b/api/src/organizational-entities/application/http-error-mapper-configuration.js
@@ -13,6 +13,7 @@ import {
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
   ParentOrganizationNotInNetworkError,
+  StructureCategoryNotFound,
   StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachCertificationCenterToOrganization,
@@ -80,6 +81,10 @@ const organizationalEntitiesDomainErrorMappingConfiguration = [
   {
     name: CountryNotFoundError.name,
     httpErrorFn: (error) => new NotFoundError(error.message, error.code, error.meta),
+  },
+  {
+    name: StructureCategoryNotFound.name,
+    httpErrorFn: (error) => new UnprocessableEntityError(error.message, error.code, error.meta),
   },
   {
     name: StructureNotFoundError.name,

--- a/api/src/organizational-entities/domain/errors.js
+++ b/api/src/organizational-entities/domain/errors.js
@@ -142,6 +142,14 @@ class ParentOrganizationNotInNetworkError extends DomainError {
   }
 }
 
+class StructureCategoryNotFound extends DomainError {
+  constructor({ code = 'STRUCTURE_CATEGORY_NOT_FOUND', message = 'Structure category does not exist', meta } = {}) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class StructureNotFoundError extends DomainError {
   constructor({ code = 'STRUCTURE_NOT_FOUND', message = 'Structure not found', meta } = {}) {
     super(message);
@@ -176,6 +184,7 @@ export {
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
   ParentOrganizationNotInNetworkError,
+  StructureCategoryNotFound,
   StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachCertificationCenterToOrganization,

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -280,6 +280,7 @@ class OrganizationForAdmin {
     if (newOrganization.organizationLearnerType.id) {
       this.organizationLearnerType = newOrganization.organizationLearnerType;
     }
+    if (newOrganization.categoryId) this.categoryId = newOrganization.categoryId;
   }
 
   setCountryName(countryName) {

--- a/api/src/organizational-entities/domain/services/organization-verification.service.js
+++ b/api/src/organizational-entities/domain/services/organization-verification.service.js
@@ -1,5 +1,10 @@
 import { logger } from '../../../shared/infrastructure/utils/logger.js';
-import { AdministrationTeamNotFound, CountryNotFoundError, OrganizationLearnerTypeNotFound } from '../errors.js';
+import {
+  AdministrationTeamNotFound,
+  CountryNotFoundError,
+  OrganizationLearnerTypeNotFound,
+  StructureCategoryNotFound,
+} from '../errors.js';
 
 const checkCountryExists = async (countryCode, countryRepository) => {
   try {
@@ -38,4 +43,22 @@ async function checkAdministrationTeamExists(administrationTeamId, administratio
   }
 }
 
-export { checkAdministrationTeamExists, checkCountryExists, checkOrganizationLearnerTypeExists };
+async function checkStructureCategoryExists(structureCategoryId, structureCategoryRepository) {
+  const existingStructureCategory = await structureCategoryRepository.findById(structureCategoryId);
+
+  if (!existingStructureCategory) {
+    throw new StructureCategoryNotFound({
+      message: `Structure category not found for id ${structureCategoryId}`,
+      meta: {
+        structureCategoryId,
+      },
+    });
+  }
+}
+
+export {
+  checkAdministrationTeamExists,
+  checkCountryExists,
+  checkOrganizationLearnerTypeExists,
+  checkStructureCategoryExists,
+};

--- a/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organization-information.usecase.js
@@ -9,6 +9,7 @@ const updateOrganizationInformation = withTransaction(async function ({
   organizationLearnerTypeRepository,
   organizationVerificationService,
   countryRepository,
+  structureCategoryRepository,
   learnersApi,
 }) {
   const existingOrganization = await organizationForAdminRepository.get({
@@ -33,6 +34,13 @@ const updateOrganizationInformation = withTransaction(async function ({
 
   if (organization.countryCode) {
     await organizationVerificationService.checkCountryExists(organization.countryCode, countryRepository);
+  }
+
+  if (organization.categoryId) {
+    await organizationVerificationService.checkStructureCategoryExists(
+      organization.categoryId,
+      structureCategoryRepository,
+    );
   }
 
   existingOrganization.updateWithDataProtectionOfficerAndTags(

--- a/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/organization-for-admin.repository.js
@@ -4,7 +4,9 @@ import { ORGANIZATION_FEATURE } from '../../../shared/constants.js';
 import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
 import { MissingAttributesError, NotFoundError } from '../../../shared/domain/errors.js';
 import { fetchPage } from '../../../shared/infrastructure/utils/knex-utils.js';
+import { logger } from '../../../shared/infrastructure/utils/logger.js';
 import * as organizationApi from '../../../team/application/api/organization.js';
+import { StructureNotFoundError } from '../../domain/errors.js';
 import { AttachedOrganization } from '../../domain/models/AttachedOrganization.js';
 import { OrganizationForAdmin } from '../../domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../domain/models/OrganizationLearnerType.js';
@@ -311,6 +313,8 @@ const update = async function ({ organization }) {
   await _addTags(knexConn, organization.tagsToAdd);
   await _removeTags(knexConn, organization.tagsToRemove);
 
+  await _updateStructureCategory(knexConn, organization.id, organization.categoryId);
+
   await knexConn(ORGANIZATIONS_TABLE_NAME)
     .update({
       ...organizationRawData,
@@ -550,6 +554,31 @@ async function _removeTags(knexConn, organizationTags) {
       organizationTags.map((organizationTag) => [organizationTag.organizationId, organizationTag.tagId]),
     )
     .delete();
+}
+
+async function _updateStructureCategory(knexConn, organizationId, categoryId) {
+  if (!categoryId) return;
+
+  const structure = await knexConn('fct_structures')
+    .join('structures', 'structures.id', 'fct_structures.structure_id')
+    .where({ organization_id: organizationId })
+    .select({ id: 'structures.id', currentCategoryId: 'structures.category_id' })
+    .first();
+
+  if (!structure) {
+    logger.error({
+      event: 'Not_found_structure',
+      message: `Not found structure for organization ${organizationId}`,
+    });
+    throw new StructureNotFoundError({
+      message: `Structure not found for organization ${organizationId}`,
+      meta: { organizationId },
+    });
+  }
+
+  if (structure.currentCategoryId === categoryId) return;
+
+  await knexConn('structures').where({ id: structure.id }).update({ category_id: categoryId, updated_at: new Date() });
 }
 
 function _toDomain(rawOrganization) {

--- a/api/src/organizational-entities/infrastructure/repositories/structure-category-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/structure-category-repository.js
@@ -12,6 +12,22 @@ const findAll = async function () {
   return structureCategories.map(_toDomain);
 };
 
+/**
+ * @function
+ * @param {number} id
+ * @returns {Promise<StructureCategory|null>}
+ */
+const findById = async function (id) {
+  const knexConn = DomainTransaction.getConnection();
+  const structureCategory = await knexConn.select('id', 'label').from('structure_categories').where({ id }).first();
+
+  if (!structureCategory) {
+    return null;
+  }
+
+  return _toDomain(structureCategory);
+};
+
 const _toDomain = function (structureCategoryDTO) {
   return new StructureCategory({
     id: structureCategoryDTO.id,
@@ -19,4 +35,4 @@ const _toDomain = function (structureCategoryDTO) {
   });
 };
 
-export { findAll };
+export { findAll, findById };

--- a/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
+++ b/api/src/organizational-entities/infrastructure/serializers/jsonapi/organizations-administration/organization-for-admin.serializer.js
@@ -165,6 +165,7 @@ const deserialize = function (json) {
       id: attributes['organization-learner-type-id'],
       name: attributes['organization-learner-type-name'],
     }),
+    categoryId: attributes['category-id'] ? parseInt(attributes['category-id']) : null,
   });
   return organization;
 };

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -891,7 +891,7 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
   });
 
   describe('PATCH /api/admin/organizations/{organizationId}', function () {
-    it('should return the updated organization and status code 200', async function () {
+    it('should return the updated category organization and status code 200', async function () {
       // given
       const administrationTeamId = databaseBuilder.factory.buildAdministrationTeam().id;
 
@@ -947,6 +947,38 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data['external-id']).not.to.equal(organization.externalId);
+    });
+
+    it('should return organization updated with status 200', async function () {
+      // given
+      const structureCategory = databaseBuilder.factory.buildStructureCategory({ label: 'Nouvelle catégorie' });
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({});
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PATCH',
+        url: `/api/admin/organizations/${organization.id}`,
+        payload: {
+          data: {
+            type: 'organizations',
+            id: organization.id,
+            attributes: {
+              'administration-team-id': organization.administrationTeamId,
+              'category-id': structureCategory.id,
+            },
+          },
+        },
+        headers: generateAuthenticatedUserRequestHeaders({
+          userId: superAdmin.id,
+        }),
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.attributes['category-id']).to.equal(structureCategory.id);
     });
   });
 

--- a/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
+++ b/api/tests/organizational-entities/integration/domain/services/organization-verification.service.test.js
@@ -5,10 +5,12 @@ import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
+  StructureCategoryNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import * as organizationVerificationService from '../../../../../src/organizational-entities/domain/services/organization-verification.service.js';
 import * as administrationTeamRepository from '../../../../../src/organizational-entities/infrastructure/repositories/administration-team-repository.js';
 import * as organizationLearnerTypeRepository from '../../../../../src/organizational-entities/infrastructure/repositories/organization-learner-type-repository.js';
+import * as structureCategoryRepository from '../../../../../src/organizational-entities/infrastructure/repositories/structure-category-repository.js';
 import * as countryRepository from '../../../../../src/shared/infrastructure/repositories/country-repository.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { catchErr } from '../../../../tooling/test-utils/error.js';
@@ -132,6 +134,47 @@ describe('Integration | Organizational Entities | Domain | Services | organizati
           new AdministrationTeamNotFound({
             meta: {
               administrationTeamId: unknownAdministrationTeamId,
+            },
+          }),
+        );
+      });
+    });
+  });
+
+  describe('#checkStructureCategoryExists', function () {
+    describe('when the structure category exists', function () {
+      it('does not throw an error', async function () {
+        // given
+        const structureCategory = databaseBuilder.factory.buildStructureCategory();
+        await databaseBuilder.commit();
+
+        // then
+        await expect(
+          organizationVerificationService.checkStructureCategoryExists(
+            structureCategory.id,
+            structureCategoryRepository,
+          ),
+        ).not.to.be.rejected;
+      });
+    });
+
+    describe('when the structure category does not exist', function () {
+      it('throws an error', async function () {
+        // given
+        const unknownStructureCategoryId = 99000;
+
+        // when
+        const error = await catchErr(organizationVerificationService.checkStructureCategoryExists)(
+          unknownStructureCategoryId,
+          structureCategoryRepository,
+        );
+
+        // then
+        expect(error).to.deepEqualInstance(
+          new StructureCategoryNotFound({
+            message: `Structure category not found for id ${unknownStructureCategoryId}`,
+            meta: {
+              structureCategoryId: unknownStructureCategoryId,
             },
           }),
         );

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organization-information.usecase_test.js
@@ -4,6 +4,7 @@ import {
   AdministrationTeamNotFound,
   CountryNotFoundError,
   OrganizationLearnerTypeNotFound,
+  StructureCategoryNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
@@ -233,6 +234,95 @@ describe('Integration | Organizational Entities | Domain | UseCases | update-org
 
       // then
       expect(response.countryCode).equal(initialOrganization.countryCode);
+    });
+  });
+
+  context('when a structure category is given', function () {
+    it('updates the category of the organization structure', async function () {
+      // given
+      const newStructureCategory = databaseBuilder.factory.buildStructureCategory({ label: 'Nouvelle catégorie' });
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({});
+
+      await databaseBuilder.commit();
+
+      const organizationNewInformation = domainBuilder.buildOrganizationForAdmin({
+        id: organization.id,
+        administrationTeamId: organization.administrationTeamId,
+        categoryId: newStructureCategory.id,
+        organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
+          id: organization.organizationLearnerTypeId,
+        }),
+      });
+
+      // when
+      const updatedOrganization = await usecases.updateOrganizationInformation({
+        userId: adminUserId,
+        organization: organizationNewInformation,
+      });
+
+      // then
+      expect(updatedOrganization.categoryId).to.equal(newStructureCategory.id);
+      expect(updatedOrganization.categoryLabel).to.equal(newStructureCategory.label);
+    });
+
+    context('when the structure category does not exist', function () {
+      it('throws a StructureCategoryNotFound error', async function () {
+        // given
+        const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({});
+
+        await databaseBuilder.commit();
+
+        const organizationNewInformation = domainBuilder.buildOrganizationForAdmin({
+          id: organization.id,
+          administrationTeamId: organization.administrationTeamId,
+          categoryId: 123456,
+          organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
+            id: organization.organizationLearnerTypeId,
+          }),
+        });
+
+        // when
+        const error = await catchErr(usecases.updateOrganizationInformation)({
+          userId: adminUserId,
+          organization: organizationNewInformation,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(StructureCategoryNotFound);
+        expect(error.message).to.equal('Structure category not found for id 123456');
+        expect(error.meta.structureCategoryId).to.equal(123456);
+      });
+    });
+  });
+
+  context('when no structure category is given', function () {
+    it('does not reset the category of the organization', async function () {
+      // given
+      const structureCategory = databaseBuilder.factory.buildStructureCategory({ label: 'Catégorie initiale' });
+      const organization = databaseBuilder.factory.buildOrganization();
+      const structure = databaseBuilder.factory.buildStructure({ categoryId: structureCategory.id });
+      databaseBuilder.factory.buildFactStructure({ structureId: structure.id, organizationId: organization.id });
+
+      await databaseBuilder.commit();
+
+      const organizationNewInformation = domainBuilder.buildOrganizationForAdmin({
+        id: organization.id,
+        administrationTeamId: organization.administrationTeamId,
+        categoryId: null,
+        organizationLearnerType: domainBuilder.acquisition.buildOrganizationLearnerType({
+          id: organization.organizationLearnerTypeId,
+        }),
+      });
+
+      // when
+      const updatedOrganization = await usecases.updateOrganizationInformation({
+        userId: adminUserId,
+        organization: organizationNewInformation,
+      });
+
+      // then
+      expect(updatedOrganization.categoryId).to.equal(structureCategory.id);
+      expect(updatedOrganization.categoryLabel).to.equal(structureCategory.label);
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/organization-for-admin.repository.test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import _ from 'lodash';
 import sinon from 'sinon';
 
+import { StructureNotFoundError } from '../../../../../src/organizational-entities/domain/errors.js';
 import { AttachedOrganization } from '../../../../../src/organizational-entities/domain/models/AttachedOrganization.js';
 import { OrganizationForAdmin } from '../../../../../src/organizational-entities/domain/models/OrganizationForAdmin.js';
 import { OrganizationLearnerType } from '../../../../../src/organizational-entities/domain/models/OrganizationLearnerType.js';
@@ -1367,6 +1368,102 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
       expect(updatedOrganization.updatedAt).to.deep.equal(new Date('2022-02-02'));
     });
 
+    it('updates the category of the organization structure', async function () {
+      // given
+      const categoryId = databaseBuilder.factory.buildStructureCategory({ label: 'Nouvelle catégorie' }).id;
+      const { organization, structure } = databaseBuilder.factory.buildOrganizationWithStructure({});
+      await databaseBuilder.commit();
+      const organizationForAdmin = new OrganizationForAdmin({
+        ...organization,
+        categoryId,
+        organizationLearnerType: domainOrganizationLearnerType,
+      });
+
+      // when
+      await organizationForAdminRepository.update({ organization: organizationForAdmin });
+
+      // then
+      const updatedStructure = await knex('structures').where({ id: structure.id }).first();
+      expect(updatedStructure.category_id).to.equal(categoryId);
+    });
+
+    it('does not update the structure of another organization', async function () {
+      // given
+      const categoryId = databaseBuilder.factory.buildStructureCategory({ label: 'Nouvelle catégorie' }).id;
+      const { organization } = databaseBuilder.factory.buildOrganizationWithStructure({});
+      const { structure: otherStructure } = databaseBuilder.factory.buildOrganizationWithStructure({});
+      await databaseBuilder.commit();
+      const organizationForAdmin = new OrganizationForAdmin({
+        ...organization,
+        categoryId,
+        organizationLearnerType: domainOrganizationLearnerType,
+      });
+
+      // when
+      await organizationForAdminRepository.update({ organization: organizationForAdmin });
+
+      // then
+      const untouchedStructure = await knex('structures').where({ id: otherStructure.id }).first();
+      expect(untouchedStructure.category_id).to.be.null;
+    });
+
+    it('does not clear the category when no category is given', async function () {
+      // given
+      const { organizationId, structureId, categoryId, structureUpdatedAt } =
+        _buildOrganizationWithCategorizedStructure();
+      await databaseBuilder.commit();
+      const organizationForAdmin = new OrganizationForAdmin({
+        id: organizationId,
+        organizationLearnerType: domainOrganizationLearnerType,
+      });
+
+      // when
+      await organizationForAdminRepository.update({ organization: organizationForAdmin });
+
+      // then
+      const untouchedStructure = await knex('structures').where({ id: structureId }).first();
+      expect(untouchedStructure.category_id).to.equal(categoryId);
+      expect(untouchedStructure.updated_at).to.deep.equal(structureUpdatedAt);
+    });
+
+    it('does not write the structure when the category is unchanged', async function () {
+      // given
+      const { organizationId, structureId, categoryId, structureUpdatedAt } =
+        _buildOrganizationWithCategorizedStructure();
+      await databaseBuilder.commit();
+      const organizationForAdmin = new OrganizationForAdmin({
+        id: organizationId,
+        categoryId,
+        organizationLearnerType: domainOrganizationLearnerType,
+      });
+
+      // when
+      await organizationForAdminRepository.update({ organization: organizationForAdmin });
+
+      // then
+      const untouchedStructure = await knex('structures').where({ id: structureId }).first();
+      expect(untouchedStructure.updated_at).to.deep.equal(structureUpdatedAt);
+    });
+
+    it('throws a StructureNotFoundError when the organization has no structure', async function () {
+      // given
+      const categoryId = databaseBuilder.factory.buildStructureCategory({ label: 'Nouvelle catégorie' }).id;
+      const organization = databaseBuilder.factory.buildOrganization();
+      await databaseBuilder.commit();
+      const organizationForAdmin = new OrganizationForAdmin({
+        ...organization,
+        categoryId,
+        organizationLearnerType: domainOrganizationLearnerType,
+      });
+
+      // when
+      const error = await catchErr(organizationForAdminRepository.update)({ organization: organizationForAdmin });
+
+      // then
+      expect(error).to.be.instanceOf(StructureNotFoundError);
+      expect(error.meta.organizationId).to.equal(organization.id);
+    });
+
     describe('#features', function () {
       it('should enable feature', async function () {
         // given
@@ -2032,3 +2129,13 @@ describe('Integration | Organizational Entities | Infrastructure | Repository | 
     });
   });
 });
+
+function _buildOrganizationWithCategorizedStructure() {
+  const structureUpdatedAt = new Date('2020-01-01');
+  const categoryId = databaseBuilder.factory.buildStructureCategory({ label: 'Catégorie initiale' }).id;
+  const organization = databaseBuilder.factory.buildOrganization();
+  const structure = databaseBuilder.factory.buildStructure({ categoryId, updatedAt: structureUpdatedAt });
+  databaseBuilder.factory.buildFactStructure({ structureId: structure.id, organizationId: organization.id });
+
+  return { organizationId: organization.id, structureId: structure.id, categoryId, structureUpdatedAt };
+}

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/structure-category-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/structure-category-repository_test.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 
-import { findAll } from '../../../../../src/organizational-entities/infrastructure/repositories/structure-category-repository.js';
+import {
+  findAll,
+  findById,
+} from '../../../../../src/organizational-entities/infrastructure/repositories/structure-category-repository.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
 
@@ -28,6 +31,29 @@ describe('Integration | Repository | structure-category-repository', function ()
 
       // then
       expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('#findById', function () {
+    it('should return the structure category matching the given id', async function () {
+      // given
+      const structureCategory = databaseBuilder.factory.buildStructureCategory({ id: 7, label: 'Lycée' });
+      databaseBuilder.factory.buildStructureCategory({ id: 1, label: 'Pro' });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await findById(structureCategory.id);
+
+      // then
+      expect(result).to.deep.equal(domainBuilder.buildStructureCategory(structureCategory));
+    });
+
+    it('should return null if there is no structure category matching the given id', async function () {
+      // when
+      const result = await findById(123);
+
+      // then
+      expect(result).to.be.null;
     });
   });
 });

--- a/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
+++ b/api/tests/organizational-entities/unit/application/http-error-mapper-configuration_test.js
@@ -6,6 +6,7 @@ import {
   CountryNotFoundError,
   NetworkAlreadyExistError,
   ParentOrganizationNotInNetworkError,
+  StructureCategoryNotFound,
   StructureNotFoundError,
   TagNotFoundError,
   UnableToAttachCertificationCenterToOrganization,
@@ -128,6 +129,25 @@ describe('Unit | Organizational Entities | Application | HttpErrorMapperConfigur
       // then
       expect(error).to.be.instanceOf(UnprocessableEntityError);
       expect(error.message).to.equal('Parent organization not in network');
+      expect(error.meta).to.equal(meta);
+    });
+  });
+
+  context('when mapping "StructureCategoryNotFound"', function () {
+    it('should return a UnprocessableEntityError Http Error', function () {
+      // given
+      const httpErrorMapper = organizationalEntitiesDomainErrorMappingConfiguration.find(
+        (httpErrorMapper) => httpErrorMapper.name === StructureCategoryNotFound.name,
+      );
+
+      const meta = { structureCategoryId: 99 };
+
+      // when
+      const error = httpErrorMapper.httpErrorFn(new StructureCategoryNotFound({ meta }));
+
+      // then
+      expect(error).to.be.instanceOf(UnprocessableEntityError);
+      expect(error.message).to.equal('Structure category does not exist');
       expect(error.meta).to.equal(meta);
     });
   });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -460,6 +460,36 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(organization.countryCode).to.equal(initialCountryCode);
     });
 
+    it('updates category id', async function () {
+      // given
+      const organization = new OrganizationForAdmin({ categoryId: 1 });
+
+      // when
+      organization.updateWithDataProtectionOfficerAndTags({
+        categoryId: 2,
+        features,
+        organizationLearnerType,
+      });
+
+      // then
+      expect(organization.categoryId).to.equal(2);
+    });
+
+    it('does not update category id to empty value', async function () {
+      // given
+      const organization = new OrganizationForAdmin({ categoryId: 1 });
+
+      // when
+      organization.updateWithDataProtectionOfficerAndTags({
+        categoryId: null,
+        features,
+        organizationLearnerType,
+      });
+
+      // then
+      expect(organization.categoryId).to.equal(1);
+    });
+
     context('updates organization isManagingStudents', function () {
       it('updates organization isManagingStudents when LEARNER_IMPORT feature does not exist', function () {
         // given

--- a/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
+++ b/api/tests/organizational-entities/unit/infrastructure/serializers/jsonapi/organization-for-admin.serializer.test.js
@@ -230,6 +230,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
         countryCode: '99100',
         organizationLearnerTypeName: 'Teacher',
         organizationLearnerTypeId: 123,
+        categoryId: '4',
       };
 
       // when
@@ -256,6 +257,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
             'country-code': organizationAttributes.countryCode,
             'organization-learner-type-id': organizationAttributes.organizationLearnerTypeId,
             'organization-learner-type-name': organizationAttributes.organizationLearnerTypeName,
+            'category-id': organizationAttributes.categoryId,
           },
         },
       });
@@ -293,6 +295,7 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
           id: 123,
           name: 'Teacher',
         }),
+        categoryId: 4,
       });
       expect(organization).to.be.instanceOf(OrganizationForAdmin);
       expect(organization).to.deep.equal(expectedOrganization);
@@ -366,6 +369,23 @@ describe('Unit | Serializer | organization-for-admin-serializer', function () {
 
       // then
       expect(organization.parentOrganizationId).to.equal(5);
+    });
+
+    it('should deserialize categoryId as null if not present', function () {
+      // when
+      const organization = organizationForAdminSerializer.deserialize({
+        data: {
+          type: 'organizations',
+          id: '7',
+          attributes: {
+            name: 'Lycée St Cricq',
+            type: Organization.types.SCO,
+          },
+        },
+      });
+
+      // then
+      expect(organization.categoryId).to.be.null;
     });
 
     it('should not deserialize country code if not present', function () {


### PR DESCRIPTION
## ☀️ Problème
Maintenant que l'on affiche l'info de la catégorie côté PixAdmin sur la page d'une organisation. On aimerait pouvoir modifier cette info.
Ce premier ticket ne comprends que le côté API

## ⛱️ Proposition
Modifier la route de patch d'organisation pour permettre de mettre à jour la catégorie d'une organisation via sa structure

## 🧴 Remarques
Un refacto global de ces routes, get/update/create organisation devra être refait car ça devient un peu complexe et un mélange de responsabilité. Noté dans notre dette technique

## 🏊 Pour tester
```
TOKEN=$(curl -s -X POST https://admin-pr17335.review.pix.fr/api/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=password&username=superadmin@example.net&password=pix123" \
  | jq -r '.access_token') && \
curl -X PATCH https://admin-pr17335.review.pix.fr/api/admin/organizations/156935 \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
  "data": {
    "id": "156935",
    "attributes": {
      "name": "Mon organisation avec catégorie modifiée",
      "administration-team-id": 8001,
      "category-id": 8005
    },
    "type": "organizations"
  }
}'
```