### PR TITLE
[TECH] Intégrer les retours internes sur les fichiers de traduction 'de', 'it' et 'es' (PIX-23349)

### DIFF
--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -2,88 +2,88 @@
   "api-error-messages": {
     "campaign-creation": {
       "custom-landing-page_too_long": "Der Text, in dem die Kampagne vorgestellt wird, ist zu lang.",
-      "external-user-id-required": "Bitte geben Sie den Wortlaut des Feldes an, das von Ihren Teilnehmern beim Start des Kurses abgefragt wird.",
-      "id-pix-type-required": "Bitte wählen Sie einen externen ID-Typ aus.",
-      "name-required": "Bitte geben Sie Ihrer Kampagne einen Namen.",
+      "external-user-id-required": "Bitte gib an, wie das Feld heißen soll, das deinen Teilnehmer:innen zu Beginn des Lernparcours angezeigt wird.",
+      "id-pix-type-required": "Bitte wähle einen externen ID-Typ aus.",
+      "name-required": "Bitte gib deiner Kampagne einen Namen.",
       "owner_not_in_organization": "Der Eigentümer ist nicht Teil der Organisation.",
-      "purpose-required": "Bitte wählen Sie das Ziel Ihrer Kampagne: Bewertung oder Profilsammlung.",
-      "target-profile-required": "Bitte wählen Sie eine Strecke für Ihre Kampagne aus.",
+      "purpose-required": "Bitte wähle das Ziel deiner Kampagne: Bewertung oder Profilsammlung.",
+      "target-profile-required": "Bitte wähle einen Lernparcours für deine Kampagne aus.",
       "title_too_long": "Der Titel der Kampagne ist zu lang."
     },
     "csv-import": {
       "property-not-uniq": "Zeile {line}: Das Feld \"{field}\" muss innerhalb der Datei eindeutig sein."
     },
-    "default": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
+    "default": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es zu einem späteren Zeitpunkt erneut.",
     "edit-student-number": {
-      "student-number-exists": "Die eingegebene Studentennummer wird bereits von dem Schüler verwendet {firstName} {lastName}."
+      "student-number-exists": "Die eingegebene Matrikelnummer wird bereits von dem:der Studierenden {firstName} {lastName} verwendet."
     },
-    "global": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
+    "global": "Es ist ein Fehler aufgetreten. Bitte versuche es zu einem späteren Zeitpunkt erneut.",
     "or-separator": " oder",
     "student-csv-import": {
-      "bad-csv-format": "Die Datei muss im csv-Format mit Komma- oder Semikolon-Trennzeichen vorliegen.",
-      "encoding-not-supported": "Kodierung der Datei nicht unterstützt.",
-      "field-bad-values": "Zeile {line}: Das Feld \"{field}\" muss \"{valids}\" lauten.",
+      "bad-csv-format": "Die Datei muss im CSV-Format vorliegen und Kommas oder Semikolons als Trennzeichen verwenden.",
+      "encoding-not-supported": "Die Dateikodierung wird nicht unterstützt.",
+      "field-bad-values": "Zeile {line}: Das Feld „{field}“ muss „{valids}“ sein.",
       "field-date-format": "Zeile {line}: Das Feld \"{field}\" muss im Format \"{acceptedFormat}\" sein.",
-      "field-email-format": "Zeile {line}: Das Feld \"{field}\" muss eine gültige E-Mail-Adresse sein.",
-      "field-length": "Zeile {line}: Das Feld \"{field}\" muss {limit} Zeichen lang sein.",
-      "field-max-length": "Zeile {line}: Das Feld \"{field}\" muss kleiner als {limit} Zeichen sein.",
-      "field-min-length": "Zeile {line}: Das Feld \"{field}\" muss mindestens {limit} Zeichen lang sein.",
+      "field-email-format": "Zeile {line}: Das Feld \"{field}\" muss eine gültige E-Mail-Adresse enthalten.",
+      "field-length": "Zeile {line}: Das Feld \"{field}\" muss {limit} Zeichen enthalten.",
+      "field-max-length": "Zeile {line}: Das Feld \"{field}\" muss weniger als {limit} Zeichen enthalten.",
+      "field-min-length": "Zeile {line}: Das Feld \"{field}\" muss mindestens {limit} Zeichen enthalten.",
       "field-pattern": "Zeile {line} : The field “{field}” enthält keinen gültigen Wert.",
       "field-required": "Zeile {line}: Das Feld \"{field}\" ist obligatorisch.",
       "header-required": "Die Spalte \"{field}\" ist obligatorisch.",
       "header-unknown": "Die Spaltenüberschriften müssen mit denen der Vorlage übereinstimmen.",
       "identifier-unique": "Zeile {line}: Das Feld \"{field}\" in dieser Zeile ist mehrfach in der Datei vorhanden.",
       "insee-code-invalid": "Zeile {line}: Das Feld \"{field}\" ist nicht im INSEE-Format.",
-      "payload-too-large": "Die Dateigröße muss weniger als {maxSize}MB betragen.",
+      "payload-too-large": "Die Dateigröße muss weniger als {maxSize} MB betragen.",
       "student-number-format": "Zeile {line}: Das Feld \"{field}\" darf keine Sonderzeichen enthalten.",
       "student-number-unique": "Zeile {line}: Das Feld \"{field}\" muss innerhalb der Datei eindeutig sein."
     },
     "student-password-reset": {
-      "organization-learner-does-not-belong-to-organization-error": "Einige der ausgewählten Schülerinnen und Schüler sind nicht mehr in dieser Organisation aufgeführt.",
-      "organization-learner-without-username-error": "Einige der ausgewählten Schülerinnen und Schüler haben keinen Benutzernamen mehr. Bitte aktualisieren Sie die Seite.",
-      "user-does-not-belong-to-organization-error": "Sie haben nicht mehr die Rechte für diese Organisation."
+      "organization-learner-does-not-belong-to-organization-error": "Einige der ausgewählten Schüler:innen sind nicht mehr Teil dieser Organisation.",
+      "organization-learner-without-username-error": "Einige der ausgewählten Schüler:innen haben keinen Benutzernamen mehr. Bitte aktualisiere die Seite.",
+      "user-does-not-belong-to-organization-error": "Du hast keine Rechte mehr für diese Organisation."
     },
     "student-xml-import": {
-      "birth-city-code-required-for-french-student": "Bei Schülern mit dem INE {nationalStudentId} ist das Feld Code Geburtsgemeinde nicht ausgefüllt. Es ist für jeden in Frankreich geborenen Schüler obligatorisch.",
-      "birthdate-required": "Bei einem Schüler mit der INE {nationalStudentId} ist das Feld Geburtsdatum nicht ausgefüllt. Es ist für jeden Schüler obligatorisch.",
-      "empty": "Die Schülerinnen und Schüler müssen eine INE sowie eine Klasse besitzen.",
+      "birth-city-code-required-for-french-student": "Bei Schüler:innen mit einer INE {nationalStudentId} bleibt das Feld mit dem Code der Geburtsgemeinde leer. Es ist für jede:n in Frankreich geborene:n Schüler:in obligatorisch.",
+      "birthdate-required": "Bei einem:einer Schüler:in mit der INE {nationalStudentId} ist das Feld Geburtsdatum nicht ausgefüllt. Es ist für jede:n Schüler:in verpflichtend.",
+      "empty": "Für die Schüler:innen müssen eine INE sowie eine Klasse angegeben werden.",
       "encoding-not-supported": "Kodierung der Datei nicht unterstützt.",
-      "first-name-required": "Bei einem Schüler mit der INE {nationalStudentId} ist das Feld Vorname nicht ausgefüllt. Dieses ist für jeden Schüler obligatorisch.",
-      "ine-required": "Das INE-Feld ist für jeden Schüler/jede Schülerin obligatorisch.",
-      "ine-unique": "Die INE {nationalStudentId} ist in der Datei mehrfach für mehrere Schüler vorhanden.",
-      "invalid-birthdate-format": "Der Schüler mit der INE {nationalStudentId} hat das falsche Format für sein Geburtsdatum. Es muss im Format 'DD/MM/YYYY' sein.",
+      "first-name-required": "Bei einem:einer Schüler:in mit der INE {nationalStudentId} ist das Feld Vorname nicht ausgefüllt. Dies ist ein Pflichtfeld für jede:n Schüler:in.",
+      "ine-required": "Das INE-Feld ist für jede:n Schüler:in verpflichtend.",
+      "ine-unique": "Die INE {nationalStudentId} ist in der Datei mehrfach für mehrere Schüler:innen vorhanden.",
+      "invalid-birthdate-format": "Das Geburtsdatum des:der Schüler:in mit der INE {nationalStudentId} hat ein ungültiges Format. Es muss im Format ‚TT/MM/JJJJ‘ angegeben werden.",
       "invalid-char-detected": "Der Name/Vorname des Schülers mit INE {nationalStudentId} enthält nicht unterstützte Zeichen.",
       "invalid-file": "Die Datei ist nicht konform.",
       "invalid-file-extension": "Erweiterung {fileExtension} nicht unterstützt.",
-      "last-name-required": "Bei einem Schüler mit der INE {nationalStudentId} ist das Feld Nachname nicht ausgefüllt. Dieses ist für jeden Schüler obligatorisch.",
-      "payload-too-large": "Die Dateigröße muss weniger als {maxSize}MB betragen.",
-      "sex-code-required": "Bei einem Schüler mit der INE {nationalStudentId} ist das Feld Geschlecht nicht ausgefüllt. Es ist für jeden Schüler obligatorisch.",
-      "uai-mismatched": "Die UAI in der SIECLE-Datei stimmt nicht mit der UAI Ihrer Einrichtung überein."
+      "last-name-required": "Bei einem:r Schüler:in mit der INE {nationalStudentId} ist das Feld Nachname nicht ausgefüllt. Dieses ist für jede:n Schüler:in verpflichtend.",
+      "payload-too-large": "Die Dateigröße muss weniger als {maxSize} MB betragen.",
+      "sex-code-required": "Bei der:dem Schüler:in mit der INE {nationalStudentId} ist das Feld Geschlecht nicht ausgefüllt. Es ist für jede:n Schüler:in verpflichtend.",
+      "uai-mismatched": "Die UAI in der SIECLE-Datei stimmt nicht mit der UAI deiner Einrichtung überein."
     }
   },
   "application": {
-    "description": "Die Plattform, die der Evaluation und der pädagogischen Überwachung gewidmet ist. Ihr Pix Orga-Bereich ermöglicht es Ihnen, eine Evaluierungskampagne zu starten oder Pix-Profile zu sammeln, den Fortschritt Ihrer Schüler oder Lernenden in einer Kampagne zu verfolgen oder auf ihre Ergebnisse zuzugreifen."
+    "description": "Die Plattform für Evaluation und Lernstandserfassung. Dein Pix Orga-Bereich ermöglicht es dir, eine Evaluierungskampagne zu starten oder Pix-Profile zu sammeln, den Fortschritt deiner Schüler:innen oder Lernenden in einer Kampagne zu verfolgen oder auf ihre Ergebnisse zuzugreifen"
   },
   "banners": {
     "certification": {
-      "message": "'<strong>'Zertifizierungen:'</strong>' vergessen Sie nicht, '< a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'die Sitzungen in Pix Certif'</a>' abzuschließen und dann die Zertifikate über den Reiter \"Zertifizierungen\" vor Schulbeginn {year} hochzuladen."
+      "message": "''Zertifizierungen:'' Vergiss nicht, '< a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'die Sitzungen in Pix Certif'' abzuschließen und dann die Zertifikate im Tab \"Zertifizierungen\" vor Schulbeginn {year} hochzuladen."
     },
     "import": {
-      "message": "Die wichtigsten Etappen des Jahres in der Schulbildung :",
-      "step1a": "Einführung : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Anleitung zum Herunterladen der Ergebnisse' class='link link--banner link--bold link--underlined' '>'Ergebnisse herunterladen'</a>' Zertifizierung und",
-      "step1b": "importieren",
-      "step1c": "die Schülerdatenbank (admin)",
-      "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Start der Pfade zum Schuljahresbeginn' class='link link--banner link--bold link--underlined' '>'Erstellen Sie die Kampagnen'</a>' (Einstiegspfad, 6. Klasse, thematische, fachspezifische und gezielte Pfade…).",
-      "step3": "Zertifizierung von Lernenden. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Leitfaden Die Zertifizierung von Schülern vorbereiten und organisieren' class='link link--banner link--bold link--underlined' '>'Erfahren Sie mehr über die Zertifizierung'</a>'."
+      "message": "Die wichtigsten Etappen des Jahres in der Schulbildung:",
+      "step1a": "Vorbereitung: '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Anleitung zum Herunterladen der Ergebnisse' class='link link--banner link--bold link--underlined' '>'Zertifizierungsergebnisse herunterladen'' und",
+      "step1b": "Importieren der",
+      "step1c": "Schüler:innendatenbank (Admin)",
+      "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Start der Lernparcours zum Schuljahresbeginn' class='link link--banner link--bold link--underlined' '>'Erstelle die Kampagnen'' (Einstiegsparcours, 6. Klasse, thematische, fachspezifische und gezielte Parcours…).",
+      "step3": "Zertifizierung von Lernenden. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Leitfaden Die Zertifizierung von Schüler:innen vorbereiten und organisieren' class='link link--banner link--bold link--underlined' '>'Erfahre mehr über die Zertifizierung'</a>'."
     },
     "last-places-lot-available": {
-      "message": "Achtung, Ihre Plätze laufen in {days, number} Tagen ab."
+      "message": "Achtung, deine Plätze laufen in {days, number} Tagen ab."
     },
     "maximum-places-exceeded": {
-      "message": "<b>Ihre Organisation hat keine freien Plätze mehr!</b><br />Um alle Funktionen nutzen zu können, räumen Sie bitte Plätze frei, wenden Sie sich an Ihren Pix-Vertreter oder '<'a href='https://pix.fr/support/form/professionnel-le' title='kontaktieren Sie uns (Deutschland)' class=\"{linkClasses}\" '>Kontaktieren Sie uns über dieses Formular</a>'. <br />Wenn Sie eine Organisation außerhalb Frankreichs sind '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='kontaktieren Sie uns (außerhalb Frankreichs)' class=\"{linkClasses}\" '>Kontaktieren Sie uns über dieses Formular</a>'."
+      "message": "<b>Deine Organisation hat keine freien Plätze mehr!</b><br />Um alle Funktionen nutzen zu können, gib bitte Plätze frei. Wende dich an deine:n Pix-Vertreter:in oder '<'a href='https://pix.fr/support/form/professionnel-le' title='kontaktiere uns (Deutschland)' class=\"{linkClasses}\" '>Kontaktiere uns über dieses Formular</a>'. <br />Wenn du Teil einer Organisation außerhalb Frankreichs bist '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='kontaktiere uns (außerhalb Frankreichs)' class=\"{linkClasses}\" '>Kontaktiere uns über dieses Formular</a>'."
     },
     "over-capacity": {
-      "message": "Achtung: Sie verbrauchen mehr Plätze als Ihre Gesamtkapazität."
+      "message": "Achtung: Du verbrauchst mehr Plätze als deine Gesamtkapazität."
     },
     "survey": {
       "message": "Hilf Pix dabei, Pix Orga weiterzuentwickeln, indem du diese kurze Umfrage zu deiner Nutzung von Kampagnen beantwortest! '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Hier geht's zur Umfrage'</a>'"
@@ -95,9 +95,9 @@
       "value": "/{total} Plätze"
     },
     "badges-acquisitions": {
-      "information": "Hier finden Sie die Anzahl der Abzeichen, die Ihre Teilnehmer in dieser Kampagne erhalten haben, sowie den Prozentsatz, zu dem sie diese erhalten haben.",
-      "obtained": "erhalten",
-      "title": "Namensschilder"
+      "information": "Hier findest du die Anzahl der Badges, die deine Teilnehmer:innen in dieser Kampagne erhalten haben, sowie den Prozentsatz, zu dem sie diese erhalten haben.",
+      "obtained": "erhaltene",
+      "title": "Badges"
     },
     "occupied-seats-count": {
       "anonymous": "davon {count, plural, =1 {1 Platz} other {{count, number} Plätze}} mit Zugang ohne Konto",
@@ -105,27 +105,27 @@
       "value": "/{total} Plätze"
     },
     "participants-average-results": {
-      "information": "Hier finden Sie die durchschnittliche Anzahl der Ergebnisse Ihrer Kampagne. Diese Zahl umfasst alle Teilnehmer, die ihren Parcours beendet und ihr Ergebnis eingesendet haben.",
+      "information": "Hier findest du das durchschnittliche Ergebnis deiner Kampagne. Diese Zahl umfasst alle Teilnehmer:innen, die ihren Lernparcours beendet und ihr Ergebnis eingesendet haben.",
       "title": "Durchschnittliches Ergebnis"
     },
     "participants-average-stages": {
-      "information": "Hier finden Sie den durchschnittlichen Lagerplatz Ihrer Kampagne. Diese Zahl umfasst alle Teilnehmer, die ihren Parcours beendet und ihr Ergebnis eingesendet haben.",
-      "title": "Mittleres Lager"
+      "information": "Hier findest du die durchschnittliche Stufe deiner Kampagne. Diese Zahl umfasst alle Teilnehmer:innen, die ihren Lernparcours beendet und ihr Ergebnis eingesendet haben.",
+      "title": "Durchschnittliche Lernstufe"
     },
     "participants-count": {
-      "information": "Hier finden Sie die Gesamtzahl der Teilnehmer Ihrer Kampagne. Diese Zahl umfasst alle Teilnehmer, die den Code eingegeben und ihre Reise oder Profilsendung begonnen haben.",
-      "loader": "Gesamtanzahl der Teilnehmer laden",
-      "title": "Teilnehmer insgesamt"
+      "information": "Hier findest du die Gesamtzahl der Teilnehmer:innen deiner Kampagne. Diese Zahl umfasst alle Teilnehmer:innen, die den Code eingegeben und ihren Lernparcours oder die Profilübermittlung begonnen haben.",
+      "loader": "Gesamtanzahl der Teilnehmer:innen laden",
+      "title": "Teilnehmer:innen insgesamt"
     },
     "place-info": {
       "with-account": {
-        "heading": "'<strong>'Der Teilnehmer hat ein Pix-Konto:'</strong>'.",
-        "message-description": "Sie können Plätze freigeben, indem Sie Teilnehmer auf der Registerkarte Teilnehmer löschen.",
-        "message-main": "1 Teilnehmer mit mindestens einer Teilnahme an einer Kampagne = 1 belegter Platz."
+        "heading": "'<strong>'Der:die Teilnehmer:in hat ein Pix-Konto:'</strong>'.",
+        "message-description": "Du kannst Plätze freigeben, indem du Teilnehmer:innen im Tab Teilnehmer:innen löschst.",
+        "message-main": "1 Teilnehmer:in mit mindestens einer Teilnahme an einer Kampagne = 1 belegter Platz."
       },
       "without-account": {
-        "heading": "'<strong>'Der Teilnehmer hat kein Pix-Konto'</strong>' (Kampagne mit Zugang ohne Konto) :",
-        "message-description": "Sie können diese Plätze freigeben, indem Sie Teilnahmen in der betreffenden Kampagne mit Accountless Access entfernen oder die Kampagne löschen.",
+        "heading": "'<strong>'Der:die Teilnehmer:in hat kein Pix-Konto'</strong>' (Kampagne mit Zugang ohne Konto) :",
+        "message-description": "Du kannst diese Plätze freigeben, indem du Teilnahmen in der betreffenden Kampagne mit Zugang ohne Konto entfernst oder die Kampagne löschst.",
         "message-main": "1 Teilnahme ohne Konto = 1 belegter Platz."
       }
     },
@@ -143,46 +143,46 @@
       "labels-a11y": {
         "date": "Datum",
         "shared": "Beendete Beteiligungen",
-        "started": "Teilnehmer insgesamt"
+        "started": "Teilnehmer:innen insgesamt"
       },
       "labels-legend": {
         "shared": "Beendete Beteiligungen",
-        "started": "Teilnehmer insgesamt"
+        "started": "Teilnehmer:innen insgesamt"
       },
-      "loader": "Laden von Teilnehmeraktivitäten",
-      "title": "Aktivität der Teilnehmer"
+      "loader": "Teilnehmer:innen-Aktivitäten werden geladen",
+      "title": "Aktivität der Teilnehmer:innen"
     },
     "participants-by-mastery-percentage": {
-      "label-a11y": "Von {from, number, ::percent} bis {to, number, ::percent}: {count, plural, =0 {0 Teilnehmer} =1 {1 Teilnehmer} other {{count, number} Teilnehmer}}.",
-      "loader": "Laden der Teilnehmerverteilung nach Ergebnis",
-      "title": "Verteilung der Teilnehmer nach Ergebnissen",
+      "label-a11y": "Von {from, number, ::percent} bis {to, number, ::percent}: {count, plural, =0 {0 Teilnehmer:innen} =1 {1 Teilnehmer:in} other {{count, number} Teilnehmer:innen}}.",
+      "loader": "Teilnehmer:innen-Verteilung nach Ergebnis wird geladen",
+      "title": "Verteilung der Teilnehmer:innen nach Ergebnissen",
       "tooltip": {
-        "label": "Anzahl der Teilnehmer: {count}.",
+        "label": "Anzahl der Teilnehmer:innen: {count}.",
         "legend": "{from, number, ::percent} - {to, number, ::percent}",
         "title": "Ergebnisse {legend}"
       }
     },
     "participants-by-stage": {
-      "loader": "Laden der Stufenverteilung von Teilnehmern",
-      "participants": "{count, plural, =0 {0 Teilnehmer} =1 {1 Teilnehmer} other {{count, number} Teilnehmer}}",
-      "title": "Verteilung der Teilnehmer nach Stufen"
+      "loader": "Stufenverteilung der Teilnehmer:innen wird geladen",
+      "participants": "{count, plural, =0 {0 Teilnehmer:innen} =1 {1 Teilnehmer:in} other {{count, number} Teilnehmer:innen}}",
+      "title": "Verteilung der Teilnehmer:innen nach Stufen"
     },
     "participants-by-status": {
       "a11y-title": "Detail nach Status",
       "labels-a11y": {
-        "shared": "{count, plural, =0 {0 Teilnehmer} =1 {1 Teilnehmer} other {{count, number} Teilnehmer}}, die ihre Ergebnisse eingesandt haben",
-        "started": "{count, plural, =0 {0 Teilnehmer} =1 {1 Teilnehmer} other {{count, number} Teilnehmer}} wird getestet"
+        "shared": "{count, plural, =0 {0 Teilnehmer:innen} =1 {1 Teilnehmer:in} other {{count, number} Teilnehmer:innen}}, die ihre Ergebnisse eingesendet haben",
+        "started": "{count, plural, =0 {0 Teilnehmer:innen} =1 {1 Teilnehmer:in} other {{count, number} Teilnehmer:innen}} testen gerade"
       },
       "labels-legend": {
-        "shared": "Abgeschlossene Beteiligungen ({count})",
+        "shared": "Abgeschlossene Teilnahmen ({count})",
         "started": "In Bearbeitung ({count})"
       },
       "labels-tooltip": {
-        "shared": "Beendete Beteiligungen: {percentage, number, ::percent .0}.",
-        "started": "In Arbeit: {percentage, number, ::percent .0}."
+        "shared": "Abgeschlossene Teilnahmen: {percentage, number, ::percent .0}.",
+        "started": "In Bearbeitung: {percentage, number, ::percent .0}."
       },
-      "loader": "Laden von Anteilen nach Status",
-      "title": "Satzung"
+      "loader": "Verteilung nach Status wird geladen",
+      "title": "Status"
     }
   },
   "common": {
@@ -193,28 +193,28 @@
       "confirm": "Bestätigen",
       "exit": "Beenden",
       "global": "Aktionen",
-      "link-to-participant": "Alle Aktivitäten des Teilnehmers anzeigen",
-      "save": "Registrieren"
+      "link-to-participant": "Alle Aktivitäten des:der Teilnehmer:in anzeigen",
+      "save": "Speichern"
     },
     "api-error-messages": {
-      "account-conflict": "Dieses Konto ist bereits mit dieser Organisation verknüpft. Bitte melden Sie sich mit einem anderen Konto an oder wenden Sie sich an den Support.",
-      "bad-request-error": "Die von Ihnen eingereichten Daten haben nicht das richtige Format.",
-      "default": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es noch einmal oder wenden Sie sich an den Support.",
-      "expired-authentication-key": "Ihre Authentifizierungsanfrage ist abgelaufen.",
-      "internal-server-error": "Es ist ein interner Fehler aufgetreten. Unsere Mitarbeiter sind dabei, das Problem zu beheben. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
+      "account-conflict": "Dieses Konto ist bereits mit dieser Organisation verknüpft. Bitte melde dich mit einem anderen Konto an oder wende dich an den Support.",
+      "bad-request-error": "Die von dir eingereichten Daten haben nicht das richtige Format.",
+      "default": "Es ist ein Fehler aufgetreten. Bitte versuche es noch einmal oder wende dich an den Support.",
+      "expired-authentication-key": "Deine Authentifizierungsanfrage ist abgelaufen.",
+      "internal-server-error": "Es ist ein interner Fehler aufgetreten. Das Pix-Team ist dabei, das Problem zu beheben. Bitte versuche es zu einem späteren Zeitpunkt erneut.",
       "login-unauthorized-error": "Die eingegebene E-Mail-Adresse oder der Benutzername und/oder das Passwort sind falsch.",
-      "login-unauthorized-remaining-attempts-error": "Achtung: Du hast noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuche} other {# Versuche}}, bevor dein Pix-Konto endgültig gesperrt wird.",
-      "login-unauthorized-remaining-attempts-with-user-name-error": "Achtung: Sie haben noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuch} other {# Versuche}}, bevor Ihr Pix-Konto endgültig gesperrt wird.'<br>'Wenn Sie Ihr Passwort vergessen haben, '<strong>'wenden Sie sich an Ihren Lehrer'</strong>', um Ihr Passwort zurückzusetzen und/oder Ihren Benutzernamen wiederzuerlangen.",
-      "login-unauthorized-with-user-name-error": "Der eingegebene Benutzername und/oder das Passwort sind falsch.'<br>'Wenn Sie es vergessen haben, '<strong>'wenden Sie sich an Ihre Lehrkraft'</strong>', um Ihr Passwort zurückzusetzen und/oder Ihren Benutzernamen wiederzuerlangen.",
-      "login-unexpected-error": "Es kann keine Verbindung hergestellt werden. Bitte versuchen Sie es in Kürze erneut. Wenn das Problem weiterhin besteht, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'kontaktieren Sie uns über das Hilfecenter'</a>'.",
-      "login-user-blocked-error": "Ihr Konto ist gesperrt, weil Sie zu viele Anmeldeversuche unternommen haben. Um es zu entsperren, '<'a href=\"{url}\"'>'kontaktieren Sie uns'</a>'.",
-      "login-user-temporary-blocked-error": "Du hast zu viele Anmeldeversuche unternommen, dein Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt. Versuchen Sie es später noch einmal oder klicken Sie auf '<'a href=\"{url}\"'>'Passwort vergessen'</a>', um es zurückzusetzen.",
-      "login-user-temporary-blocked-with-username-error": "Sie haben zu viele Anmeldeversuche unternommen, Ihr Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt.'<br>'Wenn Sie Ihr Passwort vergessen haben, '<strong>'wenden Sie sich an Ihre Lehrkraft'</strong>', um Ihr Passwort zurückzusetzen und/oder Ihren Benutzernamen abzurufen."
+      "login-unauthorized-remaining-attempts-error": "Achtung: Du hast noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuch} other {# Versuche}}, bevor dein Pix-Konto endgültig gesperrt wird.",
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Achtung: Du hast noch {remainingAttempts, plural, =0 {0 Versuche} =1 {1 Versuch} other {# Versuche}}, bevor dein Pix-Konto endgültig gesperrt wird. '<br>'Wenn du dein Passwort vergessen hast, '<strong>'wende dich an deine Lehrkraft'</strong>', um dein Passwort zurückzusetzen und/oder deinen Benutzernamen wiederzuerlangen.",
+      "login-unauthorized-with-user-name-error": "Der eingegebene Benutzername und/oder das Passwort sind falsch.'<br>'Wenn du dein Passwort vergessen hast, '<strong>'wende dich an deine Lehrkraft'</strong>', um dein Passwort zurückzusetzen und/oder deinen Benutzernamen wiederzuerlangen.",
+      "login-unexpected-error": "Es kann keine Verbindung hergestellt werden. Bitte versuche es in Kürze erneut. Wenn das Problem weiterhin besteht, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'kontaktiere uns über das Hilfecenter'</a>'.",
+      "login-user-blocked-error": "Dein Konto ist gesperrt, weil du zu viele Anmeldeversuche unternommen hast. Um es zu entsperren, '<'a href=\"{url}\"'>'kontaktiere uns'</a>'.",
+      "login-user-temporary-blocked-error": "Du hast zu viele Anmeldeversuche unternommen, dein Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt. Versuche es später noch einmal oder klicke auf '<'a href=\"{url}\"'>'Passwort vergessen'</a>', um es zurückzusetzen.",
+      "login-user-temporary-blocked-with-username-error": "Du hast zu viele Anmeldeversuche unternommen, dein Pix-Konto wird vorübergehend für {blockingDurationMinutes} Minuten gesperrt.'<br>'Wenn du dein Passwort vergessen hast, '<strong>'wende dich an deine Lehrkraft'</strong>', um dein Passwort zurückzusetzen und/oder deinen Benutzernamen abzurufen."
     },
-    "breadcrumb": "Ariadnefaden",
+    "breadcrumb": "Brotkrümelnavigation",
     "cgu": {
       "error": "Sie müssen den Nutzungsbedingungen von Pix und der Datenschutzrichtlinie zustimmen, um ein Konto zu erstellen.",
-      "label": "Ich akzeptiere die Nutzungsbedingungen und die Datenschutzrichtlinie von Pix",
+      "label": "Du musst den Nutzungsbedingungen von Pix und der Datenschutzrichtlinie zustimmen, um ein Konto zu erstellen.",
       "read-message": "Lies die '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Nutzungsbedingungen'</a>' und die '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'Datenschutzrichtlinie'</a>'."
     },
     "filters": {
@@ -235,7 +235,7 @@
         "label": "Nach Gruppen suchen",
         "placeholder": "Gruppen"
       },
-      "loading": "Laden...",
+      "loading": "Wird geladen ...",
       "participantExternalId": {
         "label": "Externe ID-Suche"
       },
@@ -272,9 +272,9 @@
       "title": "Siehe"
     },
     "result": {
-      "accessibility-description": "Ergebnis erhalten = {percentage, number, ::percent}, d. h. die Stufe {stage} auf {totalStage}.",
+      "accessibility-description": "Erzieltes Ergebnis = {percentage, number, ::percent}, d. h. die Stufe {stage} von {totalStage}.",
       "percentage": "{value, number, ::percent}",
-      "stages": "{count, plural, =0 {0 Sterne} =1 {1 Stern} other {{count, number} Sterne}} auf {total}."
+      "stages": "{count, plural, =0 {0 Sterne} =1 {1 Stern} other {{count, number} Sterne}} von {total}."
     },
     "target-profile-details": {
       "results": {
@@ -287,15 +287,15 @@
         "without-account": "Zugang ohne Konto"
       },
       "subjects": "Themen: {value, number}",
-      "thematic-results": "Namensschilder: {value, number}"
+      "thematic-results": "Badges: {value, number}"
     },
     "validation": {
       "password": {
-        "error": "Das eingegebene Passwort ist falsch. Ihr Passwort muss länger als 8 Zeichen sein und mindestens eine Zahl, einen Klein- und einen Großbuchstaben enthalten.",
+        "error": "Das eingegebene Passwort ist falsch. Dein Passwort muss länger als 8 Zeichen sein und mindestens eine Zahl, einen Klein- und einen Großbuchstaben enthalten.",
         "rules": {
-          "contains-digit": "eine Mindestzahl",
-          "contains-lowercase": "eine minimale Kleinschreibung",
-          "contains-uppercase": "mindestens ein Großbuchstabe",
+          "contains-digit": "mindestens eine Zahl",
+          "contains-lowercase": "mindestens einen Kleinbuchstaben",
+          "contains-uppercase": "mindestens einen Großbuchstaben",
           "min-length": "Mindestens 8 Zeichen"
         }
       }
@@ -305,98 +305,98 @@
     "activity-type": {
       "explanation": {
         "ASSESSMENT": "Bewertungskampagne",
-        "COMBINED_COURSE": "Lernpfad",
+        "COMBINED_COURSE": "Lernparcours",
         "EXAM": "Testmodus [beta]",
-        "PROFILES_COLLECTION": "Kampagne zum Sammeln von Profilen",
+        "PROFILES_COLLECTION": "Profilsammlungskampagne",
         "campaign": "Bewertungskampagne",
         "formation": "Ausbildung",
         "module": "Modul"
       },
       "information": {
         "ASSESSMENT": "Bewertung",
-        "COMBINED_COURSE": "Lernpfad",
+        "COMBINED_COURSE": "Lernparcours",
         "EXAM": "Testmodus [beta]",
-        "PROFILES_COLLECTION": "Sammeln von Profilen",
+        "PROFILES_COLLECTION": "Profilsammlung",
         "campaign": "Bewertung",
         "formation": "Ausbildung",
         "module": "Modul"
       }
     },
     "analysis-per-competence": {
-      "cover-rate-gauge-label": "{count, plural, =1 {Bei der Fertigkeit hat Ihr Teilnehmer ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel} erreicht.} other {Bei der Fertigkeit haben Ihre Teilnehmer ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel}.}} erreicht.",
-      "description": "{count, plural, =1 {Unterhalb findest du die Kampagnenfähigkeiten und ihre Beschreibungen sowie die Positionierung der Teilnehmer.} other {Unterhalb findest du die Kampagnenfähigkeiten und ihre Beschreibungen sowie die Positionierung der Teilnehmer.}}.",
+      "cover-rate-gauge-label": "{count, plural, =1 {Bei dieser Kompetenz hat dein:e Teilnehmer:in das Niveau {reachedLevel} von maximal {maxLevel} erreicht.} other {Bei dieser Kompetenz haben deine Teilnehmer:innen das Niveau {reachedLevel} von maximal {maxLevel} erreicht.}}",
+      "description": "{count, plural, =1 {Unten findest du die Kompetenzen der Kampagne mit ihrer Beschreibung sowie die Einstufung der Teilnehmer:innen.} other {Unten findest du die Kompetenzen der Kampagne mit ihrer Beschreibung sowie die Einstufung der Teilnehmer:innen.}}",
       "table": {
         "caption": "Kompetenzen",
         "column": {
-          "competences": "Name und Beschreibung der Fertigkeit",
-          "level": "Ebene",
-          "positioning": "Positionierung"
+          "competences": "Name und Beschreibung der Kompetenz",
+          "level": "Niveau",
+          "positioning": "Einstufung"
         }
       }
     },
     "analysis-per-tube": {
-      "cover-rate-gauge-label": "{count, plural, =1 {Bei dem Thema hat Ihr Teilnehmer ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel} erreicht.} other {Zum Thema haben Ihre Teilnehmer ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel}.}} erreicht.",
-      "description": "{count, plural, =1 {Unterhalb finden Sie die Kampagnenthemen und ihre Beschreibungen sowie die Positionierung der Teilnehmer.} other {Unterhalb finden Sie die Kampagnenthemen und ihre Beschreibungen sowie die Positionierung der Teilnehmer.}}.",
+      "cover-rate-gauge-label": "{count, plural, =1 {Bei diesem Thema hat dein:e Teilnehmer:in das Niveau {reachedLevel} von maximal {maxLevel} erreicht.} other {Bei diesem Thema haben deine Teilnehmer:innen das Niveau {reachedLevel} von maximal {maxLevel} erreicht.}}",
+      "description": "{count, plural, =1 {Unten findest du die Themen der Kampagne mit ihrer Beschreibung sowie die Einstufung der Teilnehmer:innen.} other {Unten findest du die Themen der Kampagne mit ihrer Beschreibung sowie die Einstufung der Teilnehmer:innen.}}",
       "table": {
         "caption": "{index} - {name}",
         "column": {
-          "level": "Ebene",
-          "positioning": "Positionierung",
+          "level": "Niveau",
+          "positioning": "Einstufung",
           "tubes": "Name und Beschreibung des Themas"
         }
       }
     },
     "analysis-per-tube-or-competence": {
-      "title": "Detaillierte Positionierung",
+      "title": "Detaillierte Einstufung",
       "toggle": {
-        "label": "Ansicht durch :",
+        "label": "Ansicht nach",
         "label-competences": "Kompetenzen",
         "label-tubes": "Themen"
       }
     },
     "authentication": {
       "authentication-identity-providers": {
-        "select-another-organization-link": "Eine andere Verbindungsmethode wählen",
+        "select-another-organization-link": "Eine andere Anmeldemethode wählen",
         "spacer": {
           "or": "oder"
         }
       },
       "oidc-association-confirmation": {
-        "authentication-method-to-add": "Verbindung hinzugefügt",
+        "authentication-method-to-add": "Anmeldung hinzugefügt",
         "confirm": "Weiter",
-        "current-authentication-methods": "Meine aktuellen Verbindungsmethoden",
+        "current-authentication-methods": "Meine aktuellen Anmeldemethoden",
         "email": "E-Mail-Adresse",
         "external-connection": "Externe Verbindung",
-        "external-connection-via": "Verbindung über",
+        "external-connection-via": "Anmeldung über",
         "return": "Zurück",
-        "title": "Ihrem Pix-Konto wird bald eine neue Anmeldemethode hinzugefügt.",
+        "title": "Deinem Pix-Konto wird bald eine neue Anmeldemethode hinzugefügt.",
         "username": "Kennung"
       },
       "oidc-provider-selector": {
-        "label": "Nach einer Verbindungsmethode suchen",
-        "placeholder": "Verbindungsmethode auswählen",
-        "searchLabel": "Suche nach Schlüsselwörtern"
+        "label": "Nach einer Anmeldemethode suchen",
+        "placeholder": "Anmeldemethode auswählen",
+        "searchLabel": "Schlüsselwortsuche"
       }
     },
     "certificability": {
       "placeholder-select": "Zertifizierbar / Nicht zertifizierbar"
     },
     "certificability-tooltip": {
-      "aria-label": "Erläuterung zur Zertifizierbarkeit",
-      "content": "Zertifizierbarkeit bedeutet, dass der/die Teilnehmer/in in mindestens fünf verschiedenen Kompetenzen das Niveau 1 erreicht hat.",
-      "from-collect-notice": "Die Informationen stammen aus den von ihm durchgeführten Kampagnen zum Sammeln von Profilen. Wenn der Teilnehmer sein Profil bereits versendet hat, werden das Datum sowie der Status der letzten Versendung angezeigt.",
-      "from-compute-certificability": "Dieser Status wird automatisch am Tag nach jeder Anmeldung des Teilnehmers und bei Profilerhebungen aktualisiert."
+      "aria-label": "Erklärung zur Zertifizierbarkeit",
+      "content": "Zertifizierbarkeit bedeutet, dass der:die Teilnehmer:in in mindestens fünf verschiedenen Kompetenzen Niveau 1 erreicht hat.",
+      "from-collect-notice": "Die Informationen stammen aus den von ihm:ihr durchgeführten Profilübermittlungs-Kampagnen. Wenn der:die Teilnehmer:in sein:ihr Profil bereits übermittelt hat, werden das Datum sowie der Status der letzten Übermittlung angezeigt.",
+      "from-compute-certificability": "Dieser Status wird automatisch am Tag nach jeder Anmeldung des Teilnehmers sowie bei Profilsammelkampagnen aktualisiert."
     },
     "cover-rate-gauge": {
-      "label": "Bei dieser Kampagne erreichten Ihre Teilnehmer ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel}."
+      "label": "Bei dieser Kampagne haben deine Teilnehmer:innen das Niveau {reachedLevel} von maximal {maxLevel} erreicht."
     },
     "date": {
       "no-date": "Noch kein Datum"
     },
     "global-positioning": {
-      "description": "Die Gesamtpositionierung ist das durchschnittliche Niveau, das die Teilnehmer erreicht haben (violetter Balken), im Vergleich zum Maximum, das sie in dieser Kampagne hätten erreichen können (weißer Balken).",
-      "gauge-label": "Bei dieser Kampagne erreichten Ihre Teilnehmer im Durchschnitt ein Niveau von {reachedLevel} von einem maximal erreichbaren Niveau von {maxLevel}.",
-      "title": "Globale Positionierung"
+      "description": "Die Gesamteinstufung ist das durchschnittliche Niveau, das die Teilnehmer:innen erreicht haben (violetter Balken), im Vergleich zum Maximum, das sie in dieser Kampagne hätten erreichen können (weißer Balken).",
+      "gauge-label": "Bei dieser Kampagne haben deine Teilnehmer:innen im Durchschnitt das Niveau {reachedLevel} von maximal {maxLevel} erreicht.",
+      "title": "Gesamteinstufung"
     },
     "group": {
       "SCO": "Klasse",
@@ -405,21 +405,21 @@
     "import-information-banner": {
       "error": "Import fehlgeschlagen",
       "error-link": "(siehe Importseite).",
-      "in-progress": "Ein Import ist im Gange",
+      "in-progress": "Ein Import läuft",
       "in-progress-link": "(den Status des Imports abfragen).",
-      "success": "Die Teilnehmer wurden zwar am {date} von {firstname} {lastname} importiert."
+      "success": "Die Teilnehmer:innen wurden am {date} von {firstname} {lastname} importiert."
     },
     "index": {
       "action-cards": {
         "classic": {
           "create-campaign": {
             "buttonText": "Neue Kampagne",
-            "description": "Wählen Sie die Strecke aus, auf der Sie Ihre Teilnehmer bewerten möchten, oder sammeln Sie deren Pix-Profil.",
+            "description": "Wähle den Parcours, mit dem du deine Teilnehmer:innen bewerten möchtest, oder erfasse ihr Pix-Profil.",
             "title": "Eine Kampagne erstellen"
           },
           "follow-activity": {
-            "buttonText": "Meine Kampagnen ansehen",
-            "description": "Sehen Sie sich den Status und die Ergebnisse Ihrer Teilnehmer an.",
+            "buttonText": "Meine Kampagnen anzeigen",
+            "description": "Sieh dir den Status und die Ergebnisse deiner Teilnehmer:innen an.",
             "title": "Aktivität verfolgen"
           }
         },
@@ -428,65 +428,65 @@
             "buttonText": "Die Sitzung verlängern"
           },
           "follow-activity": {
-            "buttonText": "Siehe Missionen",
-            "description": "Sehen Sie sich den Status und die Ergebnisse Ihrer Teilnehmer an.",
+            "buttonText": "Missionen anzeigen",
+            "description": "Sieh dir den Status und die Ergebnisse deiner Teilnehmer:innen an.",
             "title": "Aktivität verfolgen"
           },
           "launch-session": {
             "buttonText": "Sitzung aktivieren",
-            "description": "Die Sitzung ermöglicht den Schülerinnen und Schülern einen vierstündigen Zugang zu Pix Junior. Sobald die Sitzung aktiviert ist, kann sie verlängert werden.",
+            "description": "Die Sitzung ermöglicht Schüler:innen den Zugriff auf Pix Junior für eine Dauer von 4 Stunden. Sobald die Sitzung aktiviert ist, kann sie verlängert werden.",
             "title": "Eine Sitzung verwalten"
           }
         },
-        "title": "Was möchten Sie tun?"
+        "title": "Was möchtest du tun?"
       },
       "organization-information": {
-        "label": "Name Ihrer Organisation",
-        "title": "Informationen über Ihre Organisation"
+        "label": "Name deiner Organisation",
+        "title": "Informationen zu deiner Organisation"
       },
       "participation-statistics": {
         "completed-participations": {
-          "description": "In den letzten 30 Tagen abgeschlossene Beteiligungen.",
-          "info": "Die Anzahl der abgeschlossenen Teilnahmen in den letzten 30 Tagen berücksichtigt aktive Kampagnen, die Ihnen gehören.",
-          "no-completed-participations": "Keine abgeschlossene Teilnahme in den letzten 30 Tagen.",
-          "title": "Beendete Beteiligungen"
+          "description": "Abgeschlossene Teilnahmen in den letzten 30 Tagen.",
+          "info": "Die Anzahl der abgeschlossenen Teilnahmen in den letzten 30 Tagen berücksichtigt die aktiven Kampagnen, deren Eigentümer:in du bist.",
+          "no-completed-participations": "Keine abgeschlossenen Teilnahmen in den letzten 30 Tagen.",
+          "title": "Abgeschlossene Teilnahmen"
         },
         "completion-rate": {
-          "description": "{completed} abgeschlossene Beteiligungen auf {started} gestartete Beteiligungen.",
-          "info": "Die Abschlussrate wird anhand der aktiven Kampagnen berechnet, die sich in Ihrem Besitz befinden.",
-          "no-activity": "Derzeit keine Aktivitäten",
-          "title": "Vervollständigungsrate"
+          "description": "{completed} von {started} gestarteten Teilnahmen abgeschlossen.",
+          "info": "Die Abschlussrate wird auf der Grundlage der aktiven Kampagnen berechnet, deren Eigentümer:in du bist.",
+          "no-activity": "Derzeit keine Aktivität",
+          "title": "Abschlussrate"
         }
       },
       "welcome": {
         "description": {
-          "classic": "Willkommen auf Ihrer Plattform zur Bewertung und Entwicklung von digitalen Kompetenzen! Konfigurieren und verteilen Sie Kampagnen an Ihre Teilnehmer. Verfolgen Sie ihre Fortschritte und analysieren Sie ihre Ergebnisse, um ihnen eine auf ihre Bedürfnisse zugeschnittene Betreuung anzubieten.",
-          "missions": "Willkommen auf Ihrer Plattform zur pädagogischen Überwachung der digitalen Kompetenzen Ihrer Schülerinnen und Schüler! Wählen Sie die Aufgaben aus und verfolgen Sie ihre Fortschritte."
+          "classic": "Willkommen auf deiner Plattform zur Bewertung und Entwicklung digitaler Kompetenzen! Erstelle und teile Kampagnen mit deinen Teilnehmer:innen. Verfolge ihren Fortschritt und analysiere ihre Ergebnisse, um ihnen eine auf ihre Bedürfnisse abgestimmte Begleitung anzubieten.",
+          "missions": "Willkommen auf deiner Plattform zur pädagogischen Begleitung der digitalen Kompetenzen deiner Schüler:innen! Wähle Missionen aus und verfolge ihren Fortschritt."
         },
         "title": "Hallo {name},"
       }
     },
     "locale-switcher": {
-      "label": "Wählen Sie eine Sprache",
-      "placeholder": "Wählen Sie eine Sprache"
+      "label": "Wähle eine Sprache",
+      "placeholder": "Wähle eine Sprache"
     },
     "organization-participants-header": {
       "default": {
-        "title": "{count, plural, =0 {Teilnehmer} =1 {Teilnehmer ({count})} other {Teilnehmer ({count})}}"
+        "title": "{count, plural, =0 {Teilnehmer:innen} =1 {Teilnehmer:in ({count})} other {Teilnehmer:innen ({count})}}"
       },
       "import-button": "Importieren",
       "sco": {
-        "title": "{count, plural, =0 {Schüler} =1 {Schüler ({count})} other {Schüler ({count})}}"
+        "title": "{count, plural, =0 {Schüler:innen} =1 {Schüler:in ({count})} other {Schüler:innen ({count})}}"
       },
-      "sco-title": "{count, plural, =0 {Schüler} =1 {Schüler ({count})} other {Schüler ({count})}}",
-      "title": "{count, plural, =0 {Teilnehmer} =1 {Teilnehmer ({count})} other {Teilnehmer ({count})}}"
+      "sco-title": "{count, plural, =0 {Schüler:innen} =1 {Schüler:in ({count})} other {Schüler:innen ({count})}}",
+      "title": "{count, plural, =0 {Teilnehmer:innen} =1 {Teilnehmer:in ({count})} other {Teilnehmer:innen ({count})}}"
     },
     "participation-status": {
       "COMPLETED": "Abgeschlossen",
       "LOCKED": "Gesperrt",
-      "NOT_STARTED": "Zu tun",
+      "NOT_STARTED": "Offen",
       "SHARED": "Abgeschlossen",
-      "STARTED": "In Arbeit"
+      "STARTED": "In Bearbeitung"
     },
     "terms-of-service": {
       "actions": {
@@ -495,51 +495,51 @@
         "reject": "Ablehnen und verlassen"
       },
       "message": {
-        "requested": "Um Pix weiterhin nutzen zu können, solltest du unsere Nutzungsbedingungen lesen und ihnen zustimmen.",
-        "update-requested": "Wir haben unsere AGBs aktualisiert. Sehen Sie sich die Änderungen an und akzeptieren Sie sie, um fortzufahren."
+        "requested": "Um Pix weiterhin nutzen zu können, bitten wir dich, unsere Allgemeinen Nutzungsbedingungen zu lesen und zu akzeptieren.",
+        "update-requested": "Wir haben unsere Nutzungsbedingungen aktualisiert. Sieh dir die Änderungen an und akzeptiere sie, um fortzufahren."
       },
       "title": {
-        "requested": "Bitte akzeptieren Sie unsere Allgemeinen Geschäftsbedingungen (AGB)",
-        "update-requested": "Wichtige Aktualisierung der Allgemeinen Nutzungsbedingungen (ANB)"
+        "requested": "Bitte akzeptiere unsere Allgemeinen Nutzungsbedingungen (AGB)",
+        "update-requested": "Wichtige Aktualisierung der Allgemeinen Nutzungsbedingungen (AGB)"
       }
     },
     "ui": {
       "deletion-modal": {
-        "confirm-deletion": "Ja, ich streiche",
-        "confirmation-checkbox": "{count, plural, =1 {Ich bestätige, dass ich die Auswirkungen der Löschung gut verstanden habe.} other {Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.}}"
+        "confirm-deletion": "Löschen bestätigen",
+        "confirmation-checkbox": "Ich bestätige, dass ich die Auswirkungen der {count} Löschungen verstanden habe."
       },
       "edit-participant-name-modal": {
         "error-messages": {
-          "first-name": "Der Vorname des Nutzers darf nicht leer sein.",
-          "last-name": "Der Benutzername darf nicht leer sein."
+          "first-name": "Der Vorname des:der Nutzer:in darf nicht leer sein.",
+          "last-name": "Der Nachname des:der Nutzer:in darf nicht leer sein."
         },
         "fields": {
           "first-name": "Vorname",
           "last-name": "Name"
         },
-        "label": "Den Namen des Nutzers ändern",
+        "label": "Name des:der Nutzer:in ändern",
         "success-message": "Name erfolgreich aktualisiert"
       }
     }
   },
   "navigation": {
     "assessment-individual-results": {
-      "aria-label": "Navigation im Abschnitt Ergebnis einer Einzelbewertung"
+      "aria-label": "Navigation für den Bereich „Ergebnisse der Einzelbewertung“"
     },
     "campaign-page": {
-      "aria-label": "Navigation im Abschnitt Details einer Kampagne"
+      "aria-label": "Navigation für den Bereich „Kampagnendetails“"
     },
     "credits": {
-      "number": "{count, plural, =0 {0 credits} =1 {1 credit} other {{count, number} credits}}.",
-      "tooltip-text": "Die Anzahl der angezeigten Credits entspricht der Anzahl der von der Organisation erworbenen und gültigen Credits (unabhängig von ihrer Aktivierung). Für weitere Informationen kontaktieren Sie uns unter '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'."
+      "number": "{count, plural, =0 {0 Credits} =1 {1 Credit} other {{count, number} Credits}}",
+      "tooltip-text": "Die angezeigte Anzahl der Credits entspricht den von der Organisation erworbenen und derzeit gültigen Credits (unabhängig von ihrer Aktivierung). Für weitere Informationen kontaktiere uns bitte unter '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'."
     },
     "external-link-title": "In einem neuen Fenster öffnen",
     "footer": {
-      "a11y": "Barrierefreiheit: teilweise erfüllt",
-      "aria-label": "Fußnoten-Navigation",
+      "a11y": "Barrierefreiheit: teilweise konform",
+      "aria-label": "Fußzeilen-Navigation",
       "copyrights": "©",
-      "help-center": "Hilfezentrum",
-      "legal-notice": "Rechtliche Hinweise",
+      "help-center": "Hilfecenter",
+      "legal-notice": "Impressum",
       "pix": "Pix",
       "server-status": "Status der Dienste"
     },
@@ -550,51 +550,51 @@
       "catalogue": "Katalog",
       "certifications": "Zertifizierungen",
       "close": "Navigation schließen",
-      "combined-courses": "Lernerpfade",
+      "combined-courses": "Lernparcours",
       "documentation": "Dokumentation",
       "home": "Startseite",
       "missions": "Missionen",
       "open": "Navigation öffnen",
-      "organization-participants": "Teilnehmer",
+      "organization-participants": "Teilnehmer:innen",
       "places": "Plätze",
-      "sco-organization-participants": "Schülerinnen und Schüler",
+      "sco-organization-participants": "Schüler:innen",
       "statistics": "Statistiken",
       "sup-organization-participants": "Studierende",
-      "support": "Hilfezentrum",
+      "support": "Hilfecenter",
       "team": "Team"
     },
     "places": {
-      "link": "siehe Details",
-      "number": "{count, plural, =0 {0 verfügbarer Platz} =1 {1 verfügbarer Platz} other {{count} verfügbare Plätze}}"
+      "link": "Details anzeigen",
+      "number": "{count, plural, =0 {0 verfügbare Plätze} =1 {1 verfügbarer Platz} other {{count} verfügbare Plätze}}"
     },
     "school-sessions": {
       "activate-button": "Sitzung aktivieren",
-      "extend-button": "Die Sitzung verlängern",
+      "extend-button": "Sitzung verlängern",
       "status": {
-        "active-label": "Aktive Sitzung bis {sessionExpirationDate}.",
+        "active-label": "Sitzung aktiv bis {sessionExpirationDate}",
         "aria-label": "Erklärung zur Sitzung",
         "code-label": "Schulcode",
         "inactive-label": "Inaktive Sitzung",
-        "info-text": "Missionen sind für Schüler nur zugänglich, wenn die Sitzung aktiv ist.'<br>' Am Ende der Sitzung werden Schüler, die sich gerade in einer Mission befinden, nicht ausgeloggt.",
+        "info-text": "Schüler:innen können nur bei aktiver Sitzung auf die Missionen zugreifen.'<br>' Nach Ablauf der Sitzung werden Schüler:innen, die sich gerade in einer Mission befinden, nicht abgemeldet.",
         "title": "Status der Sitzung"
       }
     },
     "team-members": {
-      "aria-label": "Team-Navigation"
+      "aria-label": "Navigation für den Bereich „Team“"
     },
     "user-logged-menu": {
-      "button": "Organisation ändern",
-      "logout": "Sich abmelden"
+      "button": "Organisation wechseln",
+      "logout": "Abmelden"
     }
   },
   "pages": {
     "assessment-individual-results": {
-      "badges": "Namensschilder",
+      "badges": "Badges",
       "breadcrumb-current-page-label": "Teilnahme von {firstName} {lastName}",
-      "participation-label": "Partizipation #{participationNumber}",
-      "participation-not-shared": "Nicht eingesandte Ergebnisse",
-      "participation-selector": "Teilnahme wählen",
-      "participation-shared": "Gesendete Ergebnisse",
+      "participation-label": "Teilnahme #{participationNumber}",
+      "participation-not-shared": "Ergebnisse nicht übermittelt",
+      "participation-selector": "Teilnahme auswählen",
+      "participation-shared": "Ergebnisse übermittelt",
       "progression": "Fortschritt",
       "result": "Ergebnis",
       "tab": {
@@ -603,10 +603,10 @@
       },
       "table": {
         "column": {
-          "competences": "Fertigkeiten ({count, plural, =0 {-} other {{count}}})",
+          "competences": "Kompetenzen ({count, plural, =0 {-} other {{count}}})",
           "results": {
             "label": "Ergebnisse",
-            "tooltip": "'<span class=\"screen-reader-only\">'Dieser Teilnehmer hat validiert'</span>' {result, number, ::percent} '<span class=\"screen-reader-only\">'von der Kompetenz {competence}.'</span> '."
+            "tooltip": "'<span class=\"screen-reader-only\">'Diese:r Teilnehmer:in hat'</span>' {result, number, ::percent} '<span class=\"screen-reader-only\">'der Kompetenz {competence} erfolgreich abgeschlossen.'</span>'"
           }
         },
         "empty": "Warten auf Ergebnisse",
@@ -615,29 +615,29 @@
       "title": "Ergebnisse von {firstName} {lastName}"
     },
     "attestations": {
-      "basic-description": "Exportieren Sie alle Bescheinigungen",
+      "basic-description": "Alle Bescheinigungen exportieren",
       "download-attestations-button": "Herunterladen (.pdf)",
-      "no-attestations": "Für Ihre Auswahl sind keine Bescheinigungen verfügbar",
+      "no-attestations": "Keine Bescheinigung für deine Auswahl verfügbar",
       "section": {
-        "download": "Download",
+        "download": "Downloads",
         "list": "Nachverfolgung: {attestationName}."
       },
-      "select-divisions-label": "Wählen Sie die Bescheinigungen einer oder mehrerer Klassen aus",
+      "select-divisions-label": "Wähle die Bescheinigungen einer oder mehrerer Klassen aus",
       "select-label": "Bescheinigung",
       "table": {
         "column": {
           "division": "Klasse",
           "first-name": "Vorname",
-          "last-name": "Name",
-          "status": "Erhalt"
+          "last-name": "Nachname",
+          "status": "Status"
         },
         "filter": {
           "divisions": {
             "empty-option": "Klasse",
             "label": "Klasse"
           },
-          "legend": "Filter für die Tabelle der Bescheinigungen, Eingabefelder ermöglichen es, die Tabelle nach dem Vor- oder Nachnamen eines Schülers und nach Klassen zu filtern. Mithilfe von Schaltflächen können Sie nach erhaltenen oder nicht erhaltenen Bescheinigungen filtern.",
-          "results": "{total, plural, =0 {0 ergebnisse} =1 {1 ergebnisse} other {{total, number} ergebnisse}}",
+          "legend": "Filter für die Bescheinigungstabelle: Über die Eingabefelder kann die Tabelle nach Vor- oder Nachnamen der Schüler:innen sowie nach Klassen gefiltert werden. Über Schaltflächen lassen sich erworbene und nicht erworbene Bescheinigungen filtern.",
+          "results": "{total, plural, =0 {0 Ergebnisse} =1 {1 Ergebnis} other {{total, number} Ergebnisse}}",
           "status": {
             "empty-option": "Erhalten / Nicht erhalten",
             "label": "Erhalt",
@@ -655,9 +655,9 @@
     "campaign": {
       "actions": {
         "export-results": "Ergebnisse exportieren (.csv)",
-        "unarchive": "Die Kampagne dearchivieren"
+        "unarchive": "Kampagne wiederherstellen"
       },
-      "archived": "Archivierte Kampagne",
+      "archived": "Kampagne archiviert",
       "code": "Code",
       "copy": {
         "code": {
@@ -669,24 +669,24 @@
           "success": "Kopiert!"
         }
       },
-      "created-by": "Eigentümer",
+      "created-by": "Eigentümer:in",
       "created-on": "Erstellt am",
-      "empty-state": "Bisher keine Teilnehmer!",
-      "empty-state-with-copy-link": "Bisher gibt es noch keine Teilnehmer! Schicken Sie ihnen den folgenden Link, um sich Ihrer Kampagne anzuschließen.",
-      "included-in-combined-course": "Diese Bewertungskampagne ist im Lernpfad enthalten",
+      "empty-state": "Noch keine Teilnehmer:innen vorhanden!",
+      "empty-state-with-copy-link": "Noch keine Teilnehmer:innen vorhanden! Sende ihnen den folgenden Link, um deiner Kampagne beizutreten.",
+      "included-in-combined-course": "Diese Bewertungskampagne ist Teil des Lernparcours.",
       "included-in-combined-course-end": ".",
       "link": "Link",
       "multiple-sendings": {
         "status": {
-          "disabled": "Nicht",
+          "disabled": "Nein",
           "enabled": "Ja"
         },
-        "title": "Mehrfachsendung"
+        "title": "Mehrfache Übermittlung"
       },
       "name": "Name der Kampagne",
       "tab": {
         "activity": "Aktivität",
-        "combined-courses": "Lernerpfade",
+        "combined-courses": "Lernparcours",
         "results": "Ergebnisse ({count, number})",
         "review": "Analyse",
         "settings": "Einstellungen"
@@ -698,20 +698,20 @@
       },
       "delete-participation-modal": {
         "actions": {
-          "cancel": "Nicht",
-          "confirmation": "Ja, ich streiche"
+          "cancel": "Nein",
+          "confirmation": "Löschen bestätigen"
         },
         "error": "Beim Löschen der Teilnahme ist ein Problem aufgetreten.",
-        "success": "Die Teilnahme wurde erfolgreich unterdrückt.",
-        "text": "Sie sind dabei, einen Beitrag zu löschen. Dieser wird nicht mehr sichtbar sein und nicht mehr in die Kampagnenstatistik einfließen.",
-        "title": "Die Teilnahme von <strong>{firstName} {lastName}</strong> streichen?",
+        "success": "Die Teilnahme wurde erfolgreich gelöscht.",
+        "text": "Du bist dabei, eine Teilnahme zu löschen. Diese wird danach weder sichtbar sein noch in den Statistiken der Kampagne berücksichtigt.",
+        "title": "Teilnahme von <strong>{firstName} {lastName}</strong> löschen?",
         "warning": {
           "assessment-campaign-participation": {
-            "shared-participation": "Der Teilnehmer kann dann nicht mehr auf die Ergebnisse dieser Kampagne zugreifen.",
-            "started-participation": "Der Teilnehmer kann diese Teilnahme nicht wieder aufnehmen."
+            "shared-participation": "Die:der Teilnehmer:in kann nicht mehr auf die Ergebnisse dieser Kampagne zugreifen.",
+            "started-participation": "Die:der Teilnehmer:in kann diese Teilnahme nicht wieder aufnehmen."
           },
           "profiles-collection-campaign-participation": {
-            "shared-participation": "Der Teilnehmer kann dann nicht mehr an dieser Profilsammlung teilnehmen."
+            "shared-participation": "Die:der Teilnehmer:in kann an dieser Profilsammlung nicht mehr teilnehmen."
           }
         }
       },
@@ -719,35 +719,35 @@
         "column": {
           "delete": "Teilnahme löschen",
           "first-name": "Vorname",
-          "last-name": "Name",
+          "last-name": "Nachname",
           "participationCount": "Anzahl der Teilnahmen",
           "status": "Status"
         },
         "delete-button-label": "Teilnahme löschen",
-        "empty": "Keine Teilnehmer",
-        "see-results": "Ergebnisse anzeigen von {firstName} {lastName}",
-        "title": "Liste der Teilnehmer"
+        "empty": "Keine Teilnehmer:innen",
+        "see-results": "Ergebnisse von {firstName} {lastName} anzeigen",
+        "title": "Teilnehmerliste"
       },
       "title": "Aktivität"
     },
     "campaign-analysis": {
       "description": {
-        "explanation": "{count, plural, =1 {Die Positionierung spiegelt das durchschnittliche Niveau wider, das der Teilnehmer erreicht hat, im Vergleich zum maximal erreichbaren Niveau in dieser Kampagne.} other {Die Positionierung spiegelt das durchschnittliche Niveau wider, das die Teilnehmer erreicht haben, im Vergleich zum maximal erreichbaren Niveau in dieser Kampagne.}}.",
-        "nota-bene": "{count, plural, =1 {Alle dargestellten Daten stammen aus der ausgewählten Teilnahme.} other {Alle dargestellten Daten stammen aus freigegebenen und nicht gelöschten Teilnahmen an Bewertungskampagnen und werden bei jedem Besuch aktualisiert.}}.",
-        "resume": "{count, plural, =1 {Analysieren Sie nach Kompetenz oder Thema die Positionierung der Teilnehmer in dieser Kampagne, die sich auf eine Auswahl von Themen aus dem Pix-Referenzsystem bezieht.} other {Analysieren Sie nach Kompetenz oder Thema die Positionierung Ihrer Teilnehmer in dieser Kampagne, die sich auf eine Auswahl von Themen aus dem Pix-Referenzsystem bezieht.}}."
+        "explanation": "{count, plural, =1 {Die Einstufung spiegelt das von dem:der Teilnehmer:in erreichte durchschnittliche Niveau im Vergleich zum maximal erreichbaren Niveau in dieser Kampagne wider.} other {Die Einstufung spiegelt das von den Teilnehmer:innen erreichte durchschnittliche Niveau im Vergleich zum maximal erreichbaren Niveau in dieser Kampagne wider.}}",
+        "nota-bene": "{count, plural, =1 {Alle angezeigten Daten stammen aus der ausgewählten Teilnahme.} other {Alle angezeigten Daten stammen aus den geteilten und nicht gelöschten Teilnahmen der Bewertungskampagnen und werden bei jedem Aufruf aktualisiert.}}",
+        "resume": "{count, plural, =1 {Analysiere nach Kompetenz oder Thema die Einstufung des:der Teilnehmer:in in dieser Kampagne, die sich auf eine Auswahl von Themen des Pix-Referenzrahmens bezieht.} other {Analysiere nach Kompetenz oder Thema die Einstufung deiner Teilnehmer:innen in dieser Kampagne, die sich auf eine Auswahl von Themen des Pix-Referenzrahmens bezieht.}}"
       },
       "levels-correspondence": {
         "infos": {
           "link": "https://pix.fr/score-et-niveaux",
-          "text": "Erfahren Sie mehr über die Levels."
+          "text": "Mehr über die Niveaustufen erfahren."
         },
         "levels": {
-          "advanced": "5 oder 6: Fortgeschrittene",
-          "beginner": "1 oder 2: Novize",
-          "expert": "7 oder 8: Experte",
+          "advanced": "5 oder 6: Fortgeschritten",
+          "beginner": "1 oder 2: Einsteiger:in",
+          "expert": "7 oder 8: Expert:in",
           "independent": "3 oder 4: Selbstständig"
         },
-        "title": "Entsprechung der Ebenen"
+        "title": "Einordnung der Niveaustufen"
       },
       "title": "Analyse"
     },
@@ -756,9 +756,9 @@
         "create": "Kampagne erstellen",
         "delete": "Löschen"
       },
-      "combined-course-blueprints-label": "Einen Lernpfad auswählen",
-      "combined-course-blueprints-list-label": "Einen Lernpfad auswählen",
-      "copy-of": "Kopieren von",
+      "combined-course-blueprints-label": "Wähle einen Lernparcours",
+      "combined-course-blueprints-list-label": "Wähle einen Lernparcours",
+      "copy-of": "Kopie von",
       "course-label": "Einen Kurs auswählen",
       "course-selection-label": "Einen Kurs auswählen",
       "course-title": {
@@ -776,10 +776,10 @@
           "label": "Zusätzliche Kennung",
           "message": "Mit dem zusätzlichen Kennung können Sie zu Beginn der Kampagne von jedem Teilnehmer die Identifikationsdaten Ihrer Wahl anfordern.'<br>'Wenn Sie „Ja“ auswählen, können Sie die Teilnehmer anhand dieser Daten filtern und sortieren.'<br>'Wenn Sie „Nein“ auswählen, stehen in der Kampagnenauswertung nur der Vorname und der Nachname des Teilnehmers zur Verfügung."
         },
-        "label": "Bezeichnung der zusätzlichen Kennung",
-        "question-label": "Möchten Sie zu Beginn Ihrer Teilnahme eine zusätzliche Kennung anfordern?",
-        "required": "Die zusätzlichen Kennung ist obligatorisch",
-        "suggestion": "Beispiel: \"Schülernummer\" oder \"Geschäftliche E-Mail-Adresse\" *."
+        "label": "Bezeichnung der ID",
+        "question-label": "Möchtest du eine externe ID abfragen?",
+        "required": "Die externe ID ist erforderlich",
+        "suggestion": "Beispiel: „Matrikelnummer“ oder „Geschäftliche E-Mail-Adresse“ *"
       },
       "external-id-type": {
         "information": {
@@ -790,44 +790,44 @@
       },
       "landing-page-text": {
         "label": "Text auf der Startseite",
-        "sublabel": "Dieses Feld wird den Teilnehmern der Kampagne angezeigt."
+        "sublabel": "Dieses Feld wird den Teilnehmer:innen der Kampagne angezeigt."
       },
-      "legal-warning": "* Gemäß dem Gesetz über Informatik und Freiheiten und als Verantwortlicher für die Datenverarbeitung sollten Sie darauf achten, keine besonders identifizierenden oder bedeutungsvollen Daten zu verlangen, wenn dies nicht absolut notwendig ist. Die Sozialversicherungsnummer (NIR) sollte ebenso wie alle anderen sensiblen Daten nicht verwendet werden.",
+      "legal-warning": "* Im Rahmen der Datenschutzbestimmungen und als Verantwortliche:r für die Datenverarbeitung achte bitte darauf, keine besonders identifizierenden oder sensiblen Daten abzufragen, sofern dies nicht absolut notwendig ist. Die Sozialversicherungsnummer sowie alle sensiblen Daten sind strikt untersagt.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Wenn Sie Mehrfachversand wählen, kann der Teilnehmer die Kampagne mehrmals wiederholen, indem er den Code erneut eingibt. Sie haben dann Zugriff auf alle Ergebnisse.",
-          "question-label": "Möchten Sie den Teilnehmern die Möglichkeit geben, ihre Ergebnisse mehrmals einzureichen?"
+          "info": "Wenn du die mehrfache Übermittlung aktivierst, können die Teilnehmer:innen die Kampagne mehrfach durchführen, indem sie den Code erneut eingeben. Du hast Zugriff auf alle Ergebnisse.",
+          "question-label": "Möchtest du den Teilnehmer:innen erlauben, ihre Ergebnisse mehrfach zu übermitteln?"
         },
-        "info-title": "Mehrfachsendung",
-        "knowledge-elements-resettable": "Im Rahmen dieses Parcours kann der Teilnehmer versuchen, seine Ergebnisse zu verbessern, indem er alle Fragen des Parcours wiederholt.",
+        "info-title": "Mehrfache Übermittlung",
+        "knowledge-elements-resettable": "Im Rahmen dieses Parcours kann der:die Teilnehmer:in versuchen, seine:ihre Ergebnisse zu verbessern, indem er:sie alle Fragen des Parcours erneut beantwortet.",
         "profiles": {
-          "info": "Wenn Sie sich für den Mehrfachversand entscheiden, kann der Teilnehmer sein Profil mehrmals versenden, indem er den Kampagnencode erneut eingibt. Innerhalb von Pix Orga finden Sie das zuletzt gesendete Profil.",
-          "question-label": "Möchten Sie den Teilnehmern die Möglichkeit geben, ihr Profil mehrmals zu versenden?"
+          "info": "Wenn du die mehrfache Übermittlung aktivierst, können die Teilnehmer:innen ihr Profil mehrfach übermitteln, indem sie den Kampagnencode erneut eingeben. In Pix Orga findest du jeweils das zuletzt übermittelte Profil.",
+          "question-label": "Möchtest du den Teilnehmer:innen erlauben, ihr Profil mehrfach zu übermitteln?"
         }
       },
       "name": {
         "label": "Name der Kampagne"
       },
-      "no": "Nicht",
+      "no": "Nein",
       "owner": {
-        "info": "Der Besitzer der Kampagne sowie die Administratoren dieser Organisation, sind die einzigen Personen, die diese Kampagne bearbeiten oder archivieren können.",
-        "label": "Besitzer der Kampagne",
-        "placeholder": "Name und Vorname des Besitzers",
-        "search-label": "Nach einem Besitzer suchen",
-        "search-placeholder": "Nach einem Besitzer suchen",
-        "title": "Besitzer der Kampagne"
+        "info": "Nur der:die Eigentümer:in der Kampagne sowie die Administrator:innen dieser Organisation können diese Kampagne bearbeiten oder archivieren.",
+        "label": "Eigentümer:in der Kampagne",
+        "placeholder": "Vor- und Nachname des:der Eigentümer:in",
+        "search-label": "Eigentümer:in suchen",
+        "search-placeholder": "Eigentümer:in suchen",
+        "title": "Eigentümer:in der Kampagne"
       },
       "purpose": {
-        "assessment": "Bewerten Sie die Teilnehmer",
-        "assessment-info": "Bei einer Evaluierungskampagne werden die Teilnehmer zu bestimmten Themen getestet.",
-        "combined-course": "Kompetenzen der Teilnehmer entwickeln",
-        "combined-course-info": "Ein Lernpfad hilft den Teilnehmern, neue Kompetenzen zu erwerben.",
+        "assessment": "Teilnehmer:innen bewerten",
+        "assessment-info": "Eine Bewertungskampagne ermöglicht es, die Teilnehmer:innen zu bestimmten Themen zu testen.",
+        "combined-course": "Kompetenzen der Teilnehmer:innen entwickeln",
+        "combined-course-info": "Ein Lernparcours ermöglicht es, die Teilnehmer:innen beim Erwerb neuer Kompetenzen zu begleiten.",
         "exam": "Testmodus [beta]",
-        "exam-info": "Eine Kampagne vom Typ \"Testmodus\" ermöglicht es, die Teilnehmer zu bestimmten Themen zu testen, ohne das Nutzerprofil zu berücksichtigen oder zu beeinflussen. Die vorgeschlagenen Tests werden für jeden Teilnehmer entsprechend seinem Fortschritt auf der Strecke angepasst.",
-        "label": "Was ist das Ziel Ihrer Kampagne?",
-        "profiles-collection": "Sammeln Sie die Pix-Profile der Teilnehmer",
-        "profiles-collection-info": "Eine Profilsammelkampagne ruft die Profile der Teilnehmer ab: Niveaustufen pro Fertigkeit und Pix-Score.",
-        "profiles-collection-info-certificability-calculation": "Der Status Zertifizierbar wird automatisch auf der Registerkarte '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Schüler'</a>' aktualisiert.",
+        "exam-info": "Eine Kampagne vom Typ „Testmodus“ ermöglicht es, die Teilnehmer:innen zu bestimmten Themen zu testen, ohne das Nutzerprofil zu berücksichtigen und ohne dieses zu beeinflussen. Die angebotenen Aufgaben werden für jede:n Teilnehmer:in individuell an seinen:ihren Fortschritt im Parcours angepasst.",
+        "label": "Was ist das Ziel deiner Kampagne?",
+        "profiles-collection": "Pix-Profile der Teilnehmer:innen sammeln",
+        "profiles-collection-info": "Eine Kampagne zur Profilsammlung ermöglicht es, die Profile der Teilnehmer:innen einzuholen: Niveaustufen pro Kompetenz und Pix-Punktzahl.",
+        "profiles-collection-info-certificability-calculation": "Der Status „Zertifizierbar“ wird im Tab '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Schüler:innen'</a>' automatisch aktualisiert.",
         "title": "Ziel"
       },
       "settings": {
@@ -836,21 +836,21 @@
       "tags": {
         "BACK_TO_SCHOOL": "Parcours zum Schulanfang / 6. Klasse",
         "COMPETENCES": "Die 16 Kompetenzen",
-        "CUSTOM": "Maßgeschneiderte Pfade",
-        "DISCIPLINE": "Disziplinarisch",
-        "OTHER": "Andere",
+        "CUSTOM": "Maßgeschneiderter Parcours",
+        "DISCIPLINE": "Fachspezifisch",
+        "OTHER": "Sonstige",
         "PIX_PLUS": "Pix+",
         "PREDEFINED": "Vordefinierte Pfade",
         "SUBJECT": "Themen",
-        "TARGETED": "Gezielte Pfade"
+        "TARGETED": "Zielgerichtete Parcours"
       },
-      "tags-title": "Suche filtern :",
-      "target-profiles-category-label": "Strecken nach Kategorien filtern",
+      "tags-title": "Suche filtern:",
+      "target-profiles-category-label": "Parcours nach Kategorien filtern",
       "target-profiles-category-placeholder": "Kategorien",
-      "target-profiles-label": "Eine Strecke auswählen",
-      "target-profiles-list-label": "Was möchten Sie testen?",
+      "target-profiles-label": "Parcours auswählen",
+      "target-profiles-list-label": "Was möchtest du testen?",
       "target-profiles-search-placeholder": "Nach Namen suchen",
-      "title": "Erstellen einer Kampagne",
+      "title": "Kampagne erstellen",
       "yes": "Ja"
     },
     "campaign-individual-results": {
@@ -868,74 +868,74 @@
       "campaign-name": "Name der Kampagne",
       "landing-page-text": {
         "label": "Text auf der Startseite",
-        "sublabel": "Dieses Feld wird den Teilnehmern der Kampagne angezeigt."
+        "sublabel": "Dieses Feld wird den Teilnehmer:innen der Kampagne angezeigt."
       },
       "owner": {
-        "info": "Der Besitzer der Kampagne sowie die Administratoren dieser Organisation, sind die einzigen Personen, die diese Kampagne bearbeiten und archivieren können.",
-        "label": "Besitzer der Kampagne",
-        "placeholder": "Name und Vorname des Besitzers",
-        "title": "Besitzer der Kampagne"
+        "info": "Nur der:die Eigentümer:in der Kampagne sowie die Administrator:innen dieser Organisation können diese Kampagne bearbeiten und archivieren.",
+        "label": "Eigentümer:in der Kampagne",
+        "placeholder": "Vor- und Nachname des:der Eigentümer:in",
+        "title": "Eigentümer:in der Kampagne"
       },
       "personalised-test-title": {
-        "label": "Titel der Strecke",
-        "sublabel": "Dieses Feld wird den Teilnehmern der Kampagne angezeigt."
+        "label": "Titel des Parcours",
+        "sublabel": "Dieses Feld wird den Teilnehmer:innen der Kampagne angezeigt."
       },
-      "title": "Bearbeiten einer Kampagne"
+      "title": "Kampagne bearbeiten"
     },
     "campaign-results": {
       "average": "Durchschnittliche Ergebnisse",
       "filters": {
-        "aria-label": "Filter nach Beteiligungen",
-        "participations-count": "{count, plural, =0 {0 Teilnehmer} =1 {1 Teilnehmer} other {{count} Teilnehmer}}",
+        "aria-label": "Filter für Teilnahmen",
+        "participations-count": "{count, plural, =0 {0 Teilnehmer:innen} =1 {1 Teilnehmer:in} other {{count} Teilnehmer:innen}}",
         "type": {
-          "badges": "Erhaltene Abzeichen",
+          "badges": "Erhaltene Badges",
           "groups": {
             "empty": "Keine Gruppe",
             "title": "Gruppen"
           },
-          "stages": "Lager",
+          "stages": "Niveaustufen",
           "status": {
-            "empty": "Alle Beteiligungen",
+            "empty": "Alle Teilnahmen",
             "title": "Status"
           },
-          "unacquired-badges": "Nicht erhaltene Abzeichen"
+          "unacquired-badges": "Nicht erhaltene Badges"
         }
       },
       "result": "Ergebnis",
       "table": {
         "badge-tooltip": {
-          "acquired": "Erworbenes",
-          "unacquired": "Nicht erworben"
+          "acquired": "Erhalten",
+          "unacquired": "Nicht erhalten"
         },
-        "caption": "Diese Tabelle enthält eine Liste der Teilnehmer, die ihre Ergebnisse freigegeben haben. Sie zeigt für jeden Teilnehmer seinen Vor- und Nachnamen sowie die Elemente der Ergebnisse.",
+        "caption": "Diese Tabelle enthält die Liste der Teilnehmer:innen, die ihre Ergebnisse geteilt haben. Sie zeigt für jede:n Teilnehmer:in den Nachnamen, Vornamen und Ergebniselemente an.",
         "column": {
-          "ariaSharedResultCount": "Anzahl der gesendeten Ergebnisse",
-          "badges": "Namensschilder",
+          "ariaSharedResultCount": "Anzahl der übermittelten Ergebnisse",
+          "badges": "Badges",
           "evolution": "Entwicklung",
           "first-name": "Vorname",
-          "last-name": "Name",
+          "last-name": "Nachname",
           "results": {
             "label": "Ergebnisse",
-            "on-hold": " Wartet auf den Versand",
-            "under-test": "In der Testphase"
+            "on-hold": "Wartet auf Übermittlung",
+            "under-test": "Test läuft"
           },
-          "sharedResultCount": "Nb gesendete Ergebnisse"
+          "sharedResultCount": "Anz. übermittelter Ergebnisse"
         },
         "empty": "Keine Teilnahme",
         "evolution": {
-          "decrease": "In Rückschritt",
-          "increase": "Auf dem Vormarsch",
-          "stable": "Konstant",
+          "decrease": "Verschlechtert",
+          "increase": "Verbessert",
+          "stable": "Unverändert",
           "unavailable": "Nicht verfügbar"
         },
         "evolution-tooltip": {
-          "content": "Entwicklung des Teilnehmers zwischen seinen letzten beiden geteilten Ergebnissen."
+          "content": "Entwicklung des:der Teilnehmer:in zwischen den beiden zuletzt geteilten Ergebnissen."
         },
         "title": "Liste der eingegangenen Ergebnisse"
       },
       "tested-items": "Bewertete Lernergebnisse",
       "title": "Ergebnisse",
-      "validated-items": "Validierte Lernergebnisse"
+      "validated-items": "Bestätigte Lernergebnisse"
     },
     "campaign-settings": {
       "actions": {
@@ -949,7 +949,7 @@
       "campaign-type": {
         "assessment": "Bewertungskampagne",
         "exam": "Test-Kampagne [Beta]",
-        "profiles-collection": "Kampagne zum Sammeln von Profilen",
+        "profiles-collection": "Kampagne zur Profilsammlung",
         "title": "Art der Kampagne"
       },
       "delete-confirmation-modal": {
@@ -964,35 +964,35 @@
       "external-user-id-label": "Bezeichnung der zusätzlichen Kennung",
       "external-user-id-types": {
         "email": "E-Mail-Adresse",
-        "string": "Andere"
+        "string": "Sonstige"
       },
       "landing-page-text": "Text auf der Startseite",
       "multiple-sendings": {
         "status": {
-          "disabled": "Nicht",
+          "disabled": "Nein",
           "enabled": "Ja"
         },
-        "title": "Mehrfachsendung",
+        "title": "Mehrfache Übermittlung",
         "tooltip": {
-          "aria-label": "Beschreibung der Mehrfachsendung",
-          "text": "Wenn der Mehrfachversand aktiviert ist, kann der Teilnehmer seine Teilnahme durch erneute Eingabe des Kampagnencodes mehrfach versenden."
+          "aria-label": "Beschreibung der mehrfachen Übermittlung",
+          "text": "Wenn die mehrfache Übermittlung aktiviert ist, kann der:die Teilnehmer:in seine:ihre Teilnahme mehrfach übermitteln, indem er:sie den Kampagnencode erneut eingibt."
         }
       },
-      "personalised-test-title": "Titel der Strecke",
+      "personalised-test-title": "Titel des Parcours",
       "reset-to-zero": {
         "status": {
-          "disabled": "Nicht",
+          "disabled": "Nein",
           "enabled": "Ja"
         },
-        "title": "Auf Null zurücksetzen",
+        "title": "Zurücksetzen",
         "tooltip": {
           "aria-label": "Beschreibung von Zurücksetzen",
-          "text": "Wenn die Rückstellung aktiviert ist, kann der Teilnehmer die gesamte Strecke noch einmal durchlaufen und seine Ergebnisse einsenden, und zwar mehrmals, indem er den Kampagnencode erneut eingibt."
+          "text": "Wenn das Zurücksetzen aktiviert ist, kann der:die Teilnehmer:in seinen:ihren Parcours vollständig erneut durchlaufen und seine:ihre Ergebnisse mehrfach übermitteln, indem er:sie den Kampagnencode erneut eingibt."
         }
       },
       "target-profile": {
         "title": "Parcours",
-        "tooltip": "Beschreibung der Strecke"
+        "tooltip": "Beschreibung des Parcours"
       },
       "title": "Einstellungen"
     },
@@ -1001,45 +1001,45 @@
         "campaign": {
           "archived": "Archiviert",
           "label": "Aktive oder archivierte Kampagnen anzeigen",
-          "ongoing": "Aktive"
+          "ongoing": "Aktiv"
         },
         "create": "Eine Kampagne erstellen"
       },
       "action-bar": {
         "delete-button": "Löschen",
-        "error-message": "{count, plural, =1 {Ein Fehler ist aufgetreten, die Kampagne wurde nicht aus der Liste entfernt.} other {Ein Fehler ist aufgetreten, die {count} ausgewählten Kampagnen wurden nicht aus der Liste entfernt.}}",
+        "error-message": "{count, plural, =1 {Es ist ein Fehler aufgetreten: Die Kampagne wurde nicht aus der Liste gelöscht.} other {Es ist ein Fehler aufgetreten: Die {count} ausgewählten Kampagnen wurden nicht aus der Liste gelöscht.}}",
         "information": "{count, plural, =1 {{count} ausgewählte Kampagne} other {{count} ausgewählte Kampagnen}}",
-        "success-message": "{count, plural, =1 {Die Kampagne (sowie ihre Ergebnisse) wurde tatsächlich aus der Liste entfernt.} other {Die {count}ausgewählten Kampagnen (sowie ihre Ergebnisse) wurden tatsächlich aus der Liste entfernt.}}."
+        "success-message": "{count, plural, =1 {Die Kampagne (sowie ihre Ergebnisse) wurde erfolgreich aus der Liste gelöscht.} other {Die {count} ausgewählten Kampagnen (sowie ihre Ergebnisse) wurden erfolgreich aus der Liste gelöscht.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "{count, plural, =1 {Ich bestätige, dass ich die Auswirkungen der Löschung gut verstanden habe.} other {Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.}}",
+        "confirmation-checkbox": "Ich bestätige, die Auswirkungen der {count} Löschungen verstanden zu haben",
         "content": {
           "footer": "Achtung: Diese Aktion kann nicht rückgängig gemacht werden.",
-          "header": "{count, plural, =1 {Diese Kampagne wird nicht mehr sichtbar sein} other {Diese Kampagnen werden nicht mehr sichtbar sein}} in Pix Orga.",
-          "main-participation-prevent": "Alle Teilnahmen an {count, plural, =1 {dieser Kampagne} other {dieser Kampagnen}} und deren Ergebnisse werden gelöscht."
+          "header": "{count, plural, =1 {Diese Kampagne wird} other {Diese Kampagnen werden}} in Pix Orga nicht mehr sichtbar sein.",
+          "main-participation-prevent": "Alle Teilnahmen an {count, plural, =1 {dieser Kampagne} other {diesen Kampagnen}} und ihre Ergebnisse werden gelöscht."
         },
-        "title": "{count, plural, =1 {Sind Sie sicher, dass Sie die ausgewählte Kampagne löschen möchten?} other {Sind Sie sicher, dass Sie die ausgewählten '<strong>'{count}'</strong>' Kampagnen löschen möchten?}}"
+        "title": "{count, plural, =1 {Bist du sicher, dass du die ausgewählte Kampagne löschen möchtest?} other {Bist du sicher, dass du die ''{count}'' ausgewählten Kampagnen löschen möchtest?}}"
       },
       "filter": {
-        "by-name": "Nach einer Kampagne suchen",
-        "by-owner": "Nach einem Besitzer suchen",
-        "legend": "Filter für die Kampagnentabelle, Eingabefelder ermöglichen es, die Tabelle nach dem Namen der Kampagne und nach dem Namen des Eigentümers zu filtern. Über Schaltflächen können Sie nach aktiven und archivierten Kampagnen filtern.",
+        "by-name": "Kampagne suchen",
+        "by-owner": "Eigentümer:in suchen",
+        "legend": "Filter für die Kampagnentabelle: Eingabefelder ermöglichen das Filtern der Tabelle nach Kampagnenname und Name des:der Eigentümer:in. Schaltflächen ermöglichen das Filtern nach aktiven und archivierten Kampagnen.",
         "results": "{total, plural, =0 {0 Kampagne} =1 {1 Kampagne} other {{total, number} Kampagnen}}"
       },
-      "navigation": "Navigation im Abschnitt Kampagnen",
-      "no-campaign": "Keine Kampagne, klicken Sie zu Beginn auf die Schaltfläche 'Kampagne erstellen'.",
+      "navigation": "Navigation im Bereich Kampagnen",
+      "no-campaign": "Keine Kampagnen vorhanden. Klicke auf die Schaltfläche „Kampagne erstellen“, um zu starten.",
       "table": {
         "column": {
           "code": "Code",
-          "created-by": "Eigentümer",
+          "created-by": "Eigentümer:in",
           "created-on": "Erstellt am",
-          "mainCheckbox": "Ganze Spalte markieren/aufheben",
+          "mainCheckbox": "Gesamte Spalte auswählen/abwählen",
           "name": "Name der Kampagne",
-          "participants": "Teilnehmer",
-          "results": "Erhaltene Ergebnisse"
+          "participants": "Teilnehmer:innen",
+          "results": "Eingegangene Ergebnisse"
         },
-        "description-all-campaigns": "Diese Tabelle enthält eine Liste aller Kampagnen, die in Ihrem Pix Orga-Bereich erstellt wurden. Sie zeigt für jede Kampagne den Code, den Eigentümer, das Erstellungsdatum, die Anzahl der Teilnehmer und die Anzahl der erhaltenen Ergebnisse.",
-        "description-my-campaigns": "Diese Tabelle enthält eine Liste der Kampagnen, die Sie besitzen. Sie zeigt für jede Kampagne den Code, das Erstellungsdatum, die Anzahl der Teilnehmer und die Anzahl der erhaltenen Ergebnisse.",
+        "description-all-campaigns": "Diese Tabelle enthält die Liste aller in deinem Pix Orga-Bereich erstellten Kampagnen. Sie zeigt für jede Kampagne den Code, den:die Eigentümer:in, das Erstellungsdatum, die Anzahl der Teilnehmer:innen und die Anzahl der eingegangenen Ergebnisse an.",
+        "description-my-campaigns": "Diese Tabelle enthält die Liste der Kampagnen, deren Eigentümer:in du bist. Sie zeigt für jede Kampagne den Code, das Erstellungsdatum, die Anzahl der Teilnehmer:innen und die Anzahl der eingegangenen Ergebnisse an.",
         "empty": "Keine Kampagne"
       },
       "tabs": {
@@ -1053,12 +1053,12 @@
         "modules-count": "{count, plural, =0 {Kein Modul} =1 {{count} Modul} other {{count} Module}}",
         "simplified-access": "Zugang ohne Konto",
         "tag": {
-          "blueprint": "Lernpfad",
-          "target-profile": "Bewertungspfad"
+          "blueprint": "Lernparcours",
+          "target-profile": "Parcours"
         },
-        "tubes-count": "{count, plural, =0 {Kein Thema} =1 {{count} thema} other {{count} themen}}"
+        "tubes-count": "{count, plural, =0 {Kein Thema} =1 {{count} Thema} other {{count} Themen}}"
       },
-      "empty-state": "Derzeit sind keine Kurse verfügbar. Kontaktieren Sie Pix, um welche zu erhalten.",
+      "empty-state": "Derzeit ist kein Parcours verfügbar. Kontaktiere Pix, um welche zu erhalten.",
       "empty-state-with-filters": "Keine Kurse entsprechen Ihren Suchkriterien.",
       "filters": {
         "areas": {
@@ -1066,7 +1066,7 @@
           "label": "Bereiche",
           "placeholder": "{count, plural, =0 {Bereiche} =1 {Bereich ({count})} other {Bereiche ({count})}}"
         },
-        "aria-label": "Filter nach Kursen",
+        "aria-label": "Filter für Parcours",
         "categories": {
           "all": "Alle Kategorien",
           "empty": "Keine Kategorie",
@@ -1078,10 +1078,10 @@
           "placeholder": "{count, plural, =0 {Kompetenzen} =1 {Kompetenz ({count})} other {Kompetenzen ({count})}}"
         },
         "name": {
-          "label": "Name des Kurses",
+          "label": "Name des Parcours",
           "placeholder": "Nach Titel suchen"
         },
-        "nb-result": "{count, plural, =0 {Kein Kurs} =1 {{count} Kurs} other {{count} Kurse}}"
+        "nb-result": "{count, plural, =0 {Kein Parcours} =1 {{count} Parcours} other {{count} Parcours}}"
       },
       "modal": {
         "associated-badges": "Zugehörige Abzeichen",
@@ -1106,39 +1106,39 @@
       },
       "tab-filters": {
         "all": "Alle",
-        "blueprints": "Lernen",
-        "label": "Kurstyp",
-        "target-profiles": "Assessment"
+        "blueprints": "Lernparcours",
+        "label": "Art des Parcours",
+        "target-profiles": "Parcours"
       },
-      "title": "Kurskatalog"
+      "title": "Parcoursübersicht"
     },
     "certifications": {
-      "description": "Wählen Sie die Klasse aus, für die Sie die Zertifizierungsergebnisse exportieren (.csv) oder die Zertifikate herunterladen (.pdf) möchten.\n Sie können diese Liste filtern, indem Sie den Namen der Klasse direkt in das Feld eingeben.",
+      "description": "Wähle die Klasse aus, für die du die Zertifizierungsergebnisse exportieren (.csv) oder die Zertifikate herunterladen (.pdf) möchtest.\nDu kannst diese Liste filtern, indem du den Namen der Klasse direkt in das Feld eingibst.",
       "documentation-link": "https://cloud.pix.fr/s/oqnYJWHoSXz8LJk",
       "documentation-link-label": "Interpretation der Ergebnisse",
-      "documentation-link-notice": "Unter diesem Link finden Sie einige Elemente, um die Ergebnisse zu interpretieren:",
-      "download-attestations-button": "Zeugnisse herunterladen",
+      "documentation-link-notice": "Unter folgendem Link findest du einige Hilfestellungen zur Interpretation der Ergebnisse:",
+      "download-attestations-button": "Zertifikate herunterladen",
       "download-button": "Ergebnisse exportieren",
       "errors": {
         "invalid-division": "Die Klasse {selectedDivision} existiert nicht.",
         "no-certificates": "Kein Zertifikat für die Klasse {selectedDivision}.",
         "no-results": "Keine Zertifizierungsergebnisse für die Klasse {selectedDivision}."
       },
-      "no-students-imported-yet": "Auf dieser Registerkarte finden Sie die Ergebnisse und Zeugnisse der Schüler. In einem ersten Schritt müssen Sie die Schülerdatenbank Ihrer Schule importieren.",
+      "no-students-imported-yet": "In diesem Tab findest du die Ergebnisse und Zertifikate der Schüler:innen. Du musst zuerst die Schülerdatenbank deiner Schule importieren.",
       "select-label": "Klasse",
-      "title": "Ergebnisse der Zertifizierung"
+      "title": "Zertifizierungsergebnisse"
     },
     "combined-course": {
-      "campaigns": "{count, plural, =1 {Details der Kampagne ansehen} other {Details der Kampagne Nr.{index}}} ansehen",
+      "campaigns": "{count, plural, =1 {Kampagnendetails anzeigen} other {Details der Kampagne Nr. {index} anzeigen}}",
       "filters": {
-        "by-status": "Suche nach dem Status der Partizipation",
+        "by-status": "Nach Teilnahmestatus suchen",
         "status": {
           "COMPLETED": "Abgeschlossen",
-          "STARTED": "In Arbeit",
-          "placeholder": "Alle Statuten"
+          "STARTED": "In Bearbeitung",
+          "placeholder": "Alle Status"
         }
       },
-      "introduction": "Die Lernpfade verknüpfen Bewertungen und personalisierte Lernmodule, die eine pädagogische Anpassung auf der Grundlage des Niveaus jedes Teilnehmers ermöglichen.",
+      "introduction": "Lernparcours verbinden Einstufungen mit personalisierten Lernmodulen und ermöglichen so eine pädagogische Anpassung auf Basis des Niveaus jeder:jedes Teilnehmer:in.",
       "participation-detail": {
         "breadcrumb": "Teilnahme von {firstName} {lastName}",
         "column": {
@@ -1151,42 +1151,42 @@
         "step-label": "Schritt {number}."
       },
       "statistics": {
-        "completed-participations": "Abgeschlossene Beteiligungen",
-        "total-participations": "Total Beteiligungen"
+        "completed-participations": "Abgeschlossene Teilnahmen",
+        "total-participations": "Gesamtzahl der Teilnahmen"
       },
       "table": {
-        "campaign-completion": "{nbItemsCompleted, plural, =0 {Keine abgeschlossene Kampagne auf {nbItems}} =1 {Eine abgeschlossene Kampagne auf {nbItems}} other {{nbItemsCompleted} Abgeschlossene Kampagnen auf {nbItems}}}.",
+        "campaign-completion": "{nbItemsCompleted, plural, =0 {Keine von {nbItems} Kampagnen abgeschlossen.} =1 {Eine von {nbItems} Kampagnen abgeschlossen.} other {{nbItemsCompleted} von {nbItems} Kampagnen abgeschlossen.}}",
         "column": {
           "campaigns": "Kampagnen",
           "first-name": "Vorname",
           "last-name": "Name",
-          "modules": "Module",
+          "modules": "Nachname",
           "reward": "Bescheinigung",
           "status": "Status"
         },
         "description": "Listen der Teilnahmen am Parcours",
-        "module-completion": "{nbItemsCompleted, plural, =0 {Kein Modul abgeschlossen auf {nbItems}} =1 {Ein Modul abgeschlossen auf {nbItems}} other {{nbItemsCompleted} Module abgeschlossen auf {nbItems}}}.",
-        "no-module": "Keine Module empfohlen.",
+        "module-completion": "{nbItemsCompleted, plural, =0 {Kein Modul von {nbItems} abgeschlossen.} =1 {Ein Modul von {nbItems} abgeschlossen.} other {{nbItemsCompleted} von {nbItems} Modulen abgeschlossen.}}",
+        "no-module": "Keine empfohlenen Module.",
         "rewards": {
           "in-progress": "Steht noch aus",
           "not-obtained": "Nicht erhalten",
           "obtained": "Erhalten"
         },
         "tooltip": {
-          "campaigns-column": "'x / y' gibt den Fortschritt des Teilnehmers an: Er hat x Kampagnen von insgesamt y abgeschlossen. Zum Beispiel bedeutet 1/2, dass er 1 von 2 Kampagnen abgeschlossen hat.",
-          "modules-column": "'x / y' zeigt den Fortschritt des Teilnehmers an: Er hat x Module von insgesamt y abgeschlossen. Die Gesamtzahl der Module unterscheidet sich für jeden, je nach den persönlichen Empfehlungen."
+          "campaigns-column": "„x / y“ zeigt den Fortschritt des:der Teilnehmer:in an: Er:sie hat x von insgesamt y Kampagnen beendet. Zum Beispiel bedeutet 1/2, dass 1 von 2 Kampagnen beendet wurde.",
+          "modules-column": "„x / y“ zeigt den Fortschritt des:der Teilnehmer:in an: Er:sie hat x von insgesamt y Modulen beendet. Die Gesamtzahl der Module unterscheidet sich je nach den personalisierten Empfehlungen."
         }
       }
     },
     "combined-courses": {
-      "empty-state": "Derzeit sind keine Lernerpfade verfügbar.",
+      "empty-state": "Derzeit ist kein Lernparcours verfügbar.",
       "table": {
-        "caption": "Liste der Lernpfade",
+        "caption": "Liste der Lernparcours",
         "column": {
           "code": "Code",
-          "completed": "Teilnehmer, die abgeschlossen haben",
-          "name": "Name der Strecke",
-          "participants": "Teilnehmer"
+          "completed": "Abgeschlossen von",
+          "name": "Name des Parcours",
+          "participants": "Teilnehmer:innen"
         }
       }
     },
@@ -1200,119 +1200,119 @@
         },
         "fields": {
           "email": {
-            "error": "Ihre E-Mail-Adresse ist ungültig.",
+            "error": "Deine E-Mail-Adresse ist ungültig.",
             "label": "E-Mail-Adresse",
-            "placeholder": "z.B.: jean.dupont@email.com"
+            "placeholder": "z. B. max.mustermann@email.com"
           },
           "firstname": {
-            "error": "Ihr Vorname ist nicht ausgefüllt.",
+            "error": "Dein Vorname ist nicht angegeben.",
             "label": "Vorname",
             "placeholder": "z.B. Johannes"
           },
           "lastname": {
-            "error": "Ihr Name ist nicht ausgefüllt.",
-            "label": "Name",
-            "placeholder": "z.B.: Dupont"
+            "error": "Dein Nachname ist nicht angegeben.",
+            "label": "Nachname",
+            "placeholder": "z. B. Schneider"
           },
-          "legend": "Informationen für die Anmeldung erforderlich.",
+          "legend": "Erforderliche Information für die Registrierung.",
           "password": {
-            "completed-message": "{ rulesCompleted } auf { rulesCount } abgeschlossen.",
-            "instructions-label": "Ihr Passwort muss den folgenden Regeln entsprechen:",
+            "completed-message": "{ rulesCompleted } von { rulesCount } erfüllt.",
+            "instructions-label": "Dein Passwort muss folgende Regeln erfüllen:",
             "label": "Passwort"
           }
         },
-        "submit": "Ich melde mich an",
-        "subtitle": "um auf Ihren Pix Orga-Bereich zuzugreifen",
-        "title": "Melden Sie sich bei Pix an"
+        "submit": "Ich registriere mich",
+        "subtitle": "um auf deinen Pix Orga-Bereich zuzugreifen",
+        "title": "Registriere dich bei Pix"
       }
     },
     "join-request-form": {
-      "firstname": "Ihr Vorname",
-      "lastname": "Ihr Name",
+      "firstname": "Dein Vorname",
+      "lastname": "Dein Nachname",
       "legal-information": {
         "link-text": "Mehr über meine Rechte erfahren.",
         "link-url": "https://pix.fr/dp-formulaire-recuperation-pixorga-sco",
-        "text": "Die auf diesem Formular gesammelten Informationen werden in einer Datei gespeichert, die von der GIP Pix im Auftrag des Bildungsministeriums als Verantwortlicher für die Verarbeitung verarbeitet wird, um Ihrer Schule den Zugang zu ihrem Pix Orga-Bereich zu ermöglichen, indem sie ihr eine Einladung zum Beitritt zu diesem Bereich sendet."
+        "text": "Die in diesem Formular eingegebenen Daten werden vom GIP Pix im Auftrag des Bildungsministeriums verarbeitet, um deiner Schule eine Einladung zu schicken und ihr den Zugang zu Pix Orga zu ermöglichen."
       },
       "organization-code": "UAI/RNE der Einrichtung"
     },
     "login": {
-      "join-invitation": "Sie sind eingeladen, sich anzuschließen: {organizationName}.",
+      "join-invitation": "Du bist eingeladen beizutreten: {organizationName}",
       "signup": {
-        "label": "Auf Pix registrieren"
+        "label": "Bei Pix registrieren"
       },
-      "title": "Melden Sie sich an",
-      "with-pix-account": "mit Ihrem Pix-Konto"
+      "title": "Melde dich an",
+      "with-pix-account": "mit deinem Pix-Konto"
     },
     "login-form": {
-      "active-or-retrieve": "Aktivieren oder werden Sie Administrator des Pix Orga-Bereichs Ihrer Schule",
-      "admin-role-question": "Sind Sie Schulleitungspersonal oder Schulleiter?",
+      "active-or-retrieve": "Aktiviere den Pix Orga-Bereich deiner Schule oder werde dessen Administrator:in",
+      "admin-role-question": "Bist du Schulleiter:in oder Mitglied der Schulleitung?",
       "associate-account": "Mein Konto verknüpfen",
       "email": {
         "label": "E-Mail-Adresse",
-        "placeholder": "z.B.: jean.dupont@email.com"
+        "placeholder": "z. B. johannes.schneider@email.com"
       },
       "errors": {
-        "access-not-allowed": "Der Zugang zu Pix Orga ist auf eingeladene Mitglieder beschränkt. Jeder Bereich wird von einem Pix Orga-Administrator verwaltet, der der Organisation, die ihn nutzt, eigen ist. Kontaktieren Sie ihn, um von ihm eingeladen zu werden.",
-        "empty-email": "Ihre E-Mail-Adresse ist nicht ausgefüllt.",
-        "empty-password": "Ihr Passwort ist nicht ausgefüllt.",
-        "invalid-email": "Ihre E-Mail-Adresse ist ungültig.",
+        "access-not-allowed": "Der Zugriff auf Pix Orga ist auf eingeladene Mitglieder beschränkt. Jeder Bereich wird von einer eigenen Pix Orga-Administrator:in der jeweiligen Organisation verwaltet. Kontaktiere diese Person, um eine Einladung zu erhalten.",
+        "empty-email": "Deine E-Mail-Adresse ist nicht angegeben.",
+        "empty-password": "Dein Passwort ist nicht angegeben.",
+        "invalid-email": "Deine E-Mail-Adresse ist ungültig.",
         "status": {
           "404": "Die eingegebene E-Mail-Adresse und/oder das Passwort sind falsch.",
-          "409": "Diese Einladung wurde bereits angenommen oder abgesagt."
+          "409": "Diese Einladung wurde bereits angenommen oder storniert."
         }
       },
       "forgot-password": "Passwort vergessen?",
-      "invitation-already-accepted": "Diese Einladung wurde bereits angenommen. Melden Sie sich an oder wenden Sie sich an den Administrator Ihres Pix Orga-Bereichs.",
-      "invitation-not-found": "Diese Einladung wurde nicht gefunden. Kontaktieren Sie den Administrator Ihres Pix Orga-Bereichs.",
-      "invitation-was-cancelled": "Diese Einladung ist nicht mehr gültig. Wenden Sie sich an den Administrator Ihres Pix Orga-Bereichs.",
-      "login": "Ich logge mich ein",
+      "invitation-already-accepted": "Diese Einladung wurde bereits angenommen. Melde dich an oder kontaktiere die Administrator:in deines Pix Orga-Bereichs.",
+      "invitation-not-found": "Diese Einladung wurde nicht gefunden. Kontaktiere die Administrator:in deines Pix Orga-Bereichs.",
+      "invitation-was-cancelled": "Diese Einladung ist nicht mehr gültig. Kontaktiere die Administrator:in deines Pix Orga-Bereichs.",
+      "login": "Ich melde mich an",
       "password": "Passwort"
     },
     "login-or-register": {
       "login-form": {
-        "button": "Sich anmelden",
+        "button": "Anmelden",
         "title": "Ich habe bereits ein PIX-Konto"
       },
       "register-form": {
-        "button": "Anmelden",
+        "button": "Registrieren",
         "errors": {
-          "default": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
-          "email-already-exists": "Diese E-Mail-Adresse ist bereits registriert. Melden Sie sich an.",
+          "default": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es später erneut.",
+          "email-already-exists": "Diese E-Mail-Adresse ist bereits registriert. Bitte melde dich an.",
           "invalid-or-already-used-email": "Ungültige oder bereits verwendete E-Mail-Adresse"
         },
         "fields": {
           "button": {
-            "label": "Ich melde mich an"
+            "label": "Ich registriere mich"
           },
           "cgu": {
             "accept": "Ich akzeptiere die",
             "and": "und die",
-            "aria-label": "Akzeptieren Sie die Nutzungsbedingungen von Pix",
+            "aria-label": "Nutzungsbedingungen von Pix akzeptieren",
             "data-protection-policy": "Datenschutzrichtlinie",
-            "error": "Sie müssen den Nutzungsbedingungen von Pix und der Datenschutzrichtlinie zustimmen, um ein Konto zu erstellen.",
+            "error": "Du musst die Nutzungsbedingungen von Pix und die Datenschutzerklärung akzeptieren, um ein Konto zu erstellen.",
             "terms-of-use": "Nutzungsbedingungen von Pix"
           },
           "email": {
-            "error": "Ihre E-Mail-Adresse ist ungültig.",
+            "error": "Deine E-Mail-Adresse ist ungültig.",
             "label": "E-Mail-Adresse"
           },
           "first-name": {
-            "error": "Ihr Vorname ist nicht ausgefüllt.",
+            "error": "Dein Vorname ist nicht angegeben.",
             "label": "Vorname"
           },
           "last-name": {
-            "error": "Ihr Name ist nicht ausgefüllt.",
-            "label": "Name"
+            "error": "Dein Nachname ist nicht angegeben.",
+            "label": "Nachname"
           },
           "password": {
-            "error": "Ihr Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben und eine Zahl enthalten.",
+            "error": "Dein Passwort muss mindestens 8 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben sowie eine Zahl enthalten.",
             "label": "Passwort"
           }
         },
-        "title": "Ich melde mich an"
+        "title": "Ich registriere mich"
       },
-      "title": "Sie werden eingeladen, der Organisation beizutreten {organizationName}."
+      "title": "Du bist eingeladen, der Organisation {organizationName} beizutreten"
     },
     "missions": {
       "list": {
@@ -1322,63 +1322,63 @@
         "aria-label": "Mission",
         "banner": {
           "copypaste-container": {
-            "abstract": "Starten Sie Ihre ersten Missionen mit Ihren Schülern, indem Sie die Sitzung über die Schaltfläche oben aktivieren und mit dem",
+            "abstract": "Starte deine ersten Missionen mit deinen Schüler:innen, indem du die Sitzung über die Schaltfläche oben aktivierst und folgenden Code nutzt:",
             "button": {
-              "success": "kopiert!",
-              "tooltip": "kopieren Sie den Code"
+              "success": "Kopiert!",
+              "tooltip": "Code kopieren"
             }
           },
-          "hint": "Zögern Sie nicht, ihn auf Ihren Posten als Favorit zu markieren.",
-          "import-text": "Schullink",
+          "hint": "Setze dafür gerne ein Lesezeichen auf deinen Geräten.",
+          "import-text": "Link der Schule",
           "step1": {
             "admin": {
               "head": "Schritt 1: <b>Bitte</b>",
-              "link": "die Schülerdatenbank importieren",
-              "tail": "<b>aus Onde</b> (Datei exportierbar im Menü Listen & Dokumente > Auswertungen > Schüler der Schule oder deren Betreuer <b>nur Schüler des Zyklus 3 auswählen</b>)."
+              "link": "importiere die Schülerdatenbank",
+              "tail": "<b>aus Onde</b> (Datei exportierbar im Menü Listen & Dokumente > Auswertungen > Schüler:innen der Schule oder deren Erziehungsberechtigte <b>nur Schüler:innen des Zyklus 3 auswählen</b>)."
             },
-            "non-admin": "Schritt 1: <b>Fragen Sie den Administrator</b> Pix Orga Ihres Bereichs, um die Schüler zu importieren."
+            "non-admin": "Schritt 1: <b>Bitte die:den Pix Orga-Administrator:in</b> deines Bereichs, die Schüler:innen zu importieren."
           },
           "step2": {
-            "option1": "verwenden <b>den Link</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Der Code Ihrer Einrichtung wird bei jeder Anmeldung abgefragt.",
+            "option1": "Verwende <b>den Link</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Der Code deiner Einrichtung wird bei jeder Anmeldung abgefragt.",
             "option2": {
-              "body": "oder verwenden Sie den direkten Link  <'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.de/schools/{code}'</a>'",
-              "hint": "Sie können diesen Favoriten auf Computern speichern."
+              "body": "oder verwende den direkten Link  <'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.de/schools/{code}'</a>'",
+              "hint": "Du kannst dieses Lesezeichen auf den Computern speichern."
             },
-            "title": "Schritt 2: Damit die Schüler auf den Pix Junior-Bereich Ihrer Schule zugreifen können, können Sie :"
+            "title": "Damit die Schüler:innen auf den Pix Junior-Bereich deiner Schule zugreifen können, hast du folgende Möglichkeiten:"
           },
-          "step3": "Schritt 3: <b>Aktivieren Sie die Pix Junior-Sitzung</b> über die Schaltfläche in der Seitenleiste. <b>Diese Aktion sollten Sie vor jeder Sitzung mit Ihren Schülern durchführen</b>.",
-          "welcome": "Um mit der Nutzung von Pix Junior zu beginnen :"
+          "step3": "Aktiviere die Pix Junior-Sitzung über die Schaltfläche in der Seitenleiste. Aktivierte Sitzungen sind Voraussetzung für jede Einheit mit deinen Schüler:innen.",
+          "welcome": "Um mit der Nutzung von Pix Junior zu beginnen:"
         },
         "caption": "Liste der Missionen",
         "empty-state": "Es gibt keine Missionen",
         "headers": {
           "actions": "Aktionen",
-          "competences": "Gearbeitete NSRC-Kompetenzen",
+          "competences": "Behandelte CRCN-Kompetenzen",
           "name": "Mission",
-          "started-by": "Begonnen von"
+          "started-by": "Gestartet von"
         },
         "no-division": "Keine Klasse",
         "non-admin": {
-          "abstract": "Bitten Sie zunächst Ihren Administrator, die Schüler zu importieren."
+          "abstract": "Bitte deine:n Administrator:in, zuerst die Schüler:innen zu importieren."
         }
       },
       "mission": {
         "details": {
-          "button-label": "Pädagogisches Merkblatt ansehen",
+          "button-label": "Pädagogisches Datenblatt anzeigen",
           "competence": {
-            "title": "Bearbeitete NSRC-Kompetenz :"
+            "title": "Bearbeitete CRCN-Kompetenz:"
           },
           "objective": {
-            "title": "Ziele der Mission :"
+            "title": "Ziele der Mission:"
           }
         },
         "table": {
           "activities": {
-            "aria-label": "Schüler",
-            "caption": "Tabelle der Schüler mit ihrer Teilnahme an der Mission {missionName}.",
+            "aria-label": "Schüler:in",
+            "caption": "Tabelle der Schüler:innen mit ihrer Teilnahme an der Mission {missionName}",
             "filters": {
-              "aria-label": "Filter nach Schülern",
-              "learners-count": "{count, plural, =0 {Keine Schüler} =1 {1 Schüler} other {{count} Schüler}}",
+              "aria-label": "Filter nach Schüler:innen",
+              "learners-count": "{count, plural, =0 {Kein:e Schüler:in} =1 {1 Schüler:in} other {{count} Schüler:innen}}",
               "status": {
                 "label": "Status der Mission"
               }
@@ -1386,58 +1386,58 @@
             "headers": {
               "division": "Klasse",
               "first-name": "Vorname",
-              "last-name": "Name",
+              "last-name": "Nachname",
               "status": "Status der Mission"
             },
             "mission-status": {
               "completed": "Abgeschlossen",
-              "not-started": "Nicht begonnen",
-              "started": "In Arbeit"
+              "not-started": "Noch nicht gestartet",
+              "started": "In Bearbeitung"
             },
-            "no-data": "Es gibt keine Teilnehmer"
+            "no-data": "Es gibt keine Teilnehmer:innen"
           },
           "result": {
-            "aria-label": "Schüler",
-            "caption": "Tabelle der Schülerinnen und Schüler mit dem Ergebnis ihrer Teilnahme an der Mission {missionName}.",
+            "aria-label": "Schüler:in",
+            "caption": "Tabelle der Schüler:innen mit dem Ergebnis ihrer Teilnahme an der Mission {missionName}",
             "filters": {
-              "aria-label": "Filter nach Schülern",
+              "aria-label": "Filter nach Schüler:innen",
               "global-result": {
                 "label": "Bewertung der Mission",
                 "options": {
-                  "exceeded": "Überholt",
+                  "exceeded": "Übertroffen",
                   "no-result": "Keine Bewertung",
                   "not-reached": "Nicht erreicht",
                   "partially-reached": "Teilweise erreicht",
                   "reached": "Erreicht"
                 }
               },
-              "learners-count": "{count, plural, =0 {Keine Schüler} =1 {1 Schüler} other {{count} Schüler}}"
+              "learners-count": "{count, plural, =0 {Kein:e Schüler:in} =1 {1 Schüler:in} other {{count} Schüler:innen}}"
             },
             "headers": {
               "dare-challenge": "Herausforderung",
               "division": "Klasse",
               "first-name": "Vorname",
-              "last-name": "Name",
+              "last-name": "Nachname",
               "result": "Bewertung der Mission",
               "step": "Schritt {number}."
             },
             "mission-dare-result": {
-              "not-reached": "NA",
-              "reached": "A",
+              "not-reached": "NE",
+              "reached": "E",
               "undefined": "-"
             },
             "mission-result": {
-              "exceeded": "Überholt",
+              "exceeded": "Übertroffen",
               "not-reached": "Nicht erreicht",
               "partially-reached": "Teilweise erreicht",
               "reached": "Erreicht",
               "undefined": "-"
             },
-            "no-data": "Es gibt keine Teilnehmer",
+            "no-data": "Es gibt keine Teilnehmer:innen",
             "step-result": {
-              "not-reached": "NA",
-              "partially-reached": "PA",
-              "reached": "A",
+              "not-reached": "NE",
+              "partially-reached": "TE",
+              "reached": "E",
               "undefined": "-"
             }
           }
@@ -1453,30 +1453,30 @@
     },
     "oidc": {
       "login": {
-        "signup-button": "Ich habe kein Konto, ich melde mich mit meiner Organisation an",
-        "sub-title": "um es mit Ihrer neuen Verbindungsmethode zu verknüpfen",
-        "title": "Verwenden Sie Ihr Pix-Konto"
+        "signup-button": "Ich habe kein Konto, ich registriere mich über meine Organisation",
+        "sub-title": "um es mit deiner neuen Anmeldemethode zu verknüpfen",
+        "title": "Nutze dein Pix-Konto"
       },
       "signup": {
         "claims": {
-          "FrEduFonctAdm": "Administrative Funktion",
-          "FrEduNumenHash": "Technische Kennung",
-          "discipline": "Disziplin",
-          "employeeNumber": "Nummer des Mitarbeiters",
-          "first-name-label": "Vorname :",
-          "last-name-label": "Name:",
-          "population": "Bevölkerung",
-          "rne": "Zuweisende Einrichtung",
+          "FrEduFonctAdm": "Verwaltungsfunktion",
+          "FrEduNumenHash": "Technische ID",
+          "discipline": "Fachbereich",
+          "employeeNumber": "Personalnummer",
+          "first-name-label": "Vorname:",
+          "last-name-label": "Nachname:",
+          "population": "Zielgruppe",
+          "rne": "Zuordnungseinrichtung",
           "title": "Funktion"
         },
-        "description": "Ein Konto wird anhand der von der Organisation übermittelten Elemente erstellt.",
+        "description": "Ein Konto wird auf Grundlage der von der Organisation übermittelten Daten erstellt.",
         "error": {
-          "cgu": "Sie müssen den Nutzungsbedingungen von Pix und der Datenschutzrichtlinie zustimmen, um ein Konto zu erstellen.",
-          "claims": "Es war uns nicht möglich, Ihre Identitätsinformationen von der verwendeten Abteilung abzurufen. Wir bitten Sie, sich an den IT-Support dieser Organisation zu wenden."
+          "cgu": "Du musst den Nutzungsbedingungen und der Datenschutzrichtlinie von Pix zustimmen, um ein Konto zu erstellen.",
+          "claims": "Wir konnten deine Identitätsdaten nicht von dem verwendeten Dienst abrufen. Bitte wende dich an den IT-Support dieser Organisation."
         },
         "login-button": "Ich habe bereits ein Pix-Konto, ich melde mich an",
-        "signup-button": "Ich melde mich bei Pix an",
-        "sub-title": "um auf Ihren Pix Orga-Bereich zuzugreifen",
+        "signup-button": "Ich registriere mich bei Pix",
+        "sub-title": "um auf deinen Pix Orga-Bereich zuzugreifen",
         "title": "Melden Sie sich bei Pix an"
       }
     },
@@ -1491,20 +1491,20 @@
             "profiles-collection": "Profilsammlungen"
           }
         },
-        "empty-state": "Bisher noch keine Aktivitäten! Senden Sie eine Kampagne an {organizationLearnerFirstName} {organizationLearnerLastName} und beginnen Sie, ihren Fortschritt zu verfolgen.",
+        "empty-state": "Noch keine Aktivität! Sende eine Kampagne an {organizationLearnerFirstName} {organizationLearnerLastName} und verfolge ab sofort den Fortschritt.",
         "participation-list": {
           "table": {
             "column": {
               "campaign-name": "Kampagne",
               "campaign-type": "Typ",
-              "created-at": "Datum des Beginns",
+              "created-at": "Startdatum",
               "participation-count": "Anzahl der Teilnahmen",
-              "shared-at": "Datum der Absendung",
+              "shared-at": "Sendedatum",
               "status": "Status"
             }
           }
         },
-        "participations-title": "Liste aller Beteiligungen",
+        "participations-title": "Liste aller Teilnahmen",
         "profile-collection-summary": "Zusammenfassung der Teilnahmen an Kampagnen zur Profilsammlung",
         "title": "Aktivität"
       },
@@ -1513,49 +1513,49 @@
       }
     },
     "organization-participant-activity": {
-      "title": "Tätigkeit des Teilnehmers"
+      "title": "Aktivität der:des Teilnehmer:in"
     },
     "organization-participants": {
       "action-bar": {
         "delete-button": "Löschen",
-        "error-message": "{count, plural, =1 {Ein Fehler ist aufgetreten, {firstname} {lastname} wurde nicht aus der Teilnehmerliste entfernt.} other {Ein Fehler ist aufgetreten, die ausgewählten {count} Teilnehmer wurden nicht aus der Liste entfernt.}}.",
-        "information": "{count, plural, =1 {{count} ausgewählter Teilnehmer} other {{count} ausgewählter Teilnehmer}}",
-        "success-message": "{count, plural, =1 {{firstname} {lastname} wurde tatsächlich aus der Teilnehmerliste entfernt.} other {Die {count} ausgewählten Teilnehmer wurden tatsächlich aus der Liste entfernt.}}"
+        "error-message": "{count, plural, =1 {Es ist ein Fehler aufgetreten, {firstname} {lastname} wurde nicht aus der Liste der Teilnehmer:innen gelöscht.} other {Es ist ein Fehler aufgetreten, die {count} ausgewählten Teilnehmer:innen wurden nicht aus der Liste gelöscht.}}",
+        "information": "{count, plural, =1 {{count} Teilnehmer:in ausgewählt} other {{count} Teilnehmer:innen ausgewählt}}",
+        "success-message": "{count, plural, =1 {{firstname} {lastname} wurde aus der Liste der Teilnehmer:innen gelöscht.} other {Die {count} ausgewählten Teilnehmer:innen wurden aus der Liste gelöscht.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "{count, plural, =1 {Ich bestätige, dass ich die Auswirkungen der Löschung gut verstanden habe.} other {Ich bestätige, dass ich die Auswirkungen der {count} Löschungen gut verstanden habe.}}",
+        "confirmation-checkbox": "Ich bestätige, dass ich die Auswirkungen der {count} Löschungen verstanden habe",
         "content": {
           "footer": "Achtung: Diese Aktion kann nicht rückgängig gemacht werden.",
-          "header": "{count, plural, =1 {Dieser Teilnehmer wird nicht mehr sichtbar sein} other {Diese Teilnehmer werden nicht mehr sichtbar sein}} in Pix Orga.",
-          "main-campaign-prevent": "Dies wird sich also auf die Ergebnisse und Analysen der Kampagnen auswirken, die {count, plural, =1 {er} other {sie}} durchgeführt haben.",
-          "main-participation-prevent": "Alle {count, plural, =1 {seine} other {ihre}} Beteiligungen an Kampagnen werden gelöscht."
+          "header": "{count, plural, =1 {Diese:r Teilnehmer:in wird in Pix Orga nicht mehr sichtbar sein} other {Diese Teilnehmer:innen werden in Pix Orga nicht mehr sichtbar sein}}.",
+          "main-campaign-prevent": "Dies wirkt sich auf die Ergebnisse und Analysen der Kampagnen aus, {count, plural, =1 {die sie:er absolviert hat} other {die sie absolviert haben}}.",
+          "main-participation-prevent": "All {count, plural, =1 {ihre:seine} other {ihre}} Kampagnen-Teilnahmen werden gelöscht."
         },
-        "title": "{count, plural, =1 {Löschen Sie '<strong>'{firstname} {lastname}'</strong>' aus Ihren} other {Sind Sie sicher, dass Sie '<strong>'{count}'</strong>'}} Teilnehmer löschen möchten?"
+        "title": "{count, plural, =1 {''{firstname} {lastname}'' aus deinen Teilnehmer:innen löschen?} other {Bist du sicher, dass du ''{count}'' Teilnehmer:innen löschen möchtest?}}"
       },
       "empty-state": {
-        "action": "Meine Kampagnen ansehen",
-        "call-to-action": "Laden Sie sie ein, sich einer Kampagne anzuschließen, oder erstellen Sie eine neue Kampagne.",
-        "message": "Bisher keine Teilnehmer!"
+        "action": "Meine Kampagnen anzeigen",
+        "call-to-action": "Lade sie ein, einer Kampagne beizutreten, oder erstelle eine neue.",
+        "message": "Noch keine Teilnehmer:innen!"
       },
       "filters": {
-        "aria-label": "Filter nach Teilnehmern",
-        "participations-count": "{count, plural, =0 {0 Teilnehmer} =1 {1 Teilnehmer} other {{count} Teilnehmer}}",
-        "students-count": "{count, plural, =0 {0 Schüler} =1 {1 Schüler} other {{count} Schüler}}",
+        "aria-label": "Filter nach Teilnehmer:innen",
+        "participations-count": "{count, plural, =0 {0 Teilnehmer:innen} =1 {1 Teilnehmer:in} other {{count} Teilnehmer:innen}}",
+        "students-count": "{count, plural, =0 {0 Schüler:innen} =1 {1 Schüler:in} other {{count} Schüler:innen}}",
         "type": {
           "certificability": {
-            "label": "Suche nach Zertifizierbarkeit",
+            "label": "Nach Zertifizierbarkeit suchen",
             "placeholder": "Zertifizierbarkeit"
           }
         }
       },
-      "page-title": "Teilnehmer",
+      "page-title": "Teilnehmer:innen",
       "table": {
         "actions": {
-          "disable-oralization": "Sollwertanzeige deaktivieren",
-          "enable-oralization": "Sollwertanzeige aktivieren"
+          "disable-oralization": "Vorlesen der Aufgabenstellung deaktivieren",
+          "enable-oralization": "Vorlesen der Aufgabenstellung aktivieren"
         },
         "column": {
-          "checkbox": "Auswählen/Aufheben der Auswahl {firstname} {lastname}",
+          "checkbox": "{firstname} {lastname} auswählen/abwählen",
           "division": {
             "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Klasse sortiert. Klicken Sie, um in alphabetischer Reihenfolge zu sortieren.",
             "ariaLabelSortDown": "Die Tabelle ist nach Klasse sortiert, alphabetisch in umgekehrter Reihenfolge. Klicken Sie, um in alphabetischer Reihenfolge zu sortieren.",
@@ -1566,28 +1566,28 @@
             "label": "Zertifizierbarkeit"
           },
           "last-name": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Namen sortiert. Klicken Sie, um alphabetisch zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach Namen in umgekehrter alphabetischer Reihenfolge sortiert. Klicken Sie, um alphabetisch zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach Namen in alphabetischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
-            "label": "Name"
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Nachnamen sortiert. Klicke hier, um alphabetisch zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Nachnamen in umgekehrter alphabetischer Reihenfolge sortiert. Klicke hier, um alphabetisch zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Nachnamen in alphabetischer Reihenfolge sortiert. Klicke hier, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
+            "label": "Nachname"
           },
           "latest-participation": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach dem Datum der Beteiligungen sortiert. Klicken Sie, um aufsteigend zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach dem Datum der Teilnahme absteigend sortiert. Klicken Sie, um aufsteigend zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach dem Datum der Teilnahme aufsteigend sortiert. Klicken Sie, um absteigend zu sortieren.",
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Teilnahmedatum sortiert. Klicke hier, um aufsteigend zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Teilnahmedatum absteigend sortiert. Klicke hier, um aufsteigend zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Teilnahmedatum aufsteigend sortiert. Klicke hier, um absteigend zu sortieren.",
             "label": "Letzte Teilnahme"
           },
           "mainCheckbox": "Die gesamte Spalte auswählen/abwählen",
           "participation-count": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach der Anzahl der Teilnahmen sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach der Anzahl der Teilnahmen absteigend sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach der Anzahl der Teilnahmen aufsteigend sortiert. Klicken Sie, um in absteigender Reihenfolge zu sortieren.",
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Anzahl der Teilnahmen sortiert. Klicke hier, um aufsteigend zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Anzahl der Teilnahmen absteigend sortiert. Klicke hier, um aufsteigend zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Anzahl der Teilnahmen aufsteigend sortiert. Klicke hier, um absteigend zu sortieren.",
             "label": "Anzahl der Teilnahmen"
           }
         },
-        "description": "Nach Namen sortierte Tabelle der Teilnehmer.",
-        "empty": "Keine Teilnehmer",
-        "oralization-header-tooltip": "Das Aktivieren von \"Vorlesen der Anweisung\" ermöglicht es dem Schüler, seine mündliche Mitschrift zu erhalten.",
+        "description": "Tabelle der Teilnehmer:innen nach Nachnamen sortiert.",
+        "empty": "Keine Teilnehmer:innen",
+        "oralization-header-tooltip": "Das Aktivieren der „Vorlesefunktion“ ermöglicht es den Schüler:innen, die Aufgabenstellung vorgelesen zu bekommen.",
         "row-value": {
           "oralization": {
             "false": "Deaktiviert",
@@ -1599,91 +1599,91 @@
     "organization-participants-import": {
       "actions": {
         "add-sup": {
-          "details": "Ermöglicht das Hinzufügen einer Schülerliste zu einer bereits importierten und/oder das Bearbeiten der Informationen von bereits importierten Schülern.",
-          "label": "Schüler hinzufügen",
+          "details": "Ermöglicht das Hinzufügen einer Liste von Schüler:innen zur bereits importierten Liste und/oder das Ändern der Informationen bereits importierter Schüler:innen.",
+          "label": "Schüler:innen hinzufügen",
           "title": "Hinzufügen / Bearbeiten"
         },
         "participants": {
-          "details": "Mit dieser Aktion können Sie :",
-          "details-add": "neue Teilnehmer hinzufügen",
-          "details-disable": "ehemalige Teilnehmer deaktivieren",
-          "details-update": "bereits importierte Teilnehmer bearbeiten",
+          "details": "Diese Aktion ermöglicht dir:",
+          "details-add": "Diese Aktion ermöglicht dir:",
+          "details-disable": "ehemalige Teilnehmer:innen zu deaktivieren",
+          "details-update": "bereits importierte Teilnehmer:innen zu bearbeiten",
           "label": "Liste importieren",
-          "title": "Teilnehmerliste importieren"
+          "title": "Liste der Teilnehmer:innen importieren"
         },
         "replace": {
-          "details": "Ermöglicht das Importieren einer neuen Schülerliste anstelle der vorhandenen.",
+          "details": "Ermöglicht das Importieren einer neuen Liste von Schüler:innen anstelle der bestehenden.",
           "label": "Eine neue Liste importieren",
           "title": "Ersetzen"
         }
       },
       "banner": {
-        "anchor-error": "Fehlerliste ansehen",
-        "fix-error-text": "Bitte korrigieren Sie die Fehler und importieren Sie die Datei erneut.",
-        "import-error": "Der Import von Teilnehmern ist fehlgeschlagen.",
-        "import-in-progress": "Der Inhalt der Datei ist freigegeben, der Import der Teilnehmer läuft.",
-        "in-progress-text": "Bitte aktualisieren Sie diese Seite in Kürze, um den Bearbeitungsstatus der Datei zu erfahren.",
-        "retry-error-text": "Ein Fehler ist aufgetreten, bitte später importieren oder an den Pix-Support schreiben",
+        "anchor-error": "Fehlerliste anzeigen",
+        "fix-error-text": "Bitte korrigiere die Fehler und importiere die Datei erneut.",
+        "import-error": "Der Import der Teilnehmer:innen ist fehlgeschlagen.",
+        "import-in-progress": "Der Inhalt der Datei wurde überprüft, der Import der Teilnehmer:innen läuft.",
+        "in-progress-text": "Bitte aktualisiere diese Seite in Kürze, um den Bearbeitungsstatus der Datei zu erfahren.",
+        "retry-error-text": "Es ist ein Fehler aufgetreten. Bitte versuche den Import später erneut oder kontaktiere den Pix-Support.",
         "upload-completed": "Die Datei wurde am {date} von {firstName} {lastName} importiert.",
         "upload-error": "Die Datei konnte nicht importiert werden.",
-        "upload-in-progress": "Das Importieren der Datei kann einige Minuten dauern. Bitte verlassen Sie diese Seite nicht.",
+        "upload-in-progress": "Der Import der Datei kann einige Minuten dauern. Bitte verlasse diese Seite nicht.",
         "validation-error": "Der Inhalt der Datei enthält Fehler.",
         "validation-in-progress": "Der Inhalt der Datei wird gerade überprüft.",
-        "warning-banner": "Einige Werte wurden nicht erkannt. Sie wurden durch \"Nicht anerkannt\" ersetzt. Wenn Sie der Ansicht sind, dass in der einschränkenden Liste Werte fehlen, kontaktieren Sie uns bitte unter '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'."
+        "warning-banner": "Einige Werte wurden nicht erkannt. Sie wurden durch „Nicht erkannt“ ersetzt. Wenn du der Meinung bist, dass Werte in der vorgegebenen Liste fehlen, kontaktiere uns bitte unter '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'."
       },
       "error-panel": {
-        "error-wrapper": "Es wurden keine Teilnehmer importiert. Bitte bearbeiten Sie Ihre Datei und importieren Sie sie erneut.",
-        "global-error": "Es wurden keine Teilnehmer importiert. Bitte versuchen Sie es erneut oder kontaktieren Sie uns über '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'das Help Center Formular'</a>'.",
-        "title": "Fehler in der zuletzt importierten Datei :"
+        "error-wrapper": "Es wurden keine Teilnehmer:innen importiert. Bitte passe deine Datei an und importiere sie erneut.",
+        "global-error": "Es wurden keine Teilnehmer:innen importiert. Bitte versuche es erneut oder kontaktiere uns über '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'das Formular im Hilfe-Center'</a>'.",
+        "title": "Fehler in der zuletzt importierten Datei:"
       },
       "file-type-separator": ",",
-      "global-success": "Letzte erfolgreich importierte Datei am {date} durch {firstName} {lastName}.",
+      "global-success": "Zuletzt erfolgreich importierte Datei am {date} von {firstName} {lastName}.",
       "sco": {
-        "title": "Schüler importieren"
+        "title": "Schüler:innen importieren"
       },
       "sup": {
-        "title": "Schüler importieren"
+        "title": "Studierende importieren"
       },
       "supported-formats": "(unterstützte Formate: {types})",
       "title": "Importieren",
       "warnings": {
-        "diploma": "Nicht anerkannte Diplome: {diplomas};",
-        "study-scheme": "Nicht anerkannte Pläne: {studySchemes};"
+        "diploma": "Nicht erkannte Abschlüsse: {diplomas}:",
+        "study-scheme": "Nicht erkannte Ausbildungsformen: {studySchemes}:"
       }
     },
     "participants-list": {
       "latest-participation-information-tooltip": {
-        "aria-label": "Informationen über die letzte Teilnahme",
+        "aria-label": "Informationen zur letzten Teilnahme",
         "campaign-ASSESSMENT-type": "Bewertung",
-        "campaign-PROFILES_COLLECTION-type": "Sammeln von Profilen",
-        "campaign-name": "Kampagne :",
-        "campaign-status": "Status :",
-        "campaign-type": "Art :",
+        "campaign-PROFILES_COLLECTION-type": "Profilsammlungen",
+        "campaign-name": "Kampagne:",
+        "campaign-status": "Status:",
+        "campaign-type": "Typ:",
         "participation-SHARED-status": "Empfangen",
-        "participation-STARTED-status": "In Arbeit"
+        "participation-STARTED-status": "In Bearbeitung"
       }
     },
     "places": {
-      "before-date": "unter",
+      "before-date": "am",
       "places-lots": {
         "statuses": {
           "active": "Aktiv",
           "expired": "Abgelaufen",
-          "pending": "In Kürze"
+          "pending": "Bevorstehend"
         },
         "table": {
-          "caption": "Tabelle, die die Platzkäufe Ihrer Organisation auflistet. Für jeden Kauf wird Folgendes angezeigt: die Anzahl der Plätze, das Aktivierungsdatum, das Ablaufdatum und der Status (aktiv, zukünftig oder abgelaufen). Sie ist nach dem Status der Käufe und dem Ablaufdatum geordnet.",
-          "empty-state": "Noch keine Plätze frei!",
+          "caption": "Tabelle der gekauften Lizenzen deiner Organisation. Für jeden Kauf werden angegeben: die Anzahl der Lizenzen, das Aktivierungsdatum, das Ablaufdatum sowie der Status (aktiv, bevorstehend oder abgelaufen). Sie ist nach dem Status der Käufe und deren Ablaufdatum sortiert.",
+          "empty-state": "Derzeit keine Lizenzen vorhanden!",
           "headers": {
-            "activation-date": "Datum der Aktivierung",
-            "count": "Anzahl der Plätze",
-            "expiration-date": "Datum des Ablaufs",
+            "activation-date": "Aktivierungsdatum",
+            "count": "Anzahl der Lizenzen",
+            "expiration-date": "Ablaufdatum",
             "status": "Status"
           },
-          "title": "Historischer Überblick über den Kauf von Plätzen"
+          "title": "Kaufhistorie der Lizenzen"
         }
       },
-      "title": "Plätze"
+      "title": "Lizenzen"
     },
     "preselect-target-profile": {
       "compatibility": {
@@ -1696,7 +1696,7 @@
           "yes": "Kompatibel mit Tablets"
         }
       },
-      "download": "Herunterladen der Themenauswahl ({ numberOfTubesSelected }) (JSON, { fileSize }ko)",
+      "download": "Themenauswahl herunterladen ({ numberOfTubesSelected }) (JSON, { fileSize } KB)",
       "download-filename": "selection-sujets-{ organizationName }-{ date }.json",
       "levels": {
         "label": "Niveauauswahl für das folgende Thema: {title}",
@@ -1705,29 +1705,29 @@
       },
       "no-tube-selected": "Themenauswahl herunterladen (JSON, { fileSize }ko)",
       "table": {
-        "caption": "Auswahl der Themen",
+        "caption": "Themenauswahl",
         "column": {
           "compatibility": "Kompatibilität",
           "level": "Max. Niveau (optional)",
-          "name": "Themas",
-          "theme-name": "Themas"
+          "name": "Name der Aufgabe",
+          "theme-name": "Name des Themenbereichs"
         },
         "is-responsive": "ja",
-        "not-responsive": "nicht",
+        "not-responsive": "nein",
         "row-title": "Thema"
       },
-      "title": "Auswahl der Themen"
+      "title": "Themenauswahl"
     },
     "profiles-individual-results": {
       "breadcrumb-current-page-label": "Teilnahme von {firstName} {lastName}",
       "certifiable": "Zertifizierbar",
-      "competences-certifiables": "COMP. CERTIFIABLES",
+      "competences-certifiables": "ZERTIFIZIERBARE KOMP.",
       "pix": "PIX",
       "pix-score": "{score, number}",
       "table": {
         "column": {
-          "level": "Ebene",
-          "pix-score": "Pix-Score",
+          "level": "Niveau",
+          "pix-score": "Pix-Punkte",
           "skill": "Kompetenz"
         },
         "empty": "Warten auf Ergebnisse",
@@ -1737,47 +1737,47 @@
     },
     "profiles-list": {
       "table": {
-        "caption": "Diese Tabelle enthält eine Liste der Teilnehmer, die ihre Profile freigegeben haben. Sie zeigt für jeden Teilnehmer seinen Vor- und Nachnamen, das Datum der Übermittlung, den Pix-Score, die Entwicklung, den Status der Zertifizierbarkeit und die Anzahl der zertifizierbaren Kompetenzen.",
+        "caption": "Diese Tabelle enthält die Liste der Teilnehmer:innen, die ihre Profile geteilt haben. Sie zeigt für jede:n Teilnehmer:in Nachname, Vorname, Datum der Übermittlung, Pix-Punkte, Entwicklung, Zertifizierungsstatus und die Anzahl der zertifizierbaren Kompetenzen an.",
         "column": {
-          "ariaSharedProfileCount": "Anzahl der Profilfreigaben",
+          "ariaSharedProfileCount": "Anzahl geteilter Profile",
           "certifiable": "Zertifizierbar",
           "certifiable-tag": "Zertifizierbar",
           "competences-certifiables": "Zertifizierbare Komp.",
           "evolution": "Entwicklung",
           "first-name": "Vorname",
-          "last-name": "Name",
+          "last-name": "Nachname",
           "pix-score": {
-            "label": "Pix-Score",
+            "label": "Pix-Punkte",
             "value": "{score, number}"
           },
           "sending-date": {
-            "label": "Datum der Absendung",
-            "on-hold": "Wartet auf den Versand"
+            "label": "Datum der Übermittlung",
+            "on-hold": "Warten auf Übermittlung"
           },
-          "sharedProfileCount": "Anzahl der Profilfreigaben"
+          "sharedProfileCount": "Anzahl geteilter Profile"
         },
         "empty": "Warten auf Profile",
         "evolution": {
-          "decrease": "In Rückschritt",
-          "increase": "Auf dem Vormarsch",
-          "stable": "Konstant",
+          "decrease": "Verschlechtert",
+          "increase": "Verbessert",
+          "stable": "Unverändert",
           "unavailable": "Nicht verfügbar"
         },
         "evolution-tooltip": {
-          "content": "Entwicklung der pix-Score zwischen den letzten beiden Profilfreigaben."
+          "content": "Entwicklung der Pix-Punktzahl zwischen den letzten beiden Profilübermittlungen."
         },
         "title": "Liste der empfangenen Profile"
       },
       "title": "Empfangene Profile"
     },
     "sco-organization-participant-activity": {
-      "title": "Aktivität der Schülerin/des Schülers"
+      "title": "Aktivität der:des Schüler:in"
     },
     "sco-organization-participants": {
       "action-bar": {
-        "generate-username-password-button": "Generieren von Benutzernamen und/oder Passwörtern für ausgewählte Schülerinnen und Schüler",
-        "information": "{count, plural, =1 {{count} ausgewählter Schüler} other {{count} ausgewählter Schüler}}",
-        "reset-password-button": "Die Passwörter der ausgewählten Schüler zurücksetzen"
+        "generate-username-password-button": "Benutzernamen und/oder Passwörter der ausgewählten Schüler:innen generieren",
+        "information": "{count, plural, =1 {{count} Schüler:in ausgewählt} other {{count} Schüler:innen ausgewählt}}",
+        "reset-password-button": "Passwörter der ausgewählten Schüler:innen zurücksetzen"
       },
       "actions": {
         "manage-account": "Konto verwalten",
@@ -1786,15 +1786,15 @@
       "connection-types": {
         "email": "E-Mail-Adresse",
         "empty": "-",
-        "identifiant": "Kennung",
+        "identifiant": "Benutzername",
         "mediacentre": "Mediacentre",
         "none": "Keine",
         "without-mediacentre": "Ohne Mediacentre"
       },
       "filter": {
-        "aria-label": "Filter nach Schülern",
+        "aria-label": "Filter nach Schüler:innen",
         "certificability": {
-          "label": "Suche nach Zertifizierbarkeit",
+          "label": "Nach Zertifizierbarkeit suchen",
           "placeholder": "Zertifizierbarkeit"
         },
         "division": {
@@ -1805,84 +1805,84 @@
           "label": "Nach Vornamen suchen"
         },
         "last-name": {
-          "label": "Nach Namen suchen"
+          "label": "Nach Nachnamen suchen"
         },
         "login-method": {
-          "empty-option": "Verbindungsmethode",
-          "label": "Nach Verbindungsmethode suchen"
+          "empty-option": "Anmeldemethode",
+          "label": "Nach Anmeldemethode suchen"
         },
-        "students-count": "{count, plural, =0 {0 Schüler} =1 {1 Schüler} other {{count} Schüler}}"
+        "students-count": "{count, plural, =0 {0 Schüler:innen} =1 {1 Schüler:in} other {{count} Schüler:innen}}"
       },
       "generate-username-password-modal": {
-        "content-message-1": "Schülerinnen und Schüler, die noch keine Anmeldemethode haben, müssen über eine Kampagne in Ihrer Schule ein PIX-Konto einrichten.",
-        "content-message-2": "Es wird eine CSV-Datei erstellt, die sowohl die IDs als auch die Einmalpasswörter enthält.",
-        "content-message-3": "Teilen Sie diese neuen Einmalpasswörter den Schülerinnen und Schülern mit. Wenn sie sich mit diesem Passwort anmelden, wird Pix sie auffordern, ein neues Passwort einzugeben.",
-        "title": "Generieren von Benutzernamen und/oder Passwörtern für ausgewählte Schülerinnen und Schüler",
-        "warning-message": "Für Schülerinnen und Schüler, die einen Zugang zum Medienzentrum und/oder eine E-Mail-Adresse haben, wird eine Benutzerkennung und ein Passwort generiert. Bei Schülern, die bereits einen Benutzernamen besitzen, wird das Passwort zurückgesetzt."
+        "content-message-1": "Schüler:innen, die noch über keine Anmeldemethode verfügen, müssen an einer Kampagne deiner Einrichtung teilnehmen, um ihr Pix-Konto zu erstellen.",
+        "content-message-2": "Es wird eine CSV-Datei erstellt, die sowohl die Benutzernamen als auch die Einmalpasswörter enthält.",
+        "content-message-3": "Teile den Schüler:innen diese neuen Einmalpasswörter mit. Wenn sie sich mit diesem Passwort anmelden, wird Pix sie auffordern, ein neues Passwort festzulegen.",
+        "title": "Benutzernamen und/oder Passwörter der ausgewählten Schüler:innen generieren",
+        "warning-message": "Für Schüler:innen mit Zugang zum Mediacentre und/oder einer E-Mail-Adresse werden ein Benutzername und ein Passwort generiert. Für Schüler:innen, die bereits über einen Benutzernamen verfügen, wird das Passwort zurückgesetzt."
       },
       "manage-authentication-method-modal": {
-        "authentication-methods": "Verbindungsmethoden",
+        "authentication-methods": "Anmeldemethoden",
         "copied": "Kopiert!",
         "error": {
-          "default": "Es ist ein interner Fehler aufgetreten. Unsere Mitarbeiter sind dabei, das Problem zu beheben. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
-          "unexpected": "Etwas ist schief gelaufen. Bitte versuchen Sie es noch einmal."
+          "default": "Es ist ein interner Fehler aufgetreten. Unsere Teams arbeiten an der Behebung des Problems. Bitte versuche es später erneut.",
+          "unexpected": "Etwas ist schiefgelaufen. Bitte versuche es erneut."
         },
         "section": {
           "add-username": {
-            "button": "Kennung hinzufügen",
-            "label": "Eine Verbindung mit einem Benutzernamen hinzufügen"
+            "button": "Benutzernamen hinzufügen",
+            "label": "Anmeldung mit einem Benutzernamen hinzufügen"
           },
           "email": {
             "copy": "E-Mail-Adresse kopieren",
             "label": "E-Mail-Adresse"
           },
           "mediacentre": {
-            "label": "Mediacenter"
+            "label": "Mediacentre"
           },
           "password": {
-            "copy": "Kopieren des einmaligen Passworts",
+            "copy": "Einmalpasswort kopieren",
             "label": "Neues Einmalpasswort",
-            "warning-1": "Teilen Sie Ihrem Schüler/Ihrer Schülerin das neue Passwort mit.",
-            "warning-2": "Der Schüler/die Schülerin meldet sich mit diesem Einmalpasswort an.",
-            "warning-3": "Pix fordert ihn auf, ein neues auszuwählen."
+            "warning-1": "Teile dieses neue Passwort deiner:deinem Schüler:in mit.",
+            "warning-2": "Die:Der Schüler:in meldet sich mit diesem Einmalpasswort an.",
+            "warning-3": "Pix fordert sie:ihn auf, ein neues Passwort auszuwählen."
           },
           "reset-password": {
-            "button": "Das Passwort zurücksetzen",
-            "warning": "Zurücksetzen löscht das aktuelle Schülerpasswort."
+            "button": "Passwort zurücksetzen",
+            "warning": "Das Zurücksetzen löscht das aktuelle Passwort der:des Schüler:in."
           },
           "unblock": {
             "button": "Konto entsperren",
-            "subtitle": "Wenn das Schülerkonto gesperrt ist",
-            "success-notification": "Das Konto des Schülers wurde entsperrt, er kann sich wieder einloggen."
+            "subtitle": "Falls das Konto der:des Schüler:in gesperrt ist",
+            "success-notification": "Das Konto der:des Schüler:in wurde entsperrt, sie:er kann sich wieder anmelden."
           },
           "username": {
-            "copy": "Den Benutzernamen kopieren",
-            "label": "Kennung"
+            "copy": "Benutzernamen kopieren",
+            "label": "Benutzername"
           }
         },
-        "title": "Verwaltung des Pix-Kontos des Schülers"
+        "title": "Verwaltung des Pix-Kontos der:des Schüler:in"
       },
       "messages": {
-        "password-reset-success": "Das Zurücksetzen der Passwörter der ausgewählten Schülerinnen und Schüler wurde durchgeführt."
+        "password-reset-success": "Das Zurücksetzen der Passwörter der ausgewählten Schüler:innen wurde durchgeführt."
       },
-      "no-participants": "Bisher keine Schüler!",
-      "no-participants-action": "Der Administrator muss die Schülerdatenbank importieren, indem er auf die Schaltfläche Importieren klickt.",
-      "page-title": "Schülerinnen und Schüler",
+      "no-participants": "Derzeit keine Schüler:innen vorhanden!",
+      "no-participants-action": "Die:Der Administrator:in muss die Schüler:innendatenbank importieren, indem sie:er auf die Schaltfläche „Importieren“ klickt.",
+      "page-title": "Schüler:innen",
       "reset-password-modal": {
-        "content-message-1": "Auf {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} Schüler</strong> ausgewählt} other {<strong>{totalSelectedStudents} Schüler</strong> ausgewählt}}, {totalAffectedStudents, plural, =0 {<strong>kein Passwort</strong> wird zurückgesetzt} =1 {das Passwort von <strong>{totalAffectedStudents} Schülerin</strong> wird zurückgesetzt} other {die Passwörter von <strong>{totalAffectedStudents} Schüler</strong> werden zurückgesetzt}}.",
-        "content-message-2": "Es wird eine CSV-Datei erstellt, die sowohl die IDs als auch die Einmalpasswörter enthält.",
-        "content-message-3": "Teilen Sie den Schülerinnen und Schülern diese neuen Einmalpasswörter mit. Wenn sie sich mit diesem Passwort anmelden, wird Pix sie auffordern, ein neues Passwort einzugeben.",
-        "title": "Zurücksetzen der <strong>Passwörter</strong> von Schülern mit <strong>Identifikator</strong>.",
+        "content-message-1": "Von {totalSelectedStudents, plural, =1 {{totalSelectedStudents} ausgewählten Schüler:in} other {{totalSelectedStudents} ausgewählten Schüler:innen}} wird {totalAffectedStudents, plural, =0 {kein Passwort zurückgesetzt} =1 {das Passwort von {totalAffectedStudents} Schüler:in zurückgesetzt} other {das Passwort von {totalAffectedStudents} Schüler:innen zurückgesetzt}}.",
+        "content-message-2": "Es wird eine CSV-Datei erstellt, die sowohl die Benutzernamen als auch die Einmalpasswörter enthält.",
+        "content-message-3": "Teile den Schüler:innen diese neuen Einmalpasswörter mit. Wenn sie sich mit diesem Passwort anmelden, wird Pix sie auffordern, ein neues Passwort festzulegen.",
+        "title": "Zurücksetzen der <strong>Passwörter</strong> von Schüler:innen mit <strong>Benutzernamen</strong>.",
         "warning-message": "Nur die Passwörter für Zugänge über Benutzernamen können zurückgesetzt werden. Die Zugänge über E-Mail-Adressen und Mediacentre sind davon nicht betroffen."
       },
       "table": {
         "column": {
-          "checkbox": "Auswählen/Aufheben der Auswahl {firstname} {lastname}",
+          "checkbox": "{firstname} {lastname} auswählen/abwählen",
           "date-of-birth": "Geburtsdatum",
           "division": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Klassen sortiert. Klicken Sie, um nach alphanumerischer Reihenfolge zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach Klassen in umgekehrter alphanumerischer Reihenfolge sortiert. Klicken Sie, um in alphanumerischer Reihenfolge zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach Klassen in alphanumerischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphanumerischer Reihenfolge zu sortieren.",
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Klasse sortiert. Klicke hier, um alphanumerisch zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Klasse in umgekehrter alphanumerischer Reihenfolge sortiert. Klicke hier, um alphanumerisch zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Klasse in alphanumerischer Reihenfolge sortiert. Klicke hier, um in umgekehrter alphanumerischer Reihenfolge zu sortieren.",
             "label": "Klasse"
           },
           "first-name": "Vorname",
@@ -1890,13 +1890,13 @@
             "eligible": "Zertifizierbar",
             "label": "Zertifizierbarkeit",
             "non-eligible": "Nicht zertifizierbar",
-            "not-available": "Nicht mitgeteilt"
+            "not-available": "Nicht angegeben"
           },
           "last-name": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Namen sortiert. Klicken Sie, um alphabetisch zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach Namen in umgekehrter alphabetischer Reihenfolge sortiert. Klicken Sie, um alphabetisch zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach Namen in alphabetischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
-            "label": "Name"
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Nachnamen sortiert. Klicke hier, um alphabetisch zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Nachnamen in umgekehrter alphabetischer Reihenfolge sortiert. Klicke hier, um alphabetisch zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Nachnamen in alphabetischer Reihenfolge sortiert. Klicke hier, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
+            "label": "Nachname"
           },
           "last-participation-date": {
             "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach dem Datum der Beteiligungen sortiert. Klicken Sie, um aufsteigend zu sortieren.",
@@ -1904,121 +1904,121 @@
             "ariaLabelSortUp": "Die Tabelle wird nach dem Datum der Teilnahme aufsteigend sortiert. Klicken Sie, um absteigend zu sortieren.",
             "label": "Letzte Teilnahme"
           },
-          "login-method": "Verbindungsmethode(n)",
+          "login-method": "Anmeldemethode(n)",
           "mainCheckbox": "Die gesamte Spalte auswählen/abwählen",
           "participation-count": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach der Anzahl der Teilnahmen sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach der Anzahl der Teilnahmen absteigend sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach der Anzahl der Teilnahmen aufsteigend sortiert. Klicken Sie, um in absteigender Reihenfolge zu sortieren.",
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Anzahl der Teilnahmen sortiert. Klicke hier, um in aufsteigender Reihenfolge zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Anzahl der Teilnahmen in absteigender Reihenfolge sortiert. Klicke hier, um in aufsteigender Reihenfolge zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Anzahl der Teilnahmen in aufsteigender Reihenfolge sortiert. Klicke hier, um in absteigender Reihenfolge zu sortieren.",
             "label": "Anzahl der Teilnahmen"
           }
         },
-        "description": "Nach Namen sortierte Tabelle der Schüler. Bei Schülern, die eine Verbindungsmethode angegeben haben, können Sie über ein Menü in der Spalte 'Aktionen' die erlaubten Verbindungsmethoden verwalten und das Schülerpasswort zurücksetzen.",
-        "empty": "Keine Schülerinnen und Schüler."
+        "description": "Schüler:innen-Tabelle nach Nachnamen sortiert. Für Schüler:innen, die eine Anmeldemethode angegeben haben, kannst du über ein Menü in der Spalte „Aktionen“ die zulässigen Anmeldemethoden verwalten und das Passwort der:des Schüler:in zurücksetzen.",
+        "empty": "Keine Schüler:innen."
       },
-      "title": "{count, plural, =0 {Schüler} =1 {Schüler ({count})} other {Schüler ({count})}}",
+      "title": "{count, plural, =0 {Schüler:innen} =1 {Schüler:in ({count})} other {Schüler:innen ({count})}}",
       "user-account-blocking-types": {
-        "blocked": "Gesperrten Mitgliedskontos",
-        "temporarily-blocked": "Vorübergehend Gesperrten Mitgliedskontos"
+        "blocked": "Konto gesperrt",
+        "temporarily-blocked": "Konto vorübergehend gesperrt"
       }
     },
     "sso-selection": {
       "login": {
-        "button": "Ich logge mich ein",
-        "message": "Sie werden nun auf die Login-Seite von \"{providerName}\" weitergeleitet, um sich bei Pix anzumelden."
+        "button": "Ich melde mich an",
+        "message": "Du wirst zur Anmeldeseite von „{providerName}“ weitergeleitet, um dich bei Pix zu authentifizieren."
       },
       "signup": {
-        "button": "Ich melde mich an"
+        "button": "Ich registriere mich"
       },
-      "title": "Wählen Sie Ihre Verbindungsmethode"
+      "title": "Wähle deine Anmeldemethode"
     },
     "statistics": {
-      "before-date": "unter",
-      "description": "In der folgenden Tabelle können Sie die Positionierung Ihrer Teilnehmer nach Thema einsehen.'<br>' Die Positionierung gibt das durchschnittliche Niveau Ihrer Teilnehmer auf dem maximalen Niveau wieder, das sie hätten erreichen können.'<br>' Diese Daten berücksichtigen alle Teilnahmen, die im Rahmen von nicht gelöschten Bewertungskampagnen Ihrer Organisation geteilt wurden.",
+      "before-date": "am",
+      "description": "In der folgenden Tabelle kannst du den Leistungsstand deiner Teilnehmer:innen nach Themen einsehen.'<br>' Der Leistungsstand gibt das durchschnittliche Niveau deiner Teilnehmer:innen im Vergleich zum maximal erreichbaren Niveau an.'<br>' Diese Daten berücksichtigen alle geteilten Teilnahmen aus nicht gelöschten Evaluierungskampagnen deiner Organisation.",
       "empty-state": "Keine Daten verfügbar",
       "level": {
-        "advanced": "Fortgeschrittene",
-        "expert": "Experte",
+        "advanced": "Fortgeschritten",
+        "expert": "Expert:in",
         "independent": "Selbstständig",
-        "novice": "Novize"
+        "novice": "Einsteiger:in"
       },
-      "select-label": "Domain",
+      "select-label": "Bereich",
       "table": {
-        "caption": "Diese Tabelle zeigt die Auswertung der Ergebnisse aller Teilnehmer nach Themen. Sie zeigt für jede Zeile die Kompetenz, das Thema, den Abdeckungsgrad sowie die erreichte Stufe an.",
+        "caption": "Diese Tabelle zeigt die Analyse der Ergebnisse aller Teilnehmer:innen nach Themen. Sie gibt für jede Zeile die Kompetenz, das Thema, die Abdeckungsrate sowie das erreichte Niveau an.",
         "headers": {
           "competences": "Kompetenzen",
-          "positioning": "Positionierung",
-          "reached-level": "Erreichte Stufe",
+          "positioning": "Leistungsstand",
+          "reached-level": "Erreichtes Niveau",
           "topics": "Themen"
         }
       },
       "title": "Statistiken"
     },
     "sup-organization-participant-activity": {
-      "title": "Aktivität des Schülers/der Schülerin"
+      "title": "Aktivität der:des Studierenden"
     },
     "sup-organization-participants": {
       "action-bar": {
         "delete-button": "Löschen",
-        "error-message": "{count, plural, =1 {Ein Fehler ist aufgetreten, {firstname} {lastname} wurde nicht aus der Liste der Schüler entfernt.} other {Ein Fehler ist aufgetreten, die ausgewählten {count} Schüler wurden nicht aus der Liste entfernt.}}",
-        "information": "{count, plural, =1 {{count} ausgewählter Schüler} other {{count} ausgewählter Schüler}}",
-        "success-message": "{count, plural, =1 {{firstname} {lastname} wurde tatsächlich aus der Liste der Studenten entfernt.} other {Die ausgewählten {count} Studenten wurden tatsächlich aus der Liste entfernt.}}"
+        "error-message": "{count, plural, =1 {Es ist ein Fehler aufgetreten: {firstname} {lastname} wurde nicht aus der Liste der Studierenden gelöscht.} other {Es ist ein Fehler aufgetreten: Die {count} ausgewählten Studierenden wurden nicht aus der Liste gelöscht.}}",
+        "information": "{count, plural, =1 {{count} Studierende:r ausgewählt} other {{count} Studierende ausgewählt}}",
+        "success-message": "{count, plural, =1 {{firstname} {lastname} wurde erfolgreich aus der Liste der Studierenden gelöscht.} other {Die {count} ausgewählten Studierenden wurden erfolgreich aus der Liste gelöscht.}}"
       },
       "actions": {
         "download-template": "Vorlage herunterladen",
-        "edit-student-number": "Studentennummer bearbeiten",
+        "edit-student-number": "Matrikelnummer bearbeiten",
         "show-actions": "Aktionen anzeigen"
       },
       "deletion-modal": {
         "content": {
           "footer": "Achtung: Diese Aktion kann nicht rückgängig gemacht werden.",
-          "header": "{count, plural, =1 {Dieser Schüler wird nicht mehr sichtbar sein} other {Diese Schüler werden nicht mehr sichtbar sein}} in Pix Orga.",
-          "main-campaign-prevent": "Dies wird sich daher auf die Ergebnisse und Analysen der Kampagnen auswirken, die {count, plural, =1 {er} other {sie}} durchgeführt haben.",
-          "main-participation-prevent": "Alle {count, plural, =1 {seine} other {ihre}} Beteiligungen an Kampagnen werden gelöscht."
+          "header": "{count, plural, =1 {Diese:r Studierende wird nicht mehr sichtbar sein} other {Diese Studierenden werden nicht mehr sichtbar sein}} in Pix Orga.",
+          "main-campaign-prevent": "Dies wirkt sich auf die Ergebnisse und Analysen der Kampagnen aus, die {count, plural, =1 {diese:r Studierende} other {sie}} absolviert {count, plural, =1 {hat} other {haben}}.",
+          "main-participation-prevent": "Alle {count, plural, =1 {ihre:seine} other {ihre}} Kampagnenteilnahmen werden gelöscht."
         },
-        "title": "{count, plural, =1 {Entfernen Sie '<strong>'{firstname} {lastname}'</strong>' von Ihren} other {Sind Sie sicher, dass Sie '<strong>'{count}'</strong>'}} Schüler entfernen möchten?"
+        "title": "{count, plural, =1 {Möchtest du ''{firstname} {lastname}'' aus deinen Studierenden löschen?} other {Bist du sicher, dass du ''{count}'' Studierende löschen möchtest?}}"
       },
       "edit-student-number-modal": {
         "actions": {
           "update": "Aktualisieren"
         },
         "form": {
-          "error": "Die Studentennummer darf nicht leer sein.",
-          "new-student-number-label": "Neue Studentennummer",
-          "student-number": "Aktuelle Studentennummer von {firstName} {lastName} ist :",
-          "success": "Die Änderung der Studentennummer von {firstName} zu {lastName} wurde erfolgreich durchgeführt."
+          "error": "Die Matrikelnummer darf nicht leer sein.",
+          "new-student-number-label": "Neue Matrikelnummer",
+          "student-number": "Aktuelle Matrikelnummer von {firstName} {lastName} ist:",
+          "success": "Die Matrikelnummer von {firstName} {lastName} wurde erfolgreich geändert."
         },
-        "title": "Ausgabe der Studentennummer"
+        "title": "Änderung der Matrikelnummer"
       },
       "empty-state": {
-        "no-participants": "Bisher noch keine Schüler!",
-        "no-participants-action": "Der Administrator muss die Schüler importieren, indem er auf die Schaltfläche Importieren klickt."
+        "no-participants": "Derzeit keine Studierenden vorhanden!",
+        "no-participants-action": "Die:Der Administrator:in muss die Studierenden importieren, indem sie:er auf die Schaltfläche „Importieren“ klickt."
       },
       "filter": {
-        "aria-label": "Schüler filtern",
+        "aria-label": "Studierende filtern",
         "certificability": {
-          "label": "Suche nach Zertifizierbarkeit",
+          "label": "Nach Zertifizierbarkeit suchen",
           "placeholder": "Zertifizierbarkeit"
         },
         "group": {
           "empty": "Keine Gruppe",
-          "label": "Eine Gruppe eingeben",
+          "label": "Gruppe eingeben",
           "placeholder": "Nach Gruppen suchen"
         },
         "student-number": {
-          "label": "Eine Studentennummer eingeben",
+          "label": "Matrikelnummer eingeben",
           "placeholder": "1234658P"
         },
-        "students-count": "{count, plural, =0 {0 Studierende} =1 {1 Studierende} other {{count} Studierende}}"
+        "students-count": "{count, plural, =0 {0 Studierende} =1 {1 Studierende:r} other {{count} Studierende}}"
       },
       "page-title": "Studierende",
       "replace-students-modal": {
-        "confirm": "Ja, ich ersetze",
-        "confirmation-checkbox": "Ich bestätige, dass ich die Auswirkungen richtig verstanden habe",
-        "footer-content": "Schüler, die in der Anwendung existieren und im neuen Import vorhanden sind, werden nicht gelöscht und bei Bedarf aktualisiert.",
-        "last-warning": "Achtung, diese Aktion ist unumkehrbar. Schüler, die im neuen Import nicht vorhanden sind, werden aus Pix Orga entfernt.",
+        "confirm": "Ersetzen bestätigen",
+        "confirmation-checkbox": "Ich bestätige, die Auswirkungen verstanden zu haben",
+        "footer-content": "Die in der Anwendung bereits vorhandenen Studierenden, die im neuen Import enthalten sind, werden nicht gelöscht und bei Bedarf aktualisiert.",
+        "last-warning": "Achtung: Diese Aktion kann nicht rückgängig gemacht werden. Die Studierenden, die im neuen Import nicht enthalten sind, werden aus Pix Orga gelöscht.",
         "main-content": "Alle ihre Teilnahmen an Kampagnen werden gelöscht. Dies hat Auswirkungen auf die Ergebnisse und Analysen der Kampagnen, die sie durchgeführt haben. Sie können nicht mehr an Kampagnen teilnehmen, an denen sie in der Vergangenheit teilgenommen haben. Sie können jedoch an neuen Kampagnen teilnehmen.",
-        "title": "Sind Sie sicher, dass Sie die vorhandenen Schüler ersetzen wollen?"
+        "title": "Bist du sicher, dass du die vorhandenen Studierenden ersetzen möchtest?"
       },
       "table": {
         "column": {
@@ -2029,10 +2029,10 @@
             "label": "Zertifizierbarkeit"
           },
           "last-name": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Namen sortiert. Klicken Sie, um alphabetisch zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach Namen in umgekehrter alphabetischer Reihenfolge sortiert. Klicken Sie, um alphabetisch zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach Namen in alphabetischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
-            "label": "Name"
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Nachnamen sortiert. Klicke hier, um alphabetisch zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Nachnamen in umgekehrter alphabetischer Reihenfolge sortiert. Klicke hier, um alphabetisch zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Nachnamen in alphabetischer Reihenfolge sortiert. Klicke hier, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
+            "label": "Nachname"
           },
           "last-participation-date": {
             "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach dem Datum der Beteiligungen sortiert. Klicken Sie, um aufsteigend zu sortieren.",
@@ -2041,37 +2041,37 @@
             "label": "Letzte Teilnahme"
           },
           "participation-count": {
-            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach der Anzahl der Teilnahmen sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
-            "ariaLabelSortDown": "Die Tabelle wird nach der Anzahl der Teilnahmen absteigend sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
-            "ariaLabelSortUp": "Die Tabelle wird nach der Anzahl der Teilnahmen aufsteigend sortiert. Klicken Sie, um in absteigender Reihenfolge zu sortieren.",
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach Anzahl der Teilnahmen sortiert. Klicke hier, um in aufsteigender Reihenfolge zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle ist nach Anzahl der Teilnahmen in absteigender Reihenfolge sortiert. Klicke hier, um in aufsteigender Reihenfolge zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle ist nach Anzahl der Teilnahmen in aufsteigender Reihenfolge sortiert. Klicke hier, um in absteigender Reihenfolge zu sortieren.",
             "label": "Anzahl der Teilnahmen"
           },
-          "student-number": "Studentennummer"
+          "student-number": "Matrikelnummer"
         },
-        "description": "Nach Namen sortierte Tabelle der Schüler. Über ein Menü in einer zusätzlichen Spalte können Sie die Schülernummer ändern.",
-        "empty": "Keine Schüler."
+        "description": "Studierenden-Tabelle nach Nachnamen sortiert. Du kannst über ein Menü in einer zusätzlichen Spalte die Matrikelnummer bearbeiten.",
+        "empty": "Keine Studierenden."
       },
-      "title": "{count, plural, =0 {Studenten} =1 {Schüler ({count})} other {Studenten ({count})}}"
+      "title": "{count, plural, =0 {Studierende} =1 {Studierende:r ({count})} other {Studierende ({count})}}"
     },
     "team-invitations": {
       "cancel-invitation": "Einladung löschen",
       "empty-table": "Sie haben keine ausstehenden Einladungen.",
-      "invitation-cancelled-succeed-message": "Die Einladung wurde tatsächlich gelöscht.",
-      "invitation-resent-succeed-message": "Die Einladung wurde ordnungsgemäß zurückgeschickt.",
+      "invitation-cancelled-succeed-message": "Die Einladung wurde erfolgreich gelöscht.",
+      "invitation-resent-succeed-message": "Die Einladung wurde erfolgreich erneut gesendet.",
       "resend-invitation": "Einladung erneut senden",
       "table": {
         "column": {
           "email-address": "E-Mail-Adresse",
-          "pending-invitation": "Datum der letzten Sendung"
+          "pending-invitation": "Zuletzt gesendet am"
         },
         "row": {
-          "aria-label": "Einladung wartet"
+          "aria-label": "Ausstehende Einladung"
         }
       },
       "title": "Einladungen"
     },
     "team-list": {
-      "add-member-button": "Ein Mitglied einladen",
+      "add-member-button": "Mitglied einladen",
       "tabs": {
         "invitation": "Einladungen ({count, plural, =0 {-} other {{count}}})",
         "member": "Mitglieder ({count, plural, =0 {-} other {{count}}})"
@@ -2081,12 +2081,12 @@
     "team-members": {
       "actions": {
         "edit-organization-membership-role": "Rolle ändern",
-        "leave-organization": "Diesen Bereich verlassen Pix Orga",
+        "leave-organization": "Diesen Pix Orga-Bereich verlassen",
         "manage": "Verwalten",
         "remove-membership": "Löschen",
-        "save": "Registrieren",
+        "save": "Speichern",
         "select-role": {
-          "label": "Eine Rolle auswählen",
+          "label": "Rolle auswählen",
           "options": {
             "admin": "Administrator",
             "member": "Mitglied"
@@ -2095,18 +2095,18 @@
       },
       "modals": {
         "leave-organization": {
-          "message": "Sind Sie sicher, dass Sie diesen Pix Orga-Bereich verlassen möchten? Sie werden keinen Zugriff mehr auf <strong>{organizationName}</strong> haben.<br/><br/>Ihre Kampagnen bleiben für den Rest des Teams zugänglich, sie werden nicht archiviert.<br/><br/>Ihr Zugriff auf andere Pix Orga-Räume wird nicht beeinflusst.<br/><br/>Sie werden ausgeloggt.",
-          "title": "Diesen Bereich verlassen Pix Orga"
+          "message": "Bist du sicher, dass du diesen Pix Orga-Bereich verlassen möchtest? Du wirst keinen Zugriff mehr auf <strong>{organizationName}</strong> haben.<br/><br/>Deine Kampagnen bleiben für den Rest des Teams zugänglich, sie werden nicht archiviert.<br/><br/>Dein Zugriff auf andere Pix Orga-Bereiche ist davon nicht betroffen.<br/><br/>.Du wirst abgemeldet.",
+          "title": "Diesen Pix Orga-Bereich verlassen"
         }
       },
       "notifications": {
         "change-member-role": {
           "error": "Bei der Änderung der Rolle des Mitglieds ist ein Fehler aufgetreten.",
-          "success": "Die Rolle wurde tatsächlich geändert."
+          "success": "Die Rolle wurde erfolgreich geändert."
         },
         "leave-organization": {
           "error": "Beim Deaktivieren des Mitglieds ist ein Fehler aufgetreten.",
-          "success": "Sie wurden erfolgreich aus der Organisation {organizationName} entfernt. Sie werden von Pix Orga abgemeldet..."
+          "success": "Du wurdest erfolgreich aus der Organisation {organizationName} entfernt. Du wirst aus Pix Orga abgemeldet..."
         },
         "remove-membership": {
           "error": "Beim Deaktivieren des Mitglieds ist ein Fehler aufgetreten.",
@@ -2115,15 +2115,15 @@
       },
       "remove-membership-modal": {
         "actions": {
-          "remove": "Ja, Mitglied löschen"
+          "remove": "Ja, Mitglied entfernen"
         },
-        "message": "{memberFirstName} {memberLastName} wird nicht mehr auf diesen Pix Orga-Bereich zugreifen können.'<br>'Seine Kampagnen bleiben für den Rest des Teams zugänglich.",
-        "title": "Bestätigen Sie die Löschung?"
+        "message": "{memberFirstName} {memberLastName} wird nicht mehr auf diesen Pix Orga-Bereich zugreifen können.'<br>'Die Kampagnen der Person bleiben für den Rest des Teams zugänglich.",
+        "title": "Bestätigst du die Löschung?"
       },
       "table": {
         "column": {
           "first-name": "Vorname",
-          "last-name": "Name",
+          "last-name": "Nachname",
           "organization-membership-role": "Rolle"
         },
         "empty": "Warten auf Mitglieder"
@@ -2131,33 +2131,33 @@
       "title": "Mitglieder"
     },
     "team-new": {
-      "email-requirement": "Geben Sie hier die E-Mail-Adresse des Mitglieds ein, das Sie einladen möchten.",
+      "email-requirement": "Gib hier die E-Mail-Adresse des Mitglieds ein, das du einladen möchtest.",
       "errors": {
-        "default": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
-        "invalid-input": "Die von Ihnen eingereichten Daten haben nicht das richtige Format",
-        "mandatory-email-field": "Dieses Feld ist obligatorisch",
-        "sending-email-to-invalid-email-address": "Das Senden einer E-Mail für die Adresse {email} ist fehlgeschlagen. Der Postausgangsserver antwortete: \"{errorMessage}\".",
+        "default": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es später erneut.",
+        "invalid-input": "Die von dir übermittelten Daten haben nicht das richtige Format.",
+        "mandatory-email-field": "Dies ist ein Pflichtfeld.",
+        "sending-email-to-invalid-email-address": "Das Senden der E-Mail an die Adresse {email} ist fehlgeschlagen. Der Mailserver hat geantwortet: „{errorMessage}“",
         "status": {
-          "400": "Das Format der E-Mail-Adresse ist falsch.",
-          "404": "Diese E-Mail gehört keinem Nutzer.",
+          "400": "Das Format der E-Mail-Adresse ist ungültig.",
+          "404": "Diese E-Mail-Adresse gehört zu keinem:keiner Nutzer:in.",
           "412": "Dieses Mitglied wurde bereits hinzugefügt.",
-          "500": "Etwas ist schief gelaufen. Bitte versuchen Sie es noch einmal."
+          "500": "Etwas ist schiefgelaufen. Bitte versuche es erneut."
         }
       },
       "invite-form-modal": {
         "confirm": "Bestätigen",
-        "question": "Möchten Sie fortfahren?",
-        "title": "Bestätigen, dass neue Mitglieder zum Team hinzugefügt wurden",
-        "warning": "Die Mitglieder, die Sie hinzufügen, haben Zugriff auf die Ergebnisse der Teilnehmer und die Kampagnenanalyse."
+        "question": "Möchtest du fortfahren?",
+        "title": "Hinzufügen neuer Mitglieder zum Team bestätigen",
+        "warning": "Die von dir hinzugefügten Mitglieder erhalten Zugriff auf die Ergebnisse der Teilnehmer:innen und die Kampagnenanalysen."
       },
-      "invited-members": "Nach Erhalt der E-Mail können die Gäste wählen, ob sie ein Pix-Konto erstellen oder sich mit einem bestehenden Pix-Konto anmelden möchten.",
+      "invited-members": "Nach Erhalt der E-Mail können die Eingeladenen ein neues Pix-Konto erstellen oder sich mit einem bestehenden Pix-Konto anmelden.",
       "several-email-requirement": "Sie können mehrere Mitglieder einladen, indem Sie die E-Mail-Adressen durch Kommas trennen.",
       "success": {
-        "invitation": "Es wurde tatsächlich eine Einladung an die E-Mail-Adresse {email} gesendet.",
-        "multiple-invitations": "Es wurde tatsächlich eine Einladung an die aufgelisteten E-Mail-Adressen gesendet."
+        "invitation": "Du kannst mehrere Mitglieder einladen, indem du die E-Mail-Adressen durch Kommas trennst.",
+        "multiple-invitations": "Eine Einladung wurde erfolgreich an die E-Mail-Adresse {email} gesendet."
       },
       "title": "Ein Mitglied einladen",
-      "warning": "Die Mitglieder, die Sie unten hinzufügen, haben Zugriff auf die Ergebnisse der Teilnehmer und die Kampagnenanalyse. Bitte stellen Sie sicher, dass es sich bei den eingeladenen Personen um Mitglieder Ihrer Organisation handelt."
+      "warning": "Die unten von dir hinzugefügten Mitglieder erhalten Zugriff auf die Ergebnisse der Teilnehmer:innen und die Kampagnenanalysen. Bitte stelle sicher, dass die eingeladenen Personen Mitglieder deiner Organisation sind."
     },
     "team-new-item": {
       "input-label": "E-Mail-Adresse(n)",
@@ -2165,7 +2165,7 @@
     },
     "terms-of-service": {
       "accept": "Ich akzeptiere die Nutzungsbedingungen",
-      "title": "Bedingungen für die Nutzung"
+      "title": "Nutzungsbedingungen"
     }
   }
 }

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -2151,10 +2151,10 @@
         "warning": "Die von dir hinzugefügten Mitglieder erhalten Zugriff auf die Ergebnisse der Teilnehmer:innen und die Kampagnenanalysen."
       },
       "invited-members": "Nach Erhalt der E-Mail können die Eingeladenen ein neues Pix-Konto erstellen oder sich mit einem bestehenden Pix-Konto anmelden.",
-      "several-email-requirement": "Sie können mehrere Mitglieder einladen, indem Sie die E-Mail-Adressen durch Kommas trennen.",
+      "several-email-requirement": "Du kannst mehrere Mitglieder einladen, indem du die E-Mail-Adressen durch Kommas trennst.",
       "success": {
-        "invitation": "Du kannst mehrere Mitglieder einladen, indem du die E-Mail-Adressen durch Kommas trennst.",
-        "multiple-invitations": "Eine Einladung wurde erfolgreich an die E-Mail-Adresse {email} gesendet."
+        "invitation": "Eine Einladung wurde erfolgreich an die E-Mail-Adresse {email} gesendet.",
+        "multiple-invitations": "Eine Einladung wurde erfolgreich an die E-Mail-Adressen gesendet."
       },
       "title": "Ein Mitglied einladen",
       "warning": "Die unten von dir hinzugefügten Mitglieder erhalten Zugriff auf die Ergebnisse der Teilnehmer:innen und die Kampagnenanalysen. Bitte stelle sicher, dass die eingeladenen Personen Mitglieder deiner Organisation sind."

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -2,26 +2,26 @@
   "api-error-messages": {
     "campaign-creation": {
       "custom-landing-page_too_long": "El texto de presentación de la campaña es demasiado largo.",
-      "external-user-id-required": "Especifique la redacción del campo que se pedirá a los participantes que rellenen al inicio del curso.",
-      "id-pix-type-required": "Seleccione un tipo de identificador externo.",
-      "name-required": "Dé un nombre a su campaña.",
+      "external-user-id-required": "Indica el nombre del campo que se solicitará a los participantes al inicio del recorrido.",
+      "id-pix-type-required": "Selecciona un tipo de ID externo.",
+      "name-required": "Nombra tu campaña.",
       "owner_not_in_organization": "El propietario no forma parte de la organización.",
-      "purpose-required": "Elija el objetivo de su campaña: Evaluación o Recogida de perfiles.",
-      "target-profile-required": "Seleccione una ruta para su campaña.",
+      "purpose-required": "Elige el objetivo de tu campaña: Evaluar o Recopilar perfiles.",
+      "target-profile-required": "Selecciona una ruta para tu campaña.",
       "title_too_long": "El título de la campaña es demasiado largo."
     },
     "csv-import": {
-      "property-not-uniq": "Línea {line}: El campo \"{field}\" debe ser único dentro del fichero."
+      "property-not-uniq": "Línea {line}: El campo \"{field}\" debe ser único en el archivo."
     },
-    "default": "El servicio no está disponible temporalmente. Vuelva a intentarlo más tarde.",
+    "default": "Servicio temporalmente no disponible. Inténtelo de nuevo más tarde.",
     "edit-student-number": {
-      "student-number-exists": "El número de estudiante introducido ya está en uso por el estudiante {firstName} {lastName}."
+      "student-number-exists": "El número de estudiante introducido ya está siendo utilizado por el estudiante {firstName} {lastName}."
     },
-    "global": "Se ha producido un error. Vuelva a intentarlo más tarde.",
+    "global": "Se ha producido un error. Inténtalo de nuevo más tarde.",
     "or-separator": " o",
     "student-csv-import": {
       "bad-csv-format": "El archivo debe estar en formato csv con un separador de coma o punto y coma.",
-      "encoding-not-supported": "No se admite la codificación de archivos.",
+      "encoding-not-supported": "El archivo utiliza una codificación no compatible.",
       "field-bad-values": "Línea {line}: El campo \"{field}\" debe ser \"{valids}\".",
       "field-date-format": "Línea {line}: El campo \"{field}\" debe estar en formato \"{acceptedFormat}\".",
       "field-email-format": "Línea {line}: El campo \"{field}\" debe ser una dirección de correo electrónico válida.",
@@ -34,30 +34,30 @@
       "header-unknown": "Los títulos de las columnas deben ser idénticos a los de la plantilla.",
       "identifier-unique": "Línea {line}: El campo \"{field}\" de esta línea aparece varias veces en el archivo.",
       "insee-code-invalid": "Línea {line}: El campo \"{field}\" no está en formato INSEE.",
-      "payload-too-large": "El tamaño del archivo debe ser inferior a {maxSize}MB.",
+      "payload-too-large": "El tamaño del archivo no debe superar los {maxSize} MB.",
       "student-number-format": "Línea {line}: El campo \"{field}\" no debe tener caracteres especiales.",
-      "student-number-unique": "Línea {line}: El campo \"{field}\" debe ser único dentro del fichero."
+      "student-number-unique": "Línea {line}: El campo \"{field}\" debe ser único en el archivo."
     },
     "student-password-reset": {
       "organization-learner-does-not-belong-to-organization-error": "Algunos de los estudiantes seleccionados ya no figuran en esta organización.",
-      "organization-learner-without-username-error": "Algunos de los estudiantes seleccionados ya no tienen acceso. Por favor, actualice la página.",
-      "user-does-not-belong-to-organization-error": "Ya no tienes derechos para esta organización."
+      "organization-learner-without-username-error": "Algunos de los estudiantes seleccionados ya no tienen ID. Por favor, actualiza la página.",
+      "user-does-not-belong-to-organization-error": "Ya no tienes permisos en esta organización."
     },
     "student-xml-import": {
       "birth-city-code-required-for-french-student": "Un alumno con INE {nationalStudentId} no tiene rellenado el campo de código de municipio de nacimiento. Es obligatorio para todo alumno nacido en Francia.",
       "birthdate-required": "El alumno con el INE {nationalStudentId} no tiene rellenado el campo fecha de nacimiento. Es obligatorio para cada alumno.",
       "empty": "Los estudiantes deben tener un INE y una clase.",
-      "encoding-not-supported": "No se admite la codificación de archivos.",
-      "first-name-required": "El alumno con el INE {nationalStudentId} no tiene rellenado el campo nombre. Es obligatorio para cada alumno.",
+      "encoding-not-supported": "El archivo utiliza una codificación no compatible.",
+      "first-name-required": "El campo nombre del alumno con el INE {nationalStudentId} está vacío. Es obligatorio para cada alumno.",
       "ine-required": "El campo INE es obligatorio para cada estudiante.",
       "ine-unique": "El INE {nationalStudentId} está presente varias veces en el expediente para varios alumnos.",
       "invalid-birthdate-format": "Un alumno con un INE de {nationalStudentId} no tiene el formato de fecha de nacimiento correcto. Debe tener el formato 'DD/MM/AAAA'",
       "invalid-char-detected": "El nombre o apellido del alumno con INE {nationalStudentId} contiene caracteres no admitidos.",
-      "invalid-file": "El expediente no es conforme.",
-      "invalid-file-extension": "Extensión {fileExtension} no soportada.",
-      "last-name-required": "El alumno con el INE {nationalStudentId} no tiene rellenado el campo Apellidos. Es obligatorio para cada alumno.",
-      "payload-too-large": "El tamaño del archivo debe ser inferior a {maxSize}MB.",
-      "sex-code-required": "Un alumno con un INE de {nationalStudentId} no tiene rellenado el campo sexo. Es obligatorio para cada alumno.",
+      "invalid-file": "El archivo no es válido.",
+      "invalid-file-extension": "Extensión {fileExtension} no compatible.",
+      "last-name-required": "El campo Apellidos del alumno con el INE {nationalStudentId} está vacío. Es obligatorio para cada alumno.",
+      "payload-too-large": "El tamaño del archivo no debe superar los {maxSize} MB.",
+      "sex-code-required": "El campo sexo del alumno con el INE {nationalStudentId} está vacío. Es obligatorio para cada alumno.",
       "uai-mismatched": "El IAU que figura en el fichero SIECLE no corresponde al de su establecimiento."
     }
   },
@@ -66,24 +66,24 @@
   },
   "banners": {
     "certification": {
-      "message": "'<strong>'Certificaciones:'</strong>' no olvide '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizar las sesiones en Pix Certif'</a>' y, a continuación, descargar los certificados a través de la pestaña \"Certificaciones\" antes del inicio del nuevo curso escolar {year}."
+      "message": "'<strong>'Certificaciones:'</strong>' no olvides '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizar las sesiones en Pix Certif'</a>' ni de descarga los certificados a través de la pestaña \"Certificaciones\" antes del inicio de curso {year}."
     },
     "import": {
       "message": "Etapas clave del curso escolar :",
-      "step1a": "Implement : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guía descarga resultados' class='link link--banner link--bold link--underlined' '>'descarga resultados'</a>' certificación y",
+      "step1a": "Implementar : '<'a href='https://cloud.pix.fr/s/WjTnkSbFs9TDcSC' title='Guía descarga resultados' class='link link--banner link--bold link--underlined' '>'descarga resultados'</a>' certificación y",
       "step1b": "importar",
       "step1c": "base de datos de estudiantes (admin)",
-      "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Guía Iniciar los recorridos pix de vuelta al cole' class='link link--banner link--bold link--underlined' '>'Crear campañas'</a>' (itinerario de inicio de curso, de 6.º curso, temáticos, disciplinarios, específicos…).",
+      "step2": "'<'a href='https://cloud.pix.fr/s/d7MCSCq2RsSy5Pt' title='Guía Iniciar los recorridos pix de inicio de curso' class='link link--banner link--bold link--underlined' '>'Crear campañas'</a>' (itinerario de inicio de curso, de 6.º curso, temáticos, disciplinarios, específicos…).",
       "step3": "Certificar a los alumnos. '<'a href='https://cloud.pix.fr/s/opiFxfjygR76S8y' title='Guía Preparación y organización de la certificación de alumnos' class='link link--banner link--bold link--underlined' '>'Más información sobre la certificación'</a>'."
     },
     "last-places-lot-available": {
-      "message": "Tenga en cuenta que sus entradas caducan en {days, number} días."
+      "message": "Atención, sus plazas caducan en {days, number} días."
     },
     "maximum-places-exceeded": {
-      "message": "<b>¡Su organización ya no tiene plazas disponibles!</b><br />Para beneficiarse de todas las funcionalidades, libere plazas, póngase en contacto con su representante Pix o '<'a href='https://pix.fr/support/form/professionnel-le' title='contact-us(France)' class=\"{linkClasses}\"'>contacte con nosotros a través de este formulario</a>'. <br />Si es una organización fuera de Francia '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='contacta con nosotros (fuera de Francia)' class=\"{linkClasses}\" '>contacta con nosotros a través de este formulario</a>'."
+      "message": "<b>¡Tu organización ya no tiene plazas disponibles!</b><br />Libera plazas para acceder a todas las funcionalidades, ponte en contacto con tu representante Pix o '<'a href='https://pix.fr/support/form/professionnel-le' title='contáctanos(France)' class=\"{linkClasses}\"'>contáctanos a través de este formulario</a>'.<br />Si tu organización se encuentra fuera de Francia '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='contáctanos(fuera de Francia)' class=\"{linkClasses}\" '>contáctanos a través de este formulario</a>'."
     },
     "over-capacity": {
-      "message": "Tenga en cuenta que está utilizando más plazas que su capacidad total."
+      "message": "Atención, está utilizando más plazas de las que dispone."
     },
     "survey": {
       "message": "¡Ayuda a Pix a evolucionar Pix Orga respondiendo a esta breve encuesta sobre cómo utilizas las campañas! <'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Accede a la encuesta'</a>'"
@@ -95,7 +95,7 @@
       "value": "/{total} plazas"
     },
     "badges-acquisitions": {
-      "information": "Aquí encontrará el número de insignias obtenidas por sus participantes en esta campaña, así como el porcentaje obtenido.",
+      "information": "Aquí encontrarás el número de insignias obtenidas por tus participantes en esta campaña, así como el porcentaje obtenido.",
       "obtained": "obtenido",
       "title": "Insignias"
     },
@@ -105,27 +105,27 @@
       "value": "/{total} plazas"
     },
     "participants-average-results": {
-      "information": "Aquí encontrará los resultados medios de su campaña. Esta cifra incluye a todos los participantes que han completado el curso y enviado sus resultados.",
-      "title": "Resultado medio"
+      "information": "Aquí encontrarás la media de los resultados de tu campaña. Esta cifra incluye a todos los participantes que han completado su itinerario y enviado sus resultados.",
+      "title": "Media de resultados"
     },
     "participants-average-stages": {
-      "information": "Aquí puede ver el número medio de participantes en su campaña. Este número incluye a todos los participantes que han completado su curso y enviado sus resultados.",
-      "title": "Rodamiento medio"
+      "information": "Aquí encontrarás el nivel medio de tu campaña. Esta cifra incluye a todos los participantes que han completado su itinerario y enviado sus resultados.",
+      "title": "Nivel medio"
     },
     "participants-count": {
-      "information": "Aquí encontrará el número total de participantes en su campaña. Este número incluye a todos los participantes que han introducido el código y han iniciado su viaje o enviado su perfil.",
+      "information": "Aquí encontrarás el número total de participantes en tu campaña. Este número incluye a todos los participantes que han introducido el código e iniciado su viaje o enviado su perfil.",
       "loader": "Carga del número total de participantes",
       "title": "Número total de participantes"
     },
     "place-info": {
       "with-account": {
         "heading": "'<strong>'El participante tiene una cuenta Pix:'</strong>'",
-        "message-description": "Puede liberar plazas borrando participantes de la pestaña Participantes.",
+        "message-description": "Puedes liberar plazas eliminando participantes de la pestaña Participantes.",
         "message-main": "1 participante con al menos una participación en una campaña = 1 plaza ocupada."
       },
       "without-account": {
         "heading": "'<strong>'El participante no tiene cuenta en Pix'</strong>' (campaña con acceso sin cuenta):",
-        "message-description": "Puede liberar estas plazas borrando las entradas de la campaña que no tengan acceso a la cuenta en cuestión o borrando la campaña.",
+        "message-description": "Puedes liberar estas plazas eliminando participaciones de la campaña de acceso sin cuenta correspondiente o eliminando la campaña.",
         "message-main": "1 participación sin cuenta = 1 plaza ocupada."
       }
     },
@@ -137,7 +137,7 @@
   "charts": {
     "participants-by-day": {
       "captions": {
-        "shared": "Entradas completadas por día",
+        "shared": "Participaciones completadas por día",
         "started": "Número total de participantes por día"
       },
       "labels-a11y": {
@@ -154,8 +154,8 @@
     },
     "participants-by-mastery-percentage": {
       "label-a11y": "De {from, number, ::percent} a {to, number, ::percent}: {count, plural, =0 {0 participantes} =1 {1 participante} other {{count, number} participantes}}.",
-      "loader": "Carga del desglose de participantes por resultado",
-      "title": "Desglose de los participantes por resultado",
+      "loader": "Carga de la distribución de participantes por resultado",
+      "title": "Distribución de los participantes por resultado",
       "tooltip": {
         "label": "Número de participantes: {count}",
         "legend": "{from, number, ::percent} - {to, number, ::percent}",
@@ -163,25 +163,25 @@
       }
     },
     "participants-by-stage": {
-      "loader": "Carga del desglose de participantes por niveles",
+      "loader": "Carga de la distribución de participantes por niveles",
       "participants": "{count, plural, =0 {0 participante} =1 {1 participante} other {{count, number} participantes}}",
-      "title": "Desglose de los participantes por nivel"
+      "title": "Distribución de los participantes por nivel"
     },
     "participants-by-status": {
-      "a11y-title": "Desglose por estatus",
+      "a11y-title": "Desglose por estado",
       "labels-a11y": {
-        "shared": "{count, plural, =0 {0 participantes} =1 {1 participantes} other {{count, number} participantes}} que han enviado sus resultados.",
-        "started": "{count, plural, =0 {0 participantes} =1 {1 participantes} other {{count, number} participantes}} en pruebas"
+        "shared": "{count, plural, =0 {0 participantes} =1 {1 participantes} other {{count, number} participantes}} han enviado sus resultados.",
+        "started": "{count, plural, =0 {0 participantes} =1 {1 participantes} other {{count, number} participantes}} en fase de prueba"
       },
       "labels-legend": {
-        "shared": "Entradas cerradas ({count})",
-        "started": "En curso ({count})"
+        "shared": "Participaciones completadas ({count})",
+        "started": "En progreso ({count})"
       },
       "labels-tooltip": {
-        "shared": "Entradas completadas: {percentage, number, ::percent .0}",
-        "started": "En curso: {percentage, number, ::percent .0}"
+        "shared": "Participaciones completadas: {percentage, number, ::percent .0}",
+        "started": "En progreso: {percentage, number, ::percent .0}"
       },
-      "loader": "Proporciones de carga por estado",
+      "loader": "Carga de proporciones por estado",
       "title": "Reglamento"
     }
   },
@@ -190,54 +190,54 @@
       "back": "Volver",
       "cancel": "Cancelar",
       "close": "Cerrar",
-      "confirm": "Confirme",
+      "confirm": "Confirmar",
       "exit": "Salir",
       "global": "Acciones",
-      "link-to-participant": "Ver toda la actividad de los participantes",
-      "save": "Regístrese en"
+      "link-to-participant": "Ver actividad del participante",
+      "save": "Regístrate en"
     },
     "api-error-messages": {
-      "account-conflict": "Esta cuenta ya está asociada a esta organización. Inicie sesión con otra cuenta o póngase en contacto con el servicio de asistencia.",
-      "bad-request-error": "Los datos que ha enviado no están en el formato correcto.",
-      "default": "Se ha producido un error. Vuelva a intentarlo o póngase en contacto con el servicio de asistencia.",
-      "expired-authentication-key": "Su solicitud de autenticación ha caducado.",
-      "internal-server-error": "Se ha producido un error interno. Nuestros equipos están resolviendo el problema. Vuelva a intentarlo más tarde.",
+      "account-conflict": "Esta cuenta ya está asociada a esta organización. Inicia sesión con otra cuenta o ponte en contacto con el servicio de asistencia.",
+      "bad-request-error": "Los datos introducidos no tienen el formato correcto.",
+      "default": "Se ha producido un error. Vuelve a intentarlo o ponte en contacto con el servicio de asistencia.",
+      "expired-authentication-key": "Tu solicitud de autenticación ha caducado.",
+      "internal-server-error": "Se ha producido un error interno. Nuestro equipo está resolviendo el problema. Vuelve a intentarlo más tarde.",
       "login-unauthorized-error": "La dirección de correo electrónico o el nombre de usuario y/o la contraseña introducidos son incorrectos.",
       "login-unauthorized-remaining-attempts-error": "Atención: aún tienes {remainingAttempts, plural, =0 {0 intentos} =1 {1 intento} other {# intentos}} antes de que tu cuenta Pix se bloquee definitivamente.",
-      "login-unauthorized-remaining-attempts-with-user-name-error": "Advertencia: aún tienes {remainingAttempts, plural, =0 {0 intentos} =1 {1 intento} other {# intentos}} antes de que tu cuenta Pix se bloquee permanentemente.'<br>'Si lo olvidas, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecer tu contraseña y/o recuperar tu inicio de sesión.",
-      "login-unauthorized-with-user-name-error": "El nombre de usuario y/o la contraseña introducidos son incorrectos.'<br>'Si lo olvidas, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecer tu contraseña y/o recuperar tu nombre de usuario.",
-      "login-unexpected-error": "No se ha podido conectar. Por favor, inténtelo de nuevo en unos instantes. Si el problema persiste, <'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contacta con nosotros a través del centro de ayuda'</a>'.",
-      "login-user-blocked-error": "Tu cuenta está bloqueada porque has realizado demasiados intentos de conexión. Para desbloquearla, <'a href=\"{url}\"'>'contacta con nosotros'</a>'.",
-      "login-user-temporary-blocked-error": "Has realizado demasiados intentos de inicio de sesión, tu cuenta Pix está bloqueada temporalmente durante {blockingDurationMinutes} minutos. Vuelve a intentarlo más tarde o haz clic en <'a href=\"{url}\"'>'contraseña olvidada'</a>' para restablecerla.",
-      "login-user-temporary-blocked-with-username-error": "Has realizado demasiados intentos de inicio de sesión, tu cuenta Pix está bloqueada temporalmente durante {blockingDurationMinutes} minutos.'<br>'Si lo olvidas, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecer tu contraseña y/o recuperar tu inicio de sesión."
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Atención: aún tienes {remainingAttempts, plural, =0 {0 intentos} =1 {1 intento} other {# intentos}} antes de que tu cuenta Pix se bloquee permanentemente.'<br>'Si no recuerdas tus datos de acceso, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecer tu contraseña y/o recuperar tu nombre de usuario.",
+      "login-unauthorized-with-user-name-error": "El nombre de usuario y/o la contraseña introducidos son incorrectos.'<br>'Si no recuerdas tus datos de acceso, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecer tu contraseña y/o recuperar tu nombre de usuario.",
+      "login-unexpected-error": "No se ha podido establecer la conexión. Por favor, inténtalo de nuevo más tarde. Si el problema persiste, <'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contáctanos a través del centro de ayuda'</a>'.",
+      "login-user-blocked-error": "Tu cuenta está bloqueada porque has realizado demasiados intentos de inicio de sesión. Para desbloquearla, <'a href=\"{url}\"'>'ponte en contacto con nosotros'</a>'.",
+      "login-user-temporary-blocked-error": "Has realizado demasiados intentos de inicio de sesión, tu cuenta Pix está bloqueada temporalmente durante {blockingDurationMinutes} minutos. Vuelve a intentarlo más tarde o haz clic en <'a href=\"{url}\"'>'olvidé mi contraseña'</a>' para restablecerla.",
+      "login-user-temporary-blocked-with-username-error": "Has realizado demasiados intentos de inicio de sesión, tu cuenta Pix está bloqueada temporalmente durante {blockingDurationMinutes} minutos.'<br>'Si no recuerdas tus datos de acceso, '<strong>'ponte en contacto con tu profesor'</strong>' para restablecer tu contraseña y/o recuperar tu nombre de usuario."
     },
     "breadcrumb": "Rastro de migas de pan",
     "cgu": {
-      "error": "Debe aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
+      "error": "Debes aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
       "label": "Acepto las condiciones de uso y la política de privacidad de Pix",
       "read-message": "Lea las '<'a href=\"{cguUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'condiciones de uso'</a>' y la '<'a href=\"{dataProtectionPolicyUrl}\" class=\"link\" target=\"_blank\" rel=\"noreferrer\"'>'política de privacidad'</a>'."
     },
     "filters": {
       "actions": {
-        "clear": "Borrar filtros"
+        "clear": "Eliminar filtros"
       },
       "divisions": {
-        "empty": "Sin clase",
-        "label": "Búsqueda por clase",
+        "empty": "No hay clase",
+        "label": "Buscar por clase",
         "placeholder": "Clases"
       },
       "fullname": {
-        "label": "Búsqueda por nombre y apellidos",
+        "label": "Buscar por nombre y apellido",
         "placeholder": "Apellido, nombre"
       },
       "groups": {
         "empty": "No hay grupos",
-        "label": "Búsqueda por grupo",
+        "label": "Buscar por grupo",
         "placeholder": "Grupos"
       },
       "loading": "Cargando...",
       "participantExternalId": {
-        "label": "Búsqueda por ID externo"
+        "label": "Buscar por ID externo"
       },
       "placeholder": "-- Selecciona --",
       "search-label-list": "Búsqueda",
@@ -258,7 +258,7 @@
         "oralization": "Leer las instrucciones"
       }
     },
-    "loading": "Carga en curso",
+    "loading": "Carga en progreso",
     "no-content": "Sin contenido",
     "notification": {
       "close": "Cerrar la notificación"
@@ -272,30 +272,30 @@
       "title": "Ver"
     },
     "result": {
-      "accessibility-description": "Resultado obtenido = {percentage, number, ::percent}, es decir, el rodamiento {stage} sobre {totalStage}.",
+      "accessibility-description": "Resultado obtenido = {percentage, number, ::percent}, es decir, el nivel {stage} sobre {totalStage}.",
       "percentage": "{value, number, ::percent}",
       "stages": "{count, plural, =0 {0 estrellas} =1 {1 estrella} other {{count, number} estrellas}} de {total}"
     },
     "target-profile-details": {
       "results": {
-        "common": "Resultados mostrados en",
+        "common": "Los resultados se muestran en",
         "percent": "porcentaje",
         "star": "estrella"
       },
       "simplified-access": {
-        "with-account": "Acceso a la cuenta",
+        "with-account": "Acceso con cuenta",
         "without-account": "Acceso sin cuenta"
       },
-      "subjects": "Temas : {value, number}",
+      "subjects": "Temáticas : {value, number}",
       "thematic-results": "Insignias: {value, number}"
     },
     "validation": {
       "password": {
         "error": "Ha introducido una contraseña incorrecta. Su contraseña debe tener más de 8 caracteres y contener al menos un número, una letra minúscula y una letra mayúscula.",
         "rules": {
-          "contains-digit": "una cifra mínima",
-          "contains-lowercase": "un mínimo ínfimo",
-          "contains-uppercase": "al menos una letra mayúscula",
+          "contains-digit": "Debes incluir al menos un número",
+          "contains-lowercase": "Debes incluir al menos una minúscula",
+          "contains-uppercase": "Debes incluir al menos una mayúscula",
           "min-length": "8 caracteres como mínimo"
         }
       }
@@ -305,44 +305,44 @@
     "activity-type": {
       "explanation": {
         "ASSESSMENT": "Campaña de evaluación",
-        "COMBINED_COURSE": "Ruta de aprendizaje",
-        "EXAM": "Modo de consulta",
-        "PROFILES_COLLECTION": "Campaña de recogida de perfiles",
+        "COMBINED_COURSE": "Itinerario de aprendizaje",
+        "EXAM": "Modo examen",
+        "PROFILES_COLLECTION": "Campaña de recopilación de perfiles",
         "campaign": "Campaña de evaluación",
         "formation": "Formación",
         "module": "Módulo"
       },
       "information": {
         "ASSESSMENT": "Evaluación",
-        "COMBINED_COURSE": "Ruta de aprendizaje",
-        "EXAM": "Modo de consulta",
-        "PROFILES_COLLECTION": "Colección de perfiles",
+        "COMBINED_COURSE": "Itinerario de aprendizaje",
+        "EXAM": "Modo examen",
+        "PROFILES_COLLECTION": "Recopilación de perfiles",
         "campaign": "Evaluación",
         "formation": "Formación",
         "module": "Módulo"
       }
     },
     "analysis-per-competence": {
-      "cover-rate-gauge-label": "{count, plural, =1 {En la competencia sus participantes alcanzaron un nivel de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.} other {En la competencia sus participantes alcanzaron un nivel de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.}}.",
-      "description": "{count, plural, =1 {Abajo, encuentra las habilidades de la campaña y sus descripciones, así como el posicionamiento de los participantes.} other {Abajo, encuentra las habilidades de la campaña y sus descripciones, así como el posicionamiento de los participantes.}}.",
+      "cover-rate-gauge-label": "{count, plural, =1 {En esta competencia, tu participante alcanzó un nivel de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.} other {En esta competencia, tus participantes alcanzaron un nivel de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.}}",
+      "description": "{count, plural, =1 {Abajo, encuentra las competencias de la campaña y sus descripciones, así como el posicionamiento de los participantes.} other {Abajo, encuentra las competencia de la campaña y sus descripciones, así como el posicionamiento de los participantes.}}",
       "table": {
-        "caption": "Habilidades",
+        "caption": "Competencias",
         "column": {
-          "competences": "Nombre y descripción de la habilidad",
+          "competences": "Nombre y descripción de la competencia",
           "level": "Nivel",
           "positioning": "Posicionamiento"
         }
       }
     },
     "analysis-per-tube": {
-      "cover-rate-gauge-label": "{count, plural, =1 {En el tema su participante alcanzó un nivel de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.} other {En el tema sus participantes alcanzaron un nivel de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.}}.",
-      "description": "{count, plural, =1 {Abajo, encuentra los temas de la campaña y sus descripciones así como el posicionamiento de los participantes.} other {Abajo, encuentra los temas de la campaña y sus descripciones así como el posicionamiento de los participantes.}}",
+      "cover-rate-gauge-label": "{count, plural, =1 {En esta temática, tu participante alcanzó un nivel de {reachedLevel} sobre un máximo de {maxLevel}.} other {En esta temática, tus participantes alcanzaron un nivel de {reachedLevel} sobre un máximo de {maxLevel}.}}",
+      "description": "{count, plural, =1 {Abajo, encuentra las temáticas de la campaña y sus descripciones así como el posicionamiento de los participantes.} other {Abajo, encuentra las temáticas de la campaña y sus descripciones así como el posicionamiento de los participantes.}}",
       "table": {
         "caption": "{index} - {name}",
         "column": {
           "level": "Nivel",
           "positioning": "Posicionamiento",
-          "tubes": "Nombre y descripción del sujeto"
+          "tubes": "Nombre y descripción de la temática"
         }
       }
     },
@@ -350,52 +350,52 @@
       "title": "Posicionamiento detallado",
       "toggle": {
         "label": "Visto por :",
-        "label-competences": "Habilidades",
-        "label-tubes": "Temas"
+        "label-competences": "Competencias",
+        "label-tubes": "Temáticas"
       }
     },
     "authentication": {
       "authentication-identity-providers": {
-        "select-another-organization-link": "Elija otro método de conexión",
+        "select-another-organization-link": "Elige otro método de acceso",
         "spacer": {
           "or": "o"
         }
       },
       "oidc-association-confirmation": {
-        "authentication-method-to-add": "Conexión añadida",
-        "confirm": "Continúe en",
-        "current-authentication-methods": "Mis métodos de conexión actuales",
+        "authentication-method-to-add": "Acceso añadido",
+        "confirm": "Sigue en",
+        "current-authentication-methods": "Mis métodos de acceso actuales",
         "email": "Correo electrónico",
-        "external-connection": "Conexión externa",
-        "external-connection-via": "Conexión a través de",
+        "external-connection": "Acceso externo",
+        "external-connection-via": "Acceso a través de",
         "return": "Volver",
         "title": "Un nuevo método de acceso está a punto de ser añadido a tu cuenta Pix",
-        "username": "Identificador"
+        "username": "Nombre de usuario"
       },
       "oidc-provider-selector": {
-        "label": "Buscar un método de conexión",
-        "placeholder": "Seleccione un método de conexión",
-        "searchLabel": "Búsqueda por palabras clave"
+        "label": "Buscar un método de acceso",
+        "placeholder": "Seleccione un método de acceso",
+        "searchLabel": "Buscar por palabras clave"
       }
     },
     "certificability": {
       "placeholder-select": "Certificable / No certificable"
     },
     "certificability-tooltip": {
-      "aria-label": "Explicación de la certificabilidad",
-      "content": "La certificabilidad significa que el participante ha alcanzado el nivel 1 en al menos 5 competencias.",
-      "from-collect-notice": "La información procede de las campañas de recogida de perfiles realizadas por el participante. Si el participante ya ha enviado su perfil, se muestran la fecha y el estado del último envío.",
-      "from-compute-certificability": "Este estado se actualiza automáticamente al día siguiente de cada conexión del participante y durante las recopilaciones de perfil."
+      "aria-label": "¿Qué significa ser certificable?",
+      "content": "Un participante es certificable cuando ha alcanzado el nivel 1 en al menos 5 competencias.",
+      "from-collect-notice": "La información procede de las campañas de recopilación de perfiles realizadas por el participante. Si el participante ya ha enviado su perfil, se muestran la fecha y el estado del último envío.",
+      "from-compute-certificability": "Este estado se actualiza automáticamente al día siguiente de cada conexión del participante y durante las campañas de recopilación de perfil."
     },
     "cover-rate-gauge": {
-      "label": "En esta campaña, tus participantes alcanzaron un nivel de {reachedLevel} de un nivel máximo alcanzable de {maxLevel}."
+      "label": "En esta campaña, tus participantes alcanzaron un nivel de {reachedLevel} de un máximo de {maxLevel}."
     },
     "date": {
       "no-date": "Aún no hay fecha"
     },
     "global-positioning": {
       "description": "El posicionamiento global es el nivel medio alcanzado por los participantes (barra morada) comparado con el máximo que podrían haber alcanzado en esta campaña (barra blanca).",
-      "gauge-label": "Durante esta campaña, sus participantes alcanzaron un nivel medio de {reachedLevel} sobre un nivel máximo alcanzable de {maxLevel}.",
+      "gauge-label": "Durante esta campaña, tus participantes alcanzaron un nivel medio de {reachedLevel} sobre un máximo de {maxLevel}.",
       "title": "Posicionamiento global"
     },
     "group": {
@@ -405,7 +405,7 @@
     "import-information-banner": {
       "error": "Error de importación",
       "error-link": "(véase la página de importación).",
-      "in-progress": "Una importación está en curso",
+      "in-progress": "Importando",
       "in-progress-link": "(compruebe el estado de la importación).",
       "success": "Los participantes fueron efectivamente importados en {date} por {firstname} {lastname}."
     },
@@ -414,61 +414,61 @@
         "classic": {
           "create-campaign": {
             "buttonText": "Nueva campaña",
-            "description": "Elija el curso en el que desea evaluar a sus participantes o recopilar su perfil Pix.",
+            "description": "Elige el itinerario con el que deseas evaluar a tus participantes o recopilar sus perfil Pix.",
             "title": "Crear una campaña"
           },
           "follow-activity": {
             "buttonText": "Ver mis campañas",
-            "description": "Consulte el estado y los resultados de sus participantes.",
+            "description": "Consulta el estado y los resultados de tus participantes.",
             "title": "Seguimiento de la actividad"
           }
         },
         "missions": {
           "extend-session": {
-            "buttonText": "Prolongue su sesión"
+            "buttonText": "Prolongar sesión"
           },
           "follow-activity": {
             "buttonText": "Ver las misiones",
-            "description": "Consulte el estado y los resultados de sus participantes.",
+            "description": "Consulta el estado y los resultados de tus participantes.",
             "title": "Seguimiento de la actividad"
           },
           "launch-session": {
             "buttonText": "Activar la sesión",
-            "description": "La sesión da acceso a los estudiantes a Pix Junior durante 4 horas. Una vez activada la sesión, puede prorrogarse.",
+            "description": "La sesión permite a los alumnos acceder a Pix Junior durante 4 horas. Una vez la sesión activada, es posible prolongarla.",
             "title": "Gestionar una sesión"
           }
         },
-        "title": "¿Qué le gustaría hacer?"
+        "title": "¿Qué quisieras hacer?"
       },
       "organization-information": {
-        "label": "Nombre de su organización",
-        "title": "Información sobre su organización"
+        "label": "Nombre de tu organización",
+        "title": "Información sobre tu organización"
       },
       "participation-statistics": {
         "completed-participations": {
           "description": "Participaciones completadas en los últimos 30 días.",
-          "info": "El número de participaciones completadas en los últimos 30 días incluye las campañas activas de su propiedad.",
-          "no-completed-participations": "No se han realizado entradas en los últimos 30 días.",
-          "title": "Participaciones finalizadas"
+          "info": "El número de participaciones completadas en los últimos 30 días incluye las campañas activas que posees.",
+          "no-completed-participations": "No se han realizado participaciones en los últimos 30 días.",
+          "title": "Participaciones completadas"
         },
         "completion-rate": {
-          "description": "{completed} entradas completadas en {started} entradas iniciadas.",
-          "info": "La tasa de finalización se calcula a partir de las campañas activas que usted posee.",
+          "description": "{completed} participaciones completadas sobre {started} participaciones iniciadas.",
+          "info": "El porcentaje de finalización se calcula a partir de las campañas activas que posees.",
           "no-activity": "Sin actividad por el momento",
-          "title": "Tasa de finalización"
+          "title": "Porcentaje de finalización"
         }
       },
       "welcome": {
         "description": {
-          "classic": "¡Bienvenido a su plataforma de evaluación y desarrollo de competencias digitales! Configure y distribuya campañas entre sus participantes. Sigue su evolución y analiza sus resultados para ofrecerles un apoyo adaptado a sus necesidades.",
-          "missions": "Bienvenido a la plataforma de seguimiento de las competencias digitales de tus alumnos. Seleccione tareas y siga su progreso."
+          "classic": "Bienvenido a tu plataforma de evaluación y desarrollo de competencias digitales! Configura y difunde campañas entre tus participantes. Haz un seguimiento de sus progesos y analiza sus resultados para ofrecerles un acompañamiento adaptado a sus necesidades.",
+          "missions": "Bienvenido a tu plataforma de seguimiento pedagógico de competencias digitales. Selecciona las misiones y haz el seguimiento del progreso de sus alumnos."
         },
         "title": "Hola {name},"
       }
     },
     "locale-switcher": {
-      "label": "Seleccione un idioma",
-      "placeholder": "Seleccione un idioma"
+      "label": "Selecciona un idioma",
+      "placeholder": "Selecciona un idioma"
     },
     "organization-participants-header": {
       "default": {
@@ -484,29 +484,29 @@
     "participation-status": {
       "COMPLETED": "Completado",
       "LOCKED": "Bloqueado",
-      "NOT_STARTED": "Para hacer",
+      "NOT_STARTED": "Pendiente",
       "SHARED": "Completado",
-      "STARTED": "En curso"
+      "STARTED": "En progreso"
     },
     "terms-of-service": {
       "actions": {
         "accept": "Aceptar y continuar",
-        "document-link": "Lea las condiciones de uso",
-        "reject": "Rechazo y salida"
+        "document-link": "Lee las condiciones de uso",
+        "reject": "Rechazar y salir"
       },
       "message": {
-        "requested": "Para seguir utilizando Pix, lea y acepte nuestras Condiciones de uso.",
-        "update-requested": "Hemos actualizado nuestros Términos y Condiciones. Compruebe los cambios y acéptelos para continuar."
+        "requested": "Para seguir utilizando Pix, lee y acepta nuestras Condiciones de uso.",
+        "update-requested": "Hemos actualizado nuestros Términos y Condiciones. Comprueba los cambios y acéptalos para continuar."
       },
       "title": {
-        "requested": "Por favor, acepte nuestras Condiciones Generales de Uso (CGU)",
+        "requested": "Por favor, acepta nuestras Condiciones Generales de Uso (CGU)",
         "update-requested": "Actualización importante de las Condiciones Generales de Uso (CGU)"
       }
     },
     "ui": {
       "deletion-modal": {
-        "confirm-deletion": "Sí, estoy borrando",
-        "confirmation-checkbox": "{count, plural, =1 {Confirmo que comprendo perfectamente el impacto de la supresión} other {Confirmo que comprendo perfectamente el impacto de las {count} supresiones}}"
+        "confirm-deletion": "Sí, eliminar.",
+        "confirmation-checkbox": "{count, plural, =1 {Confirmo que entiendo las consecuencias de eliminar {count} elemento} other {Confirmo que entiendo las consecuencias de eliminar {count} elementos}}"
       },
       "edit-participant-name-modal": {
         "error-messages": {
@@ -531,7 +531,7 @@
     },
     "credits": {
       "number": "{count, plural, =0 {0 créditos} =1 {1 crédito} other {{count, number} créditos}}",
-      "tooltip-text": "El número de créditos mostrado corresponde al número de créditos adquiridos por la organización y actualmente válidos (independientemente de su activación). Para más información, póngase en contacto con nosotros en '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'."
+      "tooltip-text": "El número de créditos mostrado corresponde al número de créditos adquiridos por la organización y actualmente válidos (independientemente de su activación). Para más información, contáctanos por correo electrónico en '<a href=mailto:pro@pix.fr>'pro@pix.fr'</a>'."
     },
     "external-link-title": "Abrir en una ventana nueva",
     "footer": {
@@ -541,23 +541,23 @@
       "help-center": "Centro de ayuda",
       "legal-notice": "Información jurídica",
       "pix": "Pix",
-      "server-status": "Estado del departamento"
+      "server-status": "Estado de los servicios"
     },
     "main": {
       "aria-label": "Navegación principal",
       "attestations": "Certificados",
       "campaigns": "Campañas",
-      "catalogue": "catálogo",
+      "catalogue": "Catálogo",
       "certifications": "Certificaciones",
       "close": "Cerrar navegación",
-      "combined-courses": "Vías de aprendizaje",
+      "combined-courses": "Itinerarios de aprendizaje",
       "documentation": "Documentación",
       "home": "Inicio",
       "missions": "Misiones",
       "open": "Abrir navegación",
       "organization-participants": "Participantes",
-      "places": "Lugares",
-      "sco-organization-participants": "Estudiantes",
+      "places": "Plazas",
+      "sco-organization-participants": "Alumnos",
       "statistics": "Estadísticas",
       "sup-organization-participants": "Estudiantes",
       "support": "Centro de ayuda",
@@ -569,13 +569,13 @@
     },
     "school-sessions": {
       "activate-button": "Activar la sesión",
-      "extend-button": "Prolongue su sesión",
+      "extend-button": "Prolongar la sesión",
       "status": {
         "active-label": "Sesión activa hasta {sessionExpirationDate}",
         "aria-label": "Explicación de la sesión",
-        "code-label": "Código escolar",
+        "code-label": "Código escuela",
         "inactive-label": "Sesión inactiva",
-        "info-text": "Los estudiantes sólo pueden acceder a las misiones cuando la sesión está activa.'<br>' Al final de la sesión, los estudiantes que estén en medio de una misión no se desconectarán.",
+        "info-text": "Los estudiantes sólo pueden acceder a las misiones cuando la sesión está activa.'<br>'Al final de la sesión, los estudiantes que estén en medio de una misión no se desconectarán.",
         "title": "Estado de la sesión"
       }
     },
@@ -593,23 +593,23 @@
       "breadcrumb-current-page-label": "Participación de {firstName} {lastName}",
       "participation-label": "Participación #{participationNumber}",
       "participation-not-shared": "Resultados no enviados",
-      "participation-selector": "Elegir una estaca",
+      "participation-selector": "Elegir una participación",
       "participation-shared": "Envío de resultados",
-      "progression": "Avance",
-      "result": "Resultados",
+      "progression": "Progreso",
+      "result": "Resultado",
       "tab": {
         "results": "Resultados",
         "review": "Análisis"
       },
       "table": {
         "column": {
-          "competences": "Habilidades ({count, plural, =0 {-} other {{count}}})",
+          "competences": "Competencias ({count, plural, =0 {-} other {{count}}})",
           "results": {
             "label": "Resultados",
-            "tooltip": "'<span class=\"screen-reader-only\">'Este participante ha validado'</span>' {result, number, ::percent} '<span class=\"screen-reader-only\">'de habilidad {competence}.'</span>'"
+            "tooltip": "'<span class=\"screen-reader-only\">'Este participante ha validado'</span>' {result, number, ::percent} '<span class=\"screen-reader-only\">'de la competencia {competence}.'</span>'"
           }
         },
-        "empty": "A la espera de los resultados",
+        "empty": "Esperando resultados",
         "title": "Resultados por competencias"
       },
       "title": "Resultados de {firstName} {lastName}"
@@ -628,20 +628,20 @@
         "column": {
           "division": "Clase",
           "first-name": "Nombre",
-          "last-name": "Nombre",
-          "status": "Obtenga"
+          "last-name": "Apellido",
+          "status": "Obtenido"
         },
         "filter": {
           "divisions": {
             "empty-option": "Clase",
             "label": "Clase"
           },
-          "legend": "Filtros para la tabla de certificados: se pueden utilizar campos de entrada para filtrar la tabla por el nombre o apellido de un alumno y por clase. Los botones permiten filtrar o no los certificados obtenidos.",
+          "legend": "Filtros de la tabla de certificados: los campos de entrada permiten filtrar la tabla por nombre o apellido de un alumno y por clase. Los botones permiten filtrar los certificados obtenidos o no obtenidos.",
           "results": "{total, plural, =0 {0 resultado} =1 {1 resultado} other {{total, number} resultados}}",
           "status": {
             "empty-option": "Obtenido / No obtenido",
-            "label": "Obtenga",
-            "not-obtained": "No se ha obtenido",
+            "label": "Obtenido",
+            "not-obtained": "No obtenido",
             "obtained": "Obtenido"
           }
         },
@@ -661,11 +661,11 @@
       "code": "Código",
       "copy": {
         "code": {
-          "default": "Copie el código",
+          "default": "Copia el código",
           "success": "¡Copiado!"
         },
         "link": {
-          "default": "Copie el enlace directo",
+          "default": "Copia el enlace directo",
           "success": "¡Copiado!"
         }
       },
@@ -686,44 +686,44 @@
       "name": "Nombre de la campaña",
       "tab": {
         "activity": "Actividad",
-        "combined-courses": "Vías de aprendizaje",
+        "combined-courses": "Itinerario de aprendizaje",
         "results": "Resultados ({count, number})",
         "review": "Análisis",
-        "settings": "Parámetros"
+        "settings": "Configuración"
       }
     },
     "campaign-activity": {
       "actions": {
-        "delete": "Borrar"
+        "delete": "Eliminar"
       },
       "delete-participation-modal": {
         "actions": {
           "cancel": "No",
-          "confirmation": "Sí, estoy borrando"
+          "confirmation": "Sí, eliminar"
         },
-        "error": "Se ha producido un problema al eliminar la entrada.",
-        "success": "La apuesta se retiró con éxito.",
-        "text": "Si está a punto de eliminar una entrada, ya no será visible ni se incluirá en las estadísticas de la campaña.",
+        "error": "Error al eliminar la participación.",
+        "success": "La participación se ha eliminado correctamente.",
+        "text": "Está a punto de eliminar una participación, ya no será visible ni se incluirá en las estadísticas de la campaña.",
         "title": "Eliminar la participación de <strong>{firstName} {lastName}</strong>?",
         "warning": {
           "assessment-campaign-participation": {
             "shared-participation": "El participante ya no podrá acceder a los resultados de esta campaña.",
-            "started-participation": "El participante no podrá volver a participar."
+            "started-participation": "El participante ya no podrá retomar esta participación."
           },
           "profiles-collection-campaign-participation": {
-            "shared-participation": "El participante ya no podrá participar en esta recogida de perfiles."
+            "shared-participation": "El participante ya no podrá participar en esta recoplicaión de perfiles."
           }
         }
       },
       "table": {
         "column": {
-          "delete": "Eliminar la participación en los beneficios",
+          "delete": "Eliminar la participación",
           "first-name": "Nombre",
-          "last-name": "Nombre",
-          "participationCount": "Número de entradas",
+          "last-name": "Apellido",
+          "participationCount": "Número de participaciones.",
           "status": "Estado"
         },
-        "delete-button-label": "Eliminar la participación en los beneficios",
+        "delete-button-label": "Eliminar la participación",
         "empty": "Ningún participante",
         "see-results": "Ver resultados para {firstName} {lastName}",
         "title": "Lista de participantes"
@@ -732,9 +732,9 @@
     },
     "campaign-analysis": {
       "description": {
-        "explanation": "{count, plural, =1 {El posicionamiento refleja el nivel medio alcanzado por el participante, en relación con el nivel máximo alcanzable en esta campaña.} other {El posicionamiento refleja el nivel medio alcanzado por los participantes, en relación con el nivel máximo alcanzable en esta campaña.}}",
+        "explanation": "{count, plural, =1 {El posicionamiento refleja el nivel medio alcanzado por el participante, en relación con el máximo nivel de esta campaña.} other {El posicionamiento refleja el nivel medio alcanzado por los participantes, en relación con el máximo nivel de esta campaña.}}",
         "nota-bene": "{count, plural, =1 {Todos los datos presentados proceden de la participación seleccionada.} other {Todos los datos presentados proceden de participaciones compartidas y no eliminadas de campañas de evaluación y se actualizan en cada visita.}}",
-        "resume": "{count, plural, =1 {Analiza por habilidad o por materia, el posicionamiento del participante en esta campaña que cubre una selección de temas del marco de referencia Pix.} other {Analiza por habilidad o por materia, el posicionamiento de sus participantes en esta campaña que cubre una selección de temas del marco de referencia Pix.}}."
+        "resume": "{count, plural, =1 {Analiza por competencia o por temática el posicionamiento del participante en esta campaña que cubre una selección de temáticas del marco de referencia Pix.} other {Analiza por competencia o por temática el posicionamiento de tus participantes en esta campaña que cubre una selección de  temáticas del marco de referencia Pix.}}"
       },
       "levels-correspondence": {
         "infos": {
@@ -754,31 +754,31 @@
     "campaign-creation": {
       "actions": {
         "create": "Crear la campaña",
-        "delete": "Borrar"
+        "delete": "Eliminar"
       },
-      "combined-course-blueprints-label": "Seleccionar una vía de aprendizaje",
-      "combined-course-blueprints-list-label": "Seleccionar una vía de aprendizaje",
+      "combined-course-blueprints-label": "Seleccionar un itinerario de aprendizaje",
+      "combined-course-blueprints-list-label": "Seleccionar un itinerario de aprendizaje",
       "copy-of": "Copia de",
       "course-label": "Seleccionar un curso",
       "course-selection-label": "Seleccionar un curso",
       "course-title": {
-        "label": "Título del curso",
-        "sublabel": "Este campo se mostrará a los participantes de la campaña."
+        "label": "Título del itinerario",
+        "sublabel": "Este campo será visible para los participantes de la campaña."
       },
       "customization": {
         "title": "Personalización"
       },
       "exam-mode": {
-        "label": "¿Desea activar el modo de consulta?"
+        "label": "¿Desea activar el modo de examen?"
       },
       "external-id-label": {
         "information": {
-          "label": "Identificador adicional",
+          "label": "Nombre del ID externo",
           "message": "El identificador adicional te permite solicitar la información de identificación que desees al inicio de la campaña a cada participante.'<br>'Si seleccionas «sí», podrás filtrar y ordenar a los participantes según este dato.'<br>'Si seleccionas «no», solo estarán disponibles el nombre y los apellidos de la cuenta del participante en el seguimiento de la campaña."
         },
         "label": "Denominación del identificador adicional",
-        "question-label": "¿Desea solicitar un identificador adicional al inicio de su participación?",
-        "required": "El identificador adicional es obligatorio",
+        "question-label": "¿Desea solicitar un ID externo?",
+        "required": "El ID externo es obligatorio",
         "suggestion": "Ejemplo: \"Número de estudiante\" o \"Dirección de correo electrónico profesional\" *."
       },
       "external-id-type": {
@@ -786,22 +786,22 @@
           "label": "Tipo de identificador adicional",
           "message": "El tipo «dirección de correo electrónico» permite comprobar que el formato de la dirección introducida por el participante es correcto. Úsalo, por ejemplo, para solicitar una dirección de correo electrónico interna de tu centro.'<br>'El tipo «otro» ofrece un campo de texto breve. Úsalo para solicitar un número de estudiante, un número de matrícula o un identificador interno, o el nombre de un grupo o una clase."
         },
-        "question-label": "¿Qué tipo de identificador adicional desea solicitar?"
+        "question-label": "¿Cuál es el tipo de ID externo?"
       },
       "landing-page-text": {
         "label": "Texto de la página de inicio",
-        "sublabel": "Este campo se mostrará a los participantes de la campaña."
+        "sublabel": "Este campo será visible para los participantes de la campaña."
       },
       "legal-warning": "* De conformidad con la ley francesa de protección de datos, y como responsable del tratamiento, procure no pedir datos especialmente identificativos o significativos a menos que sean absolutamente imprescindibles. Debe evitarse el número de la Seguridad Social (NIR), así como cualquier dato sensible.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Si decide enviar la campaña varias veces, el participante podrá repetirla varias veces, introduciendo de nuevo el código. Tendrá acceso a todos los resultados.",
-          "question-label": "¿Desea permitir que los participantes envíen sus resultados más de una vez?"
+          "info": "Si eliges el envío múltiple, el participante podrá volver a realizar la campaña varias veces introduciendo nuevamente el código. Tendrás acceso a todos los resultados.",
+          "question-label": "¿Deseas permitir que los participantes envíen sus resultados varias veces?"
         },
         "info-title": "Envío múltiple",
-        "knowledge-elements-resettable": "Como parte del curso, los participantes pueden intentar mejorar sus resultados repitiendo todas las preguntas del curso.",
+        "knowledge-elements-resettable": "En el marco de este itinerario, el participante podrá intentar mejorar sus resultados respondiendo a las preguntas tantas veces como lo necesite.",
         "profiles": {
-          "info": "Si elige enviar varios perfiles, los participantes podrán enviar su perfil varias veces volviendo a introducir el código de la campaña. Dentro de Pix Orga, encontrará el último perfil enviado.",
+          "info": "Si eliges el envío múltiple, el participante podrá volver a enviar su perfil varias veces introduciendo nuevamente el código de campaña. En Pix Orga encontrarás el último perfil enviado.",
           "question-label": "¿Desea permitir que los participantes envíen su perfil varias veces?"
         }
       },
@@ -810,92 +810,92 @@
       },
       "no": "No",
       "owner": {
-        "info": "El propietario de la campaña y los administradores de esta organización son las únicas personas que pueden modificar o archivar esta campaña.",
+        "info": "El propietario de la campaña y los administradores de esta organización son las únicas personas que pueden editar o archivar esta campaña.",
         "label": "Propietario de la campaña",
         "placeholder": "Nombre completo del propietario",
-        "search-label": "Encontrar un propietario",
-        "search-placeholder": "Encontrar un propietario",
+        "search-label": "Buscar un propietario",
+        "search-placeholder": "Buscar un propietario",
         "title": "Propietario de la campaña"
       },
       "purpose": {
-        "assessment": "Evaluación de los participantes",
-        "assessment-info": "Una campaña de evaluación permite poner a prueba a los participantes sobre temas concretos.",
+        "assessment": "Evaluar a los participantes",
+        "assessment-info": "Una campaña de evaluación permite evaluar a los participantes sobre temáticas específicas.",
         "combined-course": "Desarrollar las competencias de los participantes",
-        "combined-course-info": "Una vía de aprendizaje ayuda a los participantes a adquirir nuevas competencias.",
-        "exam": "Modo de consulta",
-        "exam-info": "Una campaña en \"modo test\" permite examinar a los participantes sobre temas específicos, sin tener en cuenta su perfil de usuario ni influir en él. Los tests propuestos son personalizados para cada participante, en función de lo avanzado que esté en el curso.",
-        "label": "¿Cuál es el objetivo de su campaña?",
-        "profiles-collection": "Recoger los perfiles Pix de los participantes",
-        "profiles-collection-info": "Se utiliza una campaña de recogida de perfiles para recuperar el perfil de los participantes: niveles por habilidad y puntuación pix.",
-        "profiles-collection-info-certificability-calculation": "El estado certificable se actualiza automáticamente en la pestaña <'a href=\"/eleves\" class=\"{linkClasses}\"'>'Alumnos'</a>'.",
+        "combined-course-info": "Un itinerario de aprendizaje ayuda a los participantes a adquirir nuevas competencias.",
+        "exam": "Modo examen",
+        "exam-info": "Una campaña en \"modo examen\" permite evaluar a los participantes sobre temáticas específicas, sin tener en cuenta su perfil ni modificarlo. Las pruebas propuestas se personalizan para cada participante según su progreso en el itinerario.",
+        "label": "¿Cuál es el objetivo de tu campaña?",
+        "profiles-collection": "Recopilar los perfiles Pix de los participantes",
+        "profiles-collection-info": "Una campaña de recopilación de perfiles sirve para recuperar el perfil de los participantes: niveles por competencia y puntuación Pix.",
+        "profiles-collection-info-certificability-calculation": "El estado Certificable se actualiza automáticamente en la pestaña <'a href=\"/eleves\" class=\"{linkClasses}\"'>'Alumnos'</a>'.",
         "title": "Objetivo"
       },
       "settings": {
         "title": "Configuración"
       },
       "tags": {
-        "BACK_TO_SCHOOL": "Curso de vuelta al cole / 6e",
+        "BACK_TO_SCHOOL": "Itinerario de inicio de curso / 6e",
         "COMPETENCES": "Las 16 competencias",
-        "CUSTOM": "Cursos a medida",
-        "DISCIPLINE": "Disciplinario",
+        "CUSTOM": "Itinerarios a medida",
+        "DISCIPLINE": "Disciplinarios",
         "OTHER": "Otros",
         "PIX_PLUS": "Pix+",
-        "PREDEFINED": "Rutas predefinidas",
-        "SUBJECT": "Temas",
-        "TARGETED": "Cursos específicos"
+        "PREDEFINED": "Itinerarios predefinidos",
+        "SUBJECT": "Temáticas",
+        "TARGETED": "Itinerarios específicos"
       },
-      "tags-title": "Filtrar búsqueda :",
-      "target-profiles-category-label": "Filtrar rutas por categoría",
+      "tags-title": "Filtrar búsqueda:",
+      "target-profiles-category-label": "Filtrar itinerarios por categoría",
       "target-profiles-category-placeholder": "Categorías",
-      "target-profiles-label": "Seleccione una ruta",
-      "target-profiles-list-label": "¿Qué le gustaría probar?",
+      "target-profiles-label": "Selecciona un itineario",
+      "target-profiles-list-label": "¿Qué quisieras probar?",
       "target-profiles-search-placeholder": "Buscar por nombre",
       "title": "Crear una campaña",
       "yes": "Sí"
     },
     "campaign-individual-results": {
       "shared-date": "Enviado el",
-      "start-date": "Comenzó el"
+      "start-date": "Comenzado el"
     },
     "campaign-individual-review": {
       "title": "Análisis para {firstName} {lastName}"
     },
     "campaign-modification": {
       "actions": {
-        "edit": "Modifique"
+        "edit": "Editar"
       },
       "campaign-modification-success-message": "Los cambios se han guardado.",
       "campaign-name": "Nombre de la campaña",
       "landing-page-text": {
         "label": "Texto de la página de inicio",
-        "sublabel": "Este campo se mostrará a los participantes de la campaña."
+        "sublabel": "Este campo será visible para los participantes de la campaña."
       },
       "owner": {
-        "info": "El propietario de la campaña y los administradores de esta organización son las únicas personas que pueden modificar y archivar esta campaña.",
+        "info": "El propietario de la campaña y los administradores de esta organización son las únicas personas que pueden editar y archivar esta campaña.",
         "label": "Propietario de la campaña",
         "placeholder": "Nombre completo del propietario",
         "title": "Propietario de la campaña"
       },
       "personalised-test-title": {
-        "label": "Título del curso",
-        "sublabel": "Este campo se mostrará a los participantes de la campaña."
+        "label": "Título del itinerario",
+        "sublabel": "Este campo será visible para los participantes de la campaña."
       },
-      "title": "Modificar una campaña"
+      "title": "Editar una campaña"
     },
     "campaign-results": {
-      "average": "Resultados medios",
+      "average": "Media de resultados",
       "filters": {
         "aria-label": "Filtros sobre participaciones",
         "participations-count": "{count, plural, =0 {0 participante} =1 {1 participante} other {{count} participantes}}",
         "type": {
           "badges": "Insignias obtenidas",
           "groups": {
-            "empty": "Ningún grupo",
+            "empty": "No hay grupo",
             "title": "Grupos"
           },
-          "stages": "Rodamientos",
+          "stages": "Niveles",
           "status": {
-            "empty": "Todas las entradas",
+            "empty": "Todas las participaciones",
             "title": "Estado"
           },
           "unacquired-badges": "Insignias no obtenidas"
@@ -904,27 +904,27 @@
       "result": "Resultados",
       "table": {
         "badge-tooltip": {
-          "acquired": "Adquirido",
-          "unacquired": "No adquirido"
+          "acquired": "Aprobado",
+          "unacquired": "No aprobado"
         },
-        "caption": "En esta tabla figuran los participantes que han compartido sus resultados. Para cada participante, muestra su apellido, nombre y resultados.",
+        "caption": "En esta tabla figuran los participantes que han compartido sus resultados. Para cada participante se muestra el apellido, el nombre y los resultados.",
         "column": {
           "ariaSharedResultCount": "Número de resultados enviados",
           "badges": "Insignias",
-          "evolution": "Evolución",
+          "evolution": "Progreso",
           "first-name": "Nombre",
           "last-name": "Nombre",
           "results": {
             "label": "Resultados",
-            "on-hold": " En espera de envío",
-            "under-test": "En fase de pruebas"
+            "on-hold": "Envío pendiente",
+            "under-test": "Evaluación en progreso"
           },
           "sharedResultCount": "Nº de resultados enviados"
         },
         "empty": "Sin participación",
         "evolution": {
-          "decrease": "En declive",
-          "increase": "En alza",
+          "decrease": "En retroceso",
+          "increase": "Progresando",
           "stable": "Constante",
           "unavailable": "No disponible"
         },
@@ -933,23 +933,23 @@
         },
         "title": "Lista de resultados recibidos"
       },
-      "tested-items": "Activos evaluados",
+      "tested-items": "Aprendizajes evaluados",
       "title": "Resultados",
-      "validated-items": "Logros validados"
+      "validated-items": "Aprendizajes validados"
     },
     "campaign-settings": {
       "actions": {
-        "archive": "Archivo",
+        "archive": "Archivar",
         "delete": "Eliminar",
         "delete-error": "Se ha producido un error, la campaña no se ha eliminado.",
         "delete-success": "La campaña (así como sus resultados) se ha eliminado correctamente.",
         "duplicate": "Duplicar",
-        "edit": "Modifique"
+        "edit": "Editar"
       },
       "campaign-type": {
         "assessment": "Campaña de evaluación",
-        "exam": "Campaña de concursos",
-        "profiles-collection": "Campaña de recogida de perfiles",
+        "exam": "Campaña de exámenes",
+        "profiles-collection": "Campaña de recopilación de perfiles",
         "title": "Tipo de campaña"
       },
       "delete-confirmation-modal": {
@@ -960,7 +960,7 @@
         },
         "title": "¿Está seguro de que desea eliminar la campaña?"
       },
-      "direct-link": "Enlace directo",
+      "direct-link": "Acceso directo",
       "external-user-id-label": "Denominación del identificador adicional",
       "external-user-id-types": {
         "email": "Correo electrónico",
@@ -975,55 +975,55 @@
         "title": "Envío múltiple",
         "tooltip": {
           "aria-label": "Descripción del envío múltiple",
-          "text": "Si se activan los envíos múltiples, los participantes pueden enviar sus participaciones varias veces volviendo a introducir el código de la campaña."
+          "text": "Si el envío múltiple está activado, el participante pueden enviar su participación varias veces volviendo a introducir el código de la campaña."
         }
       },
-      "personalised-test-title": "Título del curso",
+      "personalised-test-title": "Título del itinerario",
       "reset-to-zero": {
         "status": {
           "disabled": "No",
           "enabled": "Sí"
         },
-        "title": "Puesta a cero",
+        "title": "Reinicio",
         "tooltip": {
           "aria-label": "Descripción del reinicio",
-          "text": "Si la función de reinicio está activada, el participante puede volver a realizar todo el curso y enviar sus resultados, varias veces, introduciendo de nuevo el código de la campaña."
+          "text": "Si la función de reinicio está activada, el participante puede volver a realizar todo el itinerario y enviar sus resultados varias veces volviendo a introducir el código de la campaña."
         }
       },
       "target-profile": {
-        "title": "Curso",
-        "tooltip": "Descripción del curso"
+        "title": "Itinerario",
+        "tooltip": "Descripción del itinerario"
       },
-      "title": "Parámetros"
+      "title": "Configuración"
     },
     "campaigns-list": {
       "action": {
         "campaign": {
-          "archived": "Archivado",
+          "archived": "Archivadas",
           "label": "Mostrar campañas activas o archivadas",
-          "ongoing": "Activo"
+          "ongoing": "Activas"
         },
         "create": "Crear una campaña"
       },
       "action-bar": {
-        "delete-button": "Borrar",
+        "delete-button": "Eliminar",
         "error-message": "{count, plural, =1 {Se ha producido un error, la campaña no se ha eliminado de la lista.} other {Se ha producido un error, las {count} campañas seleccionadas no se han eliminado de la lista.}}.",
         "information": "{count, plural, =1 {{count} campaña seleccionada} other {{count} campañas seleccionadas}}",
         "success-message": "{count, plural, =1 {La campaña (junto con sus resultados) ha sido efectivamente eliminada de la lista.} other {Las {count} campañas seleccionadas (junto con sus resultados) han sido efectivamente eliminadas de la lista.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "{count, plural, =1 {Confirmo que he comprendido perfectamente el impacto de la supresión} other {Confirmo que he comprendido perfectamente el impacto de las {count} supresiones}}",
+        "confirmation-checkbox": "{count, plural, =1 {Confirmo que entiendo las consecuencias de eliminar {count} elemento} other {Confirmo que entiendo las consecuencias de eliminar {count} elementos}}",
         "content": {
-          "footer": "Tenga en cuenta que esta acción es irreversible.",
+          "footer": "Ten en cuenta que esta acción es irreversible.",
           "header": "{count, plural, =1 {Esta campaña ya no será visible} other {Estas campañas ya no serán visibles}} en Pix Orga.",
-          "main-participation-prevent": "Se eliminarán todas las entradas a {count, plural, =1 {esta campaña} other {estas campañas}} y sus resultados."
+          "main-participation-prevent": "Se eliminarán todas las participaciones de {count, plural, =1 {esta campaña} other {estas campañas}} y sus resultados."
         },
-        "title": "{count, plural, =1 {¿Seguro que quiere borrar la campaña seleccionada?} other {¿Seguro que quiere borrar las '<strong>'{count}'</strong>' campañas seleccionadas?}}"
+        "title": "{count, plural, =1 {¿Seguro que quiere eliminar la campaña seleccionada?} other {¿Seguro que quiere eliminar las '<strong>'{count}'</strong>' campañas seleccionadas?}}"
       },
       "filter": {
         "by-name": "Buscar una campaña",
-        "by-owner": "Encontrar un propietario",
-        "legend": "Filtros para la tabla de campañas: se pueden utilizar campos de entrada para filtrar la tabla por nombre de campaña y nombre de propietario. Los botones permiten filtrar las campañas activas y archivadas.",
+        "by-owner": "Buscar un propietario",
+        "legend": "Filtros de la tabla de campañas: los campos de búsqueda permiten filtrar la tabla por nombre de campaña y por nombre del propietario. Los botones permiten filtrar las campañas activas y archivadas.",
         "results": "{total, plural, =0 {0 campaña} =1 {1 campaña} other {{total, number} campañas}}"
       },
       "navigation": "Navegar por la sección Campañas",
@@ -1032,14 +1032,14 @@
         "column": {
           "code": "Código",
           "created-by": "Propietario",
-          "created-on": "Creado el",
+          "created-on": "Creada el",
           "mainCheckbox": "Seleccionar/deseleccionar toda la columna",
           "name": "Nombre de la campaña",
           "participants": "Participantes",
           "results": "Resultados recibidos"
         },
-        "description-all-campaigns": "Esta tabla enumera todas las campañas creadas en su espacio Pix Orga. Para cada campaña, muestra el código, el propietario, la fecha de creación, el número de participantes y el número de resultados recibidos.",
-        "description-my-campaigns": "Esta tabla enumera las campañas de su propiedad. Para cada campaña, muestra su código, la fecha en que se crearon, el número de participantes y el número de resultados recibidos.",
+        "description-all-campaigns": "Esta tabla enumera todas las campañas creadas en tu espacio Pix Orga. Para cada campaña, se indican el código, el propietario, la fecha de creación, el número de participantes y el número de resultados recibidos.",
+        "description-my-campaigns": "Esta tabla enumera las campañas que posees. Para cada campaña, se indican el código, la fecha de creación, el número de participantes y el número de resultados recibidos.",
         "empty": "Ninguna campaña"
       },
       "tabs": {
@@ -1053,12 +1053,12 @@
         "modules-count": "{count, plural, =0 {Sin módulos} =1 {{count} Módulo} other {{count} Módulos}}",
         "simplified-access": "Acceso sin cuenta",
         "tag": {
-          "blueprint": "Ruta de aprendizaje",
-          "target-profile": "Ruta de evaluación"
+          "blueprint": "Itinerario de aprendizaje",
+          "target-profile": "Itinerarios de evaluación"
         },
         "tubes-count": "{count, plural, =0 {Sin temas} =1 {{count} tema} other {{count} temas}}"
       },
-      "empty-state": "No hay cursos disponibles por el momento. Póngase en contacto con Pix para obtenerlos.",
+      "empty-state": "No hay itinerarios disponibles por el momento. Contacta Pix para obtenerlos.",
       "empty-state-with-filters": "Ningún curso coincide con sus criterios de búsqueda.",
       "filters": {
         "areas": {
@@ -1066,7 +1066,7 @@
           "label": "Dominios",
           "placeholder": "{count, plural, =0 {Dominios} =1 {Dominio ({count})} other {Dominios ({count})}}"
         },
-        "aria-label": "Filtros sobre los cursos",
+        "aria-label": "Filtros sobre los itinearios",
         "categories": {
           "all": "Todas las categorías",
           "empty": "Ninguna categoría",
@@ -1078,7 +1078,7 @@
           "placeholder": "{count, plural, =0 {Competencias} =1 {Competencia ({count})} other {Competencias ({count})}}"
         },
         "name": {
-          "label": "Nombre del curso",
+          "label": "Nombre del itinerario",
           "placeholder": "Buscar por título"
         },
         "nb-result": "{count, plural, =0 {Ningún curso} =1 {{count} curso} other {{count} cursos}}"
@@ -1092,7 +1092,7 @@
           "prescribed": "Prescrito",
           "recommended": "Recomendado",
           "step": "Paso {number}",
-          "title": "Contenido de la ruta de aprendizaje"
+          "title": "Contenido de la Itinerario de aprendizaje"
         },
         "max-level": "Nivel máx.",
         "open-modal": "Ver detalles del curso {name}",
@@ -1107,10 +1107,10 @@
       "tab-filters": {
         "all": "Todos",
         "blueprints": "Aprendizaje",
-        "label": "Tipo de curso",
+        "label": "Tipos de itinerarios",
         "target-profiles": "Evaluación"
       },
-      "title": "Catálogo de cursos"
+      "title": "Catálogo de itinerarios"
     },
     "certifications": {
       "description": "Seleccione la clase cuyos resultados de certificación desea exportar (.csv) o descargar los certificados (.pdf).\n Puede filtrar esta lista introduciendo el nombre de la clase directamente en el campo.",
@@ -1124,17 +1124,17 @@
         "no-certificates": "No hay certificado para la clase {selectedDivision}.",
         "no-results": "No hay resultados de certificación para la clase {selectedDivision}."
       },
-      "no-students-imported-yet": "En esta pestaña encontrará los resultados y certificados de los alumnos. En primer lugar, debe importar la base de datos de alumnos de su centro.",
+      "no-students-imported-yet": "En esta pestaña encontrarás los resultados y certificados de los alumnos. En primer lugar, debes importar la base de datos de alumnos de tu centro educativo.",
       "select-label": "Clase",
       "title": "Resultados de la certificación"
     },
     "combined-course": {
       "campaigns": "{count, plural, =1 {Ver detalles de la campaña} other {Ver detalles de la campaña #{index}}}",
       "filters": {
-        "by-status": "Búsqueda por estado de participación",
+        "by-status": "Buscar por estado de participación",
         "status": {
           "COMPLETED": "Completado",
-          "STARTED": "En curso",
+          "STARTED": "En progreso",
           "placeholder": "Todos los estados"
         }
       },
@@ -1151,7 +1151,7 @@
         "step-label": "Paso {number}"
       },
       "statistics": {
-        "completed-participations": "Participaciones realizadas",
+        "completed-participations": "Participaciones completadas",
         "total-participations": "Total participaciones"
       },
       "table": {
@@ -1164,7 +1164,7 @@
           "reward": "Certificado",
           "status": "Estado"
         },
-        "description": "Lista de participantes",
+        "description": "Lista de participantes del itinerario",
         "module-completion": "{nbItemsCompleted, plural, =0 {Ningún módulo completado en {nbItems}} =1 {Un módulo completado en {nbItems}} other {{nbItemsCompleted} módulos completados en {nbItems}}}.",
         "no-module": "No se recomienda ningún módulo.",
         "rewards": {
@@ -1179,13 +1179,13 @@
       }
     },
     "combined-courses": {
-      "empty-state": "Por el momento no hay ninguna ruta de aprendizaje disponible.",
+      "empty-state": "Por el momento no hay ningún itinerario de aprendizaje disponible.",
       "table": {
-        "caption": "Lista de vías de aprendizaje",
+        "caption": "Lista de itinerarios de aprendizaje",
         "column": {
           "code": "Código",
-          "completed": "Participantes que completaron",
-          "name": "Nombre del curso",
+          "completed": "Participantes con participación completada",
+          "name": "Nombre del itinerario",
           "participants": "Participantes"
         }
       }
@@ -1200,73 +1200,73 @@
         },
         "fields": {
           "email": {
-            "error": "Su dirección de correo electrónico no es válida.",
+            "error": "La dirección de correo electrónico no es válida.",
             "label": "Correo electrónico",
-            "placeholder": "Por ejemplo: jean.dupont@email.com"
+            "placeholder": "Por ejemplo: juan.garcia@correoelectronico.com"
           },
           "firstname": {
-            "error": "Su nombre de pila no está rellenado.",
+            "error": "No has indicado tu nombre",
             "label": "Nombre",
-            "placeholder": "ej: Jean"
+            "placeholder": "ej: Juan"
           },
           "lastname": {
-            "error": "No se ha introducido su nombre.",
-            "label": "Nombre",
-            "placeholder": "por ejemplo, Dupont"
+            "error": "No has indicado tu apellido",
+            "label": "Apellido",
+            "placeholder": "por ejemplo, García"
           },
-          "legend": "Información necesaria para la inscripción.",
+          "legend": "Información necesaria para crear una cuenta.",
           "password": {
             "completed-message": "{ rulesCompleted } en { rulesCount } completado.",
             "instructions-label": "Su contraseña debe cumplir las siguientes normas:",
             "label": "Contraseña"
           }
         },
-        "submit": "Deseo inscribirme",
+        "submit": "Registarse",
         "subtitle": "para acceder a su espacio Pix Orga",
-        "title": "Inscríbete en Pix"
+        "title": "Crea una cuenta en Pix"
       }
     },
     "join-request-form": {
-      "firstname": "Su nombre",
-      "lastname": "Su nombre",
+      "firstname": "Tu nombre",
+      "lastname": "Tu apellido",
       "legal-information": {
         "link-text": "Más información sobre mis derechos.",
         "link-url": "https://pix.fr/dp-formulaire-recuperation-pixorga-sco",
-        "text": "La información recogida en este formulario se registra en un fichero procesado por GIP Pix por cuenta del Ministerio de Educación Nacional, en calidad de responsable del tratamiento, con el fin de permitir a su escuela acceder a su espacio Pix Orga enviándole una invitación para unirse a este espacio."
+        "text": "La información recogida en este formulario se registra en un fichero gestionado por GIP Pix por cuenta del Ministerio de Educación Nacional, en calidad de responsable del tratamiento, para permitir que tu centro educativo acceda a su espacio Pix Orga mediante el envío de una invitación para unirse a dicho espacio."
       },
       "organization-code": "UAI/RNE del establecimiento"
     },
     "login": {
-      "join-invitation": "Le invitamos a unirse: {organizationName}",
+      "join-invitation": "Te invitamos a unirte: {organizationName}",
       "signup": {
         "label": "Registrarse en Pix"
       },
-      "title": "Conéctese a",
-      "with-pix-account": "con su cuenta Pix"
+      "title": "Conectarse a",
+      "with-pix-account": "con tu cuenta Pix"
     },
     "login-form": {
-      "active-or-retrieve": "Activa o conviértete en administrador del espacio Pix Orga de tu escuela",
-      "admin-role-question": "¿Es usted directivo o director?",
+      "active-or-retrieve": "Activa o conviértete en administrador del espacio Pix Orga de tu centro educativo",
+      "admin-role-question": "¿Eres directivo o director?",
       "associate-account": "Vincular mi cuenta",
       "email": {
         "label": "Correo electrónico",
-        "placeholder": "Por ejemplo: jean.dupont@email.com"
+        "placeholder": "Por ejemplo: juan.garcia@correoelectronico.com"
       },
       "errors": {
-        "access-not-allowed": "El acceso a Pix Orga está limitado a los miembros invitados. Cada área está gestionada por un administrador de Pix Orga específico de la organización que la utiliza. Póngase en contacto con él/ella para que le invite.",
-        "empty-email": "No se ha introducido su dirección de correo electrónico.",
-        "empty-password": "No se ha introducido la contraseña.",
-        "invalid-email": "Su dirección de correo electrónico no es válida.",
+        "access-not-allowed": "El acceso a Pix Orga está limitado a los miembros invitados. Cada área está gestionada por un administrador de Pix Orga específico de la organización que la utiliza. Ponte en contacto con él/ella para que te invite.",
+        "empty-email": "No has indicado tu dirección de correo electrónico.",
+        "empty-password": "No has indicado la contraseña.",
+        "invalid-email": "La dirección de correo electrónico introducida no es válida.",
         "status": {
           "404": "La dirección de correo electrónico y/o la contraseña introducidas son incorrectas.",
           "409": "Esta invitación ya ha sido aceptada o cancelada."
         }
       },
-      "forgot-password": "¿Ha olvidado su contraseña?",
+      "forgot-password": "¿Has olvidado tu contraseña?",
       "invitation-already-accepted": "Esta invitación ya ha sido aceptada. Inicia sesión o ponte en contacto con el administrador de tu espacio Pix Orga.",
-      "invitation-not-found": "No se ha encontrado esta invitación. Póngase en contacto con el administrador de su espacio Pix Orga.",
-      "invitation-was-cancelled": "Esta invitación ya no es válida. Póngase en contacto con el administrador de su espacio Pix Orga.",
-      "login": "Quiero conectar",
+      "invitation-not-found": "No se ha encontrado esta invitación. Ponte en contacto con el administrador de tu espacio Pix Orga.",
+      "invitation-was-cancelled": "Esta invitación ya no es válida. Ponte en contacto con el administrador de tu espacio Pix Orga.",
+      "login": "Conectarme",
       "password": "Contraseña"
     },
     "login-or-register": {
@@ -1275,44 +1275,44 @@
         "title": "Ya tengo una cuenta PIX"
       },
       "register-form": {
-        "button": "Inscríbete",
+        "button": "Crea una cuenta",
         "errors": {
-          "default": "El servicio no está disponible temporalmente. Vuelva a intentarlo más tarde.",
-          "email-already-exists": "Esta dirección de correo electrónico ya está registrada, inicie sesión.",
+          "default": "El servicio no está disponible temporalmente. Vuelve a intentarlo más tarde.",
+          "email-already-exists": "Esta dirección de correo electrónico ya está registrada, inicia sesión.",
           "invalid-or-already-used-email": "Dirección de correo electrónico no válida o ya utilizada"
         },
         "fields": {
           "button": {
-            "label": "Deseo inscribirme"
+            "label": "Registrarse"
           },
           "cgu": {
-            "accept": "Acepto la",
-            "and": "y el",
+            "accept": "Acepto las",
+            "and": "y la",
             "aria-label": "Aceptar las condiciones de uso de Pix",
             "data-protection-policy": "política de privacidad",
-            "error": "Debe aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
+            "error": "Debes aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
             "terms-of-use": "condiciones de uso de Pix"
           },
           "email": {
-            "error": "Su dirección de correo electrónico no es válida.",
+            "error": "La dirección de correo electrónico introducida no es válida.",
             "label": "Correo electrónico"
           },
           "first-name": {
-            "error": "Su nombre de pila no está rellenado.",
+            "error": "No has indicado tu nombre",
             "label": "Nombre"
           },
           "last-name": {
-            "error": "No se ha introducido su nombre.",
-            "label": "Nombre"
+            "error": "No has indicado tu apellido",
+            "label": "Apellido"
           },
           "password": {
-            "error": "Su contraseña debe tener al menos 8 caracteres y contener como mínimo una letra mayúscula, una letra minúscula y un número.",
+            "error": "Tu contraseña debe tener al menos 8 caracteres e incluir como mínimo una mayúscula, una minúscula y un número.",
             "label": "Contraseña"
           }
         },
-        "title": "Deseo inscribirme"
+        "title": "Registrarse"
       },
-      "title": "Le invitamos a unirse a la organización {organizationName}."
+      "title": "Te invitamos a unirse a la organización {organizationName}."
     },
     "missions": {
       "list": {
@@ -1322,31 +1322,31 @@
         "aria-label": "Misión",
         "banner": {
           "copypaste-container": {
-            "abstract": "Inicie las primeras misiones con sus alumnos activando la sesión mediante el botón de arriba y utilizando el botón",
+            "abstract": "Inicie las primeras misiones con sus alumnos activando la sesión mediante el botón de arriba y utilizando el",
             "button": {
               "success": "¡Copiado!",
               "tooltip": "copiar el código"
             }
           },
-          "hint": "No dude en añadirlo a sus favoritos.",
-          "import-text": "enlace escolar",
+          "hint": "No dudes en añadirlo a tus favoritos.",
+          "import-text": "enlace del centro educativo",
           "step1": {
             "admin": {
               "head": "Paso 1: <b>Por favor</b>.",
               "link": "importar la base de datos de estudiantes",
-              "tail": "<b>Desde Onde</b> (fichero exportable en el menú Listados y documentos > Extracciones > Alumnos del centro o sus supervisores <b>seleccionando sólo alumnos de ciclo 3</b>)."
+              "tail": "<b>Desde Onde</b> (fichero exportable en el menú Listados y documentos > Extracciones > Alumnos del centro educativo o sus supervisores <b>seleccionando sólo alumnos de ciclo 3</b>)."
             },
             "non-admin": "Paso 1: <b>Solicita al administrador</b> Pix Orga de tu espacio para poder importar los alumnos."
           },
           "step2": {
-            "option1": "utiliza <b>el enlace</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Se te pedirá el código de tu centro cada vez que te conectes.",
+            "option1": "utiliza <b>el enlace</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Se te pedirá el código de tu centro educativo cada vez que te conectes.",
             "option2": {
-              "body": "o utilice el enlace directo '<'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.co.uk/schools/{code}'</a>'",
+              "body": "o utiliza el enlace directo '<'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.co.uk/schools/{code}'</a>'",
               "hint": "Puedes guardar este favorito en los ordenadores."
             },
-            "title": "Paso 2: Para que los alumnos puedan acceder al espacio Pix Junior de tu centro, puedes :"
+            "title": "Paso 2: Para que los alumnos puedan acceder al espacio Pix Junior de tu centro educativo, puedes:"
           },
-          "step3": "Paso 3: <b>Activar la sesión Pix Junior</b> a través del botón de la barra lateral. <b>Esta acción debe realizarse antes de cada sesión con sus alumnos</b>.",
+          "step3": "Paso 3: <b>Activa la sesión Pix Junior</b> a través del botón de la barra lateral. <b>Esta acción debe realizarse antes de cada sesión con tus alumnos</b>.",
           "welcome": "Para empezar a utilizar Pix Junior :"
         },
         "caption": "Lista de misiones",
@@ -1359,7 +1359,7 @@
         },
         "no-division": "Sin clase",
         "non-admin": {
-          "abstract": "Para empezar, pida a su administrador que importe a los alumnos."
+          "abstract": "Para empezar, pide a tu administrador que importe a los alumnos."
         }
       },
       "mission": {
@@ -1374,10 +1374,10 @@
         },
         "table": {
           "activities": {
-            "aria-label": "Estudiante",
+            "aria-label": "Alumno",
             "caption": "Tabla de alumnos con su participación en la misión {missionName}",
             "filters": {
-              "aria-label": "Filtro para estudiantes",
+              "aria-label": "Filtro de alumnos",
               "learners-count": "{count, plural, =0 {Sin alumnos} =1 {1 alumno} other {{count} alumnos}}",
               "status": {
                 "label": "Estado de la misión"
@@ -1386,13 +1386,13 @@
             "headers": {
               "division": "Clase",
               "first-name": "Nombre",
-              "last-name": "Nombre",
+              "last-name": "Apellido",
               "status": "Estado de la misión"
             },
             "mission-status": {
               "completed": "Completado",
               "not-started": "No iniciado",
-              "started": "En curso"
+              "started": "En progreso"
             },
             "no-data": "No hay participantes"
           },
@@ -1400,14 +1400,14 @@
             "aria-label": "Estudiante",
             "caption": "Tabla de alumnos con el resultado de su participación en la misión {missionName}",
             "filters": {
-              "aria-label": "Filtro para estudiantes",
+              "aria-label": "Filtro de alumnos",
               "global-result": {
                 "label": "Evaluación de la misión",
                 "options": {
                   "exceeded": "Superado",
                   "no-result": "Sin evaluación",
                   "not-reached": "No alcanzado",
-                  "partially-reached": "Logrado parcialmente",
+                  "partially-reached": "Parcialmente alcanzado",
                   "reached": "Alcanzado"
                 }
               },
@@ -1417,7 +1417,7 @@
               "dare-challenge": "Desafío",
               "division": "Clase",
               "first-name": "Nombre",
-              "last-name": "Nombre",
+              "last-name": "Apellido",
               "result": "Evaluación de la misión",
               "step": "Paso {number}"
             },
@@ -1429,7 +1429,7 @@
             "mission-result": {
               "exceeded": "Superado",
               "not-reached": "No alcanzado",
-              "partially-reached": "Logrado parcialmente",
+              "partially-reached": "Parcialmente alcanzado",
               "reached": "Alcanzado",
               "undefined": "-"
             },
@@ -1444,7 +1444,7 @@
         },
         "tabs": {
           "activities": "Actividades",
-          "aria-label": "Navegación entre la actividad o los resultados de la misión",
+          "aria-label": "Navegación en la actividad o los resultados de la misión",
           "results": "Resultados"
         },
         "title": "Detalles de una misión"
@@ -1454,41 +1454,41 @@
     "oidc": {
       "login": {
         "signup-button": "No tengo cuenta, me registro con mi organización",
-        "sub-title": "para vincularlo a su nuevo método de conexión",
+        "sub-title": "para vincularlo a tu nuevo método de acceso",
         "title": "Utiliza tu cuenta Pix"
       },
       "signup": {
         "claims": {
           "FrEduFonctAdm": "Función administrativa",
-          "FrEduNumenHash": "Identificador técnico",
+          "FrEduNumenHash": "ID técnico",
           "discipline": "Disciplina",
           "employeeNumber": "Número de empleado",
-          "first-name-label": "Nombre :",
-          "last-name-label": "Nombre :",
+          "first-name-label": "Nombre:",
+          "last-name-label": "Apellido:",
           "population": "Población",
           "rne": "Lugar de trabajo",
           "title": "Función"
         },
         "description": "Se creará una cuenta utilizando la información facilitada por la organización",
         "error": {
-          "cgu": "Debe aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
-          "claims": "No hemos podido recuperar su información de identidad del servicio utilizado. Póngase en contacto con el servicio de asistencia informática de la organización."
+          "cgu": "Debes aceptar las condiciones de uso y la política de privacidad de Pix para crear una cuenta.",
+          "claims": "No hemos podido recuperar tu información de identidad del servicio utilizado. Ponte en contacto con el servicio de asistencia informática de la organización."
         },
-        "login-button": "Ya tengo una cuenta Pix, me gustaría conectarme",
-        "signup-button": "Deseo inscribirme en Pix",
-        "sub-title": "para acceder a su espacio Pix Orga",
-        "title": "Inscríbete en Pix"
+        "login-button": "Ya tengo una cuenta Pix, quiero iniciar sesión.",
+        "signup-button": "Quiero registrarme en Pix",
+        "sub-title": "para acceder a tu espacio Pix Orga",
+        "title": "Registrarse en Pix"
       }
     },
     "organization-learner": {
       "activity": {
-        "assessment-summary": "Resumen de la participación en campañas de evaluación",
+        "assessment-summary": "Resumen de las participaciones en campañas de evaluación",
         "cards": {
-          "shared": "Enviado: {count}",
-          "started": "En curso: {count}",
+          "shared": "Enviadas: {count}",
+          "started": "En progreso: {count}",
           "title": {
-            "assessment": "Clasificaciones",
-            "profiles-collection": "Colección de perfiles"
+            "assessment": "Evaluaciones",
+            "profiles-collection": "Recopilación de perfiles"
           }
         },
         "empty-state": "¡No hay actividad por el momento! Envía una campaña a {organizationLearnerFirstName} {organizationLearnerLastName} y empieza a seguir su progreso.",
@@ -1498,14 +1498,14 @@
               "campaign-name": "Campaña",
               "campaign-type": "Tipo",
               "created-at": "Fecha de inicio",
-              "participation-count": "Número de entradas",
+              "participation-count": "Número de participaciones",
               "shared-at": "Fecha de envío",
               "status": "Estado"
             }
           }
         },
-        "participations-title": "Lista de todas las entradas",
-        "profile-collection-summary": "Resumen de la participación en campañas de recogida de perfiles",
+        "participations-title": "Lista de participaciones",
+        "profile-collection-summary": "Resumen de las participaciones en campañas de recopilación de perfiles",
         "title": "Actividad"
       },
       "header": {
@@ -1513,24 +1513,24 @@
       }
     },
     "organization-participant-activity": {
-      "title": "Actividad de los participantes"
+      "title": "Actividad del participante"
     },
     "organization-participants": {
       "action-bar": {
-        "delete-button": "Borrar",
+        "delete-button": "Eliminar",
         "error-message": "{count, plural, =1 {Se ha producido un error, {firstname} {lastname} no se ha eliminado de la lista de participantes.} other {Se ha producido un error, los {count} participantes seleccionados no se han eliminado de la lista.}}.",
         "information": "{count, plural, =1 {{count} participante seleccionado} other {{count} participantes seleccionados}}",
         "success-message": "{count, plural, =1 {{firstname} {lastname} ha sido efectivamente eliminado de la lista de participantes.} other {Los {count} participantes seleccionados han sido efectivamente eliminados de la lista.}}."
       },
       "deletion-modal": {
-        "confirmation-checkbox": "{count, plural, =1 {Confirmo que comprendo perfectamente el impacto de la supresión} other {Confirmo que comprendo perfectamente el impacto de las {count} supresiones}}",
+        "confirmation-checkbox": "{count, plural, =1 {Confirmo que entiendo las consecuencias de eliminar {count} elemento} other {Confirmo que entiendo las consecuencias de eliminar {count} elementos}}",
         "content": {
-          "footer": "Tenga en cuenta que esta acción es irreversible.",
+          "footer": "Ten en cuenta que esta acción es irreversible.",
           "header": "{count, plural, =1 {Este participante ya no será visible} other {Estos participantes ya no serán visibles}} en Pix Orga.",
-          "main-campaign-prevent": "Esto repercutirá, por tanto, en los resultados y análisis de las campañas que {count, plural, =1 {ha} other {han}} realizado.",
-          "main-participation-prevent": "Todas {count, plural, =1 {sus} other {sus}} entradas de campaña serán eliminadas."
+          "main-campaign-prevent": "Esto afectará los resultados y análisis de las campañas que {count, plural, =1 {ha} other {han}} realizado.",
+          "main-participation-prevent": "Todas {count, plural, =1 {sus} other {sus}} participaciones de campaña serán eliminadas."
         },
-        "title": "{count, plural, =1 {Borra '<strong>'{firstname} {lastname}'</strong>' de tus} other {¿Estás seguro de que quieres borrar '<strong>'{count}'</strong>'}} participantes?"
+        "title": "{count, plural, =1 {Elimina '<strong>'{firstname} {lastname}'</strong>' de tus} other {¿Estás seguro de que quieres eliminar '<strong>'{count}'</strong>'}} participantes?"
       },
       "empty-state": {
         "action": "Ver mis campañas",
@@ -1543,8 +1543,8 @@
         "students-count": "{count, plural, =0 {0 alumnos} =1 {1 alumno} other {{count} alumnos}}",
         "type": {
           "certificability": {
-            "label": "Búsqueda por certificabilidad",
-            "placeholder": "Certificación"
+            "label": "Buscar por estado de certificación",
+            "placeholder": "Estado de certificación"
           }
         }
       },
@@ -1563,34 +1563,34 @@
           },
           "first-name": "Nombre",
           "is-certifiable": {
-            "label": "Certificación"
+            "label": "Estado de certificación"
           },
           "last-name": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por nombre. Haga clic para ordenar alfabéticamente.",
-            "ariaLabelSortDown": "La tabla está ordenada por nombre, en orden alfabético inverso. Haga clic para ordenar alfabéticamente.",
-            "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por nombre. Haga clic para ordenar en orden alfabético inverso.",
-            "label": "Nombre"
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por nombre. Haz clic para ordenarla alfabéticamente.",
+            "ariaLabelSortDown": "La tabla está ordenada por apellido, en orden alfabético inverso. Haz clic para ordenarla alfabéticamente.",
+            "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por apellido. Haz clic para ordenarla en orden alfabético inverso.",
+            "label": "Apellido"
           },
           "latest-participation": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por fecha de participación. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortDown": "La tabla está ordenada por fecha de participación descendente. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortUp": "La tabla está ordenada por fecha de participación en orden ascendente. Haga clic para ordenar en orden descendente.",
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por fecha de participación. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortDown": "La tabla está ordenada por fecha de participación descendente. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortUp": "La tabla está ordenada por fecha de participación en orden ascendente. Haz clic para ordenarla en orden descendente.",
             "label": "Última participación"
           },
           "mainCheckbox": "Seleccionar/deseleccionar toda la columna",
           "participation-count": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de entradas. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortDown": "La tabla está ordenada por número descendente de entradas. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortUp": "La tabla está ordenada por número creciente de entradas. Haga clic para ordenar en orden descendente.",
-            "label": "Número de entradas"
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de participaciones. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortDown": "La tabla está ordenada por número descendente de participaciones. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortUp": "La tabla está ordenada por número creciente de participaciones. Haz clic para ordenarla en orden descendente.",
+            "label": "Número de participaciones"
           }
         },
-        "description": "Tabla de participantes ordenados por nombre.",
+        "description": "Tabla de participantes ordenados por apellido.",
         "empty": "Ningún participante",
         "oralization-header-tooltip": "Al activar \"leer las instrucciones\", el alumno obtendrá una transcripción hablada.",
         "row-value": {
           "oralization": {
-            "false": "Fuera de",
+            "false": "Desactivado",
             "true": "Activado"
           }
         }
@@ -1599,47 +1599,47 @@
     "organization-participants-import": {
       "actions": {
         "add-sup": {
-          "details": "Permite añadir una lista de alumnos a la lista ya importada y/o modificar la información de los alumnos ya importados.",
-          "label": "Añadir estudiantes",
-          "title": "Añadir / modificar"
+          "details": "Permite añadir una lista de alumnos a la lista ya importada y/o editar la información de los alumnos ya importados.",
+          "label": "Añadir alumnos",
+          "title": "Añadir / editar"
         },
         "participants": {
-          "details": "Esta acción le permite :",
+          "details": "Esta acción permite:",
           "details-add": "añadir nuevos participantes",
           "details-disable": "desactivar antiguos participantes",
-          "details-update": "modificar los participantes ya importados",
+          "details-update": "editar los participantes ya importados",
           "label": "Importar lista",
           "title": "Importar la lista de participantes"
         },
         "replace": {
           "details": "Permite importar una nueva lista de alumnos en lugar de la existente.",
           "label": "Importar una nueva lista",
-          "title": "Sustituir"
+          "title": "Reemplazar"
         }
       },
       "banner": {
         "anchor-error": "Ver la lista de errores",
-        "fix-error-text": "Por favor, corrija los errores e importe el archivo de nuevo.",
-        "import-error": "La importación de participantes ha fracasado.",
-        "import-in-progress": "Se ha validado el contenido del fichero y se están importando los participantes.",
-        "in-progress-text": "Por favor, actualice esta página en unos momentos para comprobar el estado del archivo.",
-        "retry-error-text": "Se ha producido un error, por favor importe más tarde o escriba al soporte de Pix",
+        "fix-error-text": "Por favor, corrige los errores e importa el archivo nuevamente.",
+        "import-error": "Error al importar participantes.",
+        "import-in-progress": "Se ha validado el contenido del archivo y se están importando los participantes.",
+        "in-progress-text": "Por favor, actualiza esta página dentro de unos instantes para consultar el estado del archivo.",
+        "retry-error-text": "Se ha producido un error, por favor realiza el importe más tarde o escribe al soporte de Pix",
         "upload-completed": "El archivo fue importado en {date} por {firstName} {lastName}.",
         "upload-error": "No se ha podido importar el archivo.",
-        "upload-in-progress": "La importación del archivo puede tardar unos minutos. No abandone esta página.",
-        "validation-error": "El contenido del fichero contiene errores.",
-        "validation-in-progress": "Se está validando el contenido del fichero.",
-        "warning-banner": "Algunos valores no han sido reconocidos. Se han sustituido por \"No reconocido\". Si considera que falta algún valor en la lista restrictiva, póngase en contacto con nosotros en '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'"
+        "upload-in-progress": "La importación del archivo puede tardar unos minutos. No abandones esta página.",
+        "validation-error": "El contenido del archivo contiene errores.",
+        "validation-in-progress": "Se está validando el contenido del archivo.",
+        "warning-banner": "Algunos valores no han sido reconocidos. Se han sustituido por \"No reconocido\". Si consideras que falta algún valor en la lista restrictiva, ponte en contacto con nosotros en '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'"
       },
       "error-panel": {
-        "error-wrapper": "No se ha importado ningún participante. Por favor, modifique su archivo e impórtelo de nuevo.",
-        "global-error": "No se ha importado ningún participante. Vuelva a intentarlo o póngase en contacto con nosotros a través de '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda'</a>'.",
-        "title": "Errores en el último archivo importado :"
+        "error-wrapper": "No se ha importado ningún participante. Por favor, edita tu archivo e impórtalo de nuevo.",
+        "global-error": "No se ha importado ningún participante. Inténtalo nuevamente o ponte en contacto con nosotros a través de '<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">'el formulario del centro de ayuda'</a>'.",
+        "title": "Errores en el último archivo importado:"
       },
       "file-type-separator": ",",
       "global-success": "Último archivo importado con éxito en {date} por {firstName} {lastName}.",
       "sco": {
-        "title": "Importar estudiantes"
+        "title": "Importar alumnos"
       },
       "sup": {
         "title": "Importar estudiantes"
@@ -1655,35 +1655,35 @@
       "latest-participation-information-tooltip": {
         "aria-label": "Información sobre la última participación",
         "campaign-ASSESSMENT-type": "Evaluación",
-        "campaign-PROFILES_COLLECTION-type": "Colección de perfiles",
-        "campaign-name": "Campaña :",
-        "campaign-status": "Estado :",
-        "campaign-type": "Tipo :",
+        "campaign-PROFILES_COLLECTION-type": "Recopilación de perfiles",
+        "campaign-name": "Campaña:",
+        "campaign-status": "Estado:",
+        "campaign-type": "Tipo:",
         "participation-SHARED-status": "Recibido",
-        "participation-STARTED-status": "En curso"
+        "participation-STARTED-status": "En progreso"
       }
     },
     "places": {
       "before-date": "en",
       "places-lots": {
         "statuses": {
-          "active": "Activos",
+          "active": "Activo",
           "expired": "Caducado",
           "pending": "Próximamente"
         },
         "table": {
-          "caption": "Tabla que enumera las compras de entradas de su organización. Para cada compra, muestra: el número de plazas, la fecha de activación, la fecha de caducidad y el estado (activo, próximamente o caducado). Está ordenada según el estado de las compras y su fecha de caducidad.",
-          "empty-state": "¡No hay sitio por el momento!",
+          "caption": "Tabla que enumera las compras de plazas de tu organización. Para cada compra, muestra: el número de plazas, la fecha de activación, la fecha de caducidad y el estado (activo, próximamente o caducado). Está ordenada según el estado de las compras y su fecha de caducidad.",
+          "empty-state": "¡No hay plazas por el momento!",
           "headers": {
             "activation-date": "Fecha de activación",
             "count": "Número de plazas",
             "expiration-date": "Fecha de caducidad",
             "status": "Estado"
           },
-          "title": "Historial de compra de entradas"
+          "title": "Historial de compra de plazas"
         }
       },
-      "title": "Lugares"
+      "title": "Plazas"
     },
     "preselect-target-profile": {
       "compatibility": {
@@ -1696,16 +1696,16 @@
           "yes": "Compatible con tabletas"
         }
       },
-      "download": "Descargar la selección de temas ({ numberOfTubesSelected }) (JSON, { fileSize }ko)",
+      "download": "Descargar la selección de temáticas ({ numberOfTubesSelected }) (JSON, { fileSize }ko)",
       "download-filename": "selection-subjects-{ organizationName }-{ date }.json",
       "levels": {
         "label": "Seleccionar el nivel del siguiente tema: {title}",
         "placeholder": "Seleccionar un nivel",
         "tooltip": "No hay pruebas disponibles para los niveles que aparecen en gris"
       },
-      "no-tube-selected": "Descargar la selección de temas (JSON, { fileSize }ko)",
+      "no-tube-selected": "Descargar la selección de temáticas (JSON, { fileSize }ko)",
       "table": {
-        "caption": "Selección de temas",
+        "caption": "Selección de temáticas",
         "column": {
           "compatibility": "Compatibilidad",
           "level": "Nivel máximo (opcional)",
@@ -1716,7 +1716,7 @@
         "not-responsive": "no",
         "row-title": "Asunto"
       },
-      "title": "Selección de temas"
+      "title": "Selección de temáticas"
     },
     "profiles-individual-results": {
       "breadcrumb-current-page-label": "Participación de {firstName} {lastName}",
@@ -1730,14 +1730,14 @@
           "pix-score": "Puntuación Pix",
           "skill": "Experiencia"
         },
-        "empty": "A la espera de los resultados",
+        "empty": "Resultados pendientes",
         "title": "Resultados por competencias"
       },
       "title": "Perfil de {firstName} {lastName}"
     },
     "profiles-list": {
       "table": {
-        "caption": "Esta tabla contiene la lista de participantes que han compartido sus perfiles. Indica para cada participante sus apellidos, su nombre, la fecha de envío, la puntuación Pix, la evolución, el estado de certificabilidad y el número de competencias certificables.",
+        "caption": "Esta tabla contiene la lista de participantes que han compartido sus perfiles. Indica para cada participante sus apellidos, su nombre, la fecha de envío, la puntuación Pix, la evolución, el estado de certificación y el número de competencias certificables.",
         "column": {
           "ariaSharedProfileCount": "Número de acciones de perfil",
           "certifiable": "Certificable",
@@ -1745,21 +1745,21 @@
           "competences-certifiables": "Comp. certificable",
           "evolution": "Evolución",
           "first-name": "Nombre",
-          "last-name": "Nombre",
+          "last-name": "Apellido",
           "pix-score": {
             "label": "Puntuación Pix",
             "value": "{score, number}"
           },
           "sending-date": {
             "label": "Fecha de envío",
-            "on-hold": "En espera de envío"
+            "on-hold": "Envío pendiente"
           },
           "sharedProfileCount": "Número de acciones de perfil"
         },
-        "empty": "A la espera de perfiles",
+        "empty": "Perfiles pendientes",
         "evolution": {
-          "decrease": "En declive",
-          "increase": "En alza",
+          "decrease": "En retroceso",
+          "increase": "Progresando",
           "stable": "Constante",
           "unavailable": "No disponible"
         },
@@ -1771,66 +1771,66 @@
       "title": "Perfiles recibidos"
     },
     "sco-organization-participant-activity": {
-      "title": "Actividad de los estudiantes"
+      "title": "Actividad de los alumnos"
     },
     "sco-organization-participants": {
       "action-bar": {
-        "generate-username-password-button": "Generar nombres de usuario y/o contraseñas para los estudiantes seleccionados",
+        "generate-username-password-button": "Generar nombres de usuario y/o contraseñas para los alumnos seleccionados",
         "information": "{count, plural, =1 {{count} alumno seleccionado} other {{count} alumnos seleccionados}}",
         "reset-password-button": "Restablecer las contraseñas de los alumnos seleccionados"
       },
       "actions": {
-        "manage-account": "Gestionar su cuenta",
+        "manage-account": "Gestionar la cuenta",
         "show-actions": "Mostrar acciones"
       },
       "connection-types": {
         "email": "Correo electrónico",
         "empty": "-",
-        "identifiant": "Identificador",
+        "identifiant": "ID",
         "mediacentre": "Mediacentre",
         "none": "No",
         "without-mediacentre": "Sin Mediacentre"
       },
       "filter": {
-        "aria-label": "Filtros para estudiantes",
+        "aria-label": "Filtros para alumnos",
         "certificability": {
-          "label": "Búsqueda por certificabilidad",
-          "placeholder": "Certificación"
+          "label": "Buscar por estado de certificación",
+          "placeholder": "Estado de certificación"
         },
         "division": {
           "empty": "Sin clase",
-          "label": "Búsqueda por clase"
+          "label": "Buscar por clase"
         },
         "first-name": {
-          "label": "Búsqueda por nombre"
-        },
-        "last-name": {
           "label": "Buscar por nombre"
         },
+        "last-name": {
+          "label": "Buscar por apellido"
+        },
         "login-method": {
-          "empty-option": "Método de conexión",
-          "label": "Búsqueda por método de conexión"
+          "empty-option": "Método de acceso",
+          "label": "Buscar por método de acceso"
         },
         "students-count": "{count, plural, =0 {0 alumnos} =1 {1 alumno} other {{count} alumnos}}"
       },
       "generate-username-password-modal": {
-        "content-message-1": "Los alumnos que aún no dispongan de un método de acceso deberán pasar por una campaña en su centro para crear su cuenta PIX.",
+        "content-message-1": "Los alumnos que aún no dispongan de un método de acceso deberán pasar por una campaña en tu centro educativo para crear su cuenta PIX.",
         "content-message-2": "Se generará un archivo CSV con los nombres de usuario y las contraseñas de un solo uso.",
         "content-message-3": "Comparte estas nuevas contraseñas de un solo uso con tus alumnos. Cuando inicien sesión con esta contraseña, Pix les pedirá que introduzcan una nueva.",
         "title": "Generar nombres de usuario y/o contraseñas para los estudiantes seleccionados",
-        "warning-message": "Se generará un nombre de usuario y una contraseña para los estudiantes que tengan acceso al Mediacentre y/o una dirección de correo electrónico. A los estudiantes que ya dispongan de un nombre de usuario se les restablecerá la contraseña."
+        "warning-message": "Los alumnos que aún no dispongan de un método de acceso deberán pasar por una campaña en tu centro educativo para crear su cuenta PIX."
       },
       "manage-authentication-method-modal": {
-        "authentication-methods": "Métodos de conexión",
+        "authentication-methods": "Métodos de acceso",
         "copied": "¡Copiado!",
         "error": {
-          "default": "Se ha producido un error interno. Nuestros equipos están resolviendo el problema. Vuelva a intentarlo más tarde.",
-          "unexpected": "Algo ha ido mal. Por favor, inténtelo de nuevo."
+          "default": "Se ha producido un error interno. Nuestro equipo está resolviendo el problema. Vuelve a intentarlo más tarde.",
+          "unexpected": "Algo ha salido mal. Inténtalo de nuevo."
         },
         "section": {
           "add-username": {
-            "button": "Añadir identificador",
-            "label": "Añadir una conexión con un nombre de usuario"
+            "button": "Añadir ID",
+            "label": "Añadir inicio de sesión con nombre de usuario"
           },
           "email": {
             "copy": "Copiar dirección de correo electrónico",
@@ -1843,12 +1843,12 @@
             "copy": "Copia la contraseña única",
             "label": "Nueva contraseña de un solo uso",
             "warning-1": "Dale a tu alumno esta nueva contraseña.",
-            "warning-2": "El estudiante se conecta con esta contraseña de un solo uso.",
+            "warning-2": "El alumno se conecta con esta contraseña de un solo uso.",
             "warning-3": "Pix le pide que elija uno nuevo."
           },
           "reset-password": {
             "button": "Restablecer contraseña",
-            "warning": "Restablecer borra la contraseña actual del estudiante."
+            "warning": "Restablecer elimina la contraseña actual del alumno."
           },
           "unblock": {
             "button": "Desbloquear la cuenta",
@@ -1856,8 +1856,8 @@
             "success-notification": "La cuenta del alumno ha sido desbloqueada, ya puede volver a conectarse."
           },
           "username": {
-            "copy": "Identificador de copia",
-            "label": "Identificador"
+            "copy": "Copia del nombre de usuario",
+            "label": "Nombre de usuario"
           }
         },
         "title": "Gestión de la cuenta Pix del alumno"
@@ -1867,12 +1867,12 @@
       },
       "no-participants": "Hasta ahora no hay estudiantes.",
       "no-participants-action": "El administrador debe importar la base de datos de los alumnos haciendo clic en el botón importar.",
-      "page-title": "Estudiantes",
+      "page-title": "Alumnos",
       "reset-password-modal": {
-        "content-message-1": "En {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} estudiante</strong> seleccionado} other {<strong>{totalSelectedStudents} estudiante</strong> seleccionado}}, {totalAffectedStudents, plural, =0 {<strong>no se restablecerán las contraseñas</strong>} =1 {la <strong>{totalAffectedStudents} contraseña del estudiante</strong> se restablecerán} other {las contraseñas de <strong>{totalAffectedStudents} alumnos</strong> se restablecerán}}.",
+        "content-message-1": "En {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} alumno</strong> seleccionado} other {<strong>{totalSelectedStudents} alumno</strong> seleccionado}}, {totalAffectedStudents, plural, =0 {<strong>no se restablecerán las contraseñas</strong>} =1 {la <strong>{totalAffectedStudents} contraseña del alumno</strong> se restablecerán} other {las contraseñas de <strong>{totalAffectedStudents} alumnos</strong> se restablecerán}}.",
         "content-message-2": "Se generará un archivo CSV con los nombres de usuario y las contraseñas de un solo uso.",
-        "content-message-3": "Entregue estas nuevas contraseñas de un solo uso a los alumnos. Cuando se conecten con esta contraseña, Pix les pedirá que introduzcan una nueva.",
-        "title": "Restablecimiento de las <strong>contraseñas</strong> de los alumnos con <strong>identificador</strong>.",
+        "content-message-3": "Entrega estas nuevas contraseñas de un solo uso a los alumnos. Cuando se conecten con esta contraseña, Pix les pedirá que introduzcan una nueva.",
+        "title": "Restablecimiento de las <strong>contraseñas</strong> de los alumnos con <strong>nombre de usuario</strong>.",
         "warning-message": "Sólo se pueden restablecer las contraseñas de acceso. El acceso por dirección de correo electrónico y Mediacentre no se ven afectados."
       },
       "table": {
@@ -1880,9 +1880,9 @@
           "checkbox": "Seleccionar/Deseleccionar {firstname} {lastname}",
           "date-of-birth": "Fecha de nacimiento",
           "division": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por clase. Haga clic para ordenar alfanuméricamente.",
-            "ariaLabelSortDown": "La tabla está ordenada por clase, en orden alfanumérico inverso. Haga clic para ordenar por orden alfanumérico.",
-            "ariaLabelSortUp": "La tabla está ordenada por clase, en orden alfanumérico. Haga clic para ordenar en orden alfanumérico inverso.",
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por clase. Haz clic para ordenarla alfanuméricamente.",
+            "ariaLabelSortDown": "La tabla está ordenada por clase, en orden alfanumérico inverso. Haz clic para ordenarla por orden alfanumérico.",
+            "ariaLabelSortUp": "La tabla está ordenada por clase, en orden alfanumérico. Haz clic para ordenarla en orden alfanumérico inverso.",
             "label": "Clase"
           },
           "first-name": "Nombre",
@@ -1893,10 +1893,10 @@
             "not-available": "No comunicado"
           },
           "last-name": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por nombre. Haga clic para ordenar alfabéticamente.",
-            "ariaLabelSortDown": "La tabla está ordenada por nombre, en orden alfabético inverso. Haga clic para ordenar alfabéticamente.",
-            "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por nombre. Haga clic para ordenar en orden alfabético inverso.",
-            "label": "Nombre"
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por apellido. Haz clic para ordenarla alfabéticamente.",
+            "ariaLabelSortDown": "La tabla está ordenada por nombre, en orden alfabético inverso. Haz clic para ordenarla alfabéticamente.",
+            "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por nombre. Haz clic para ordenarla en orden alfabético inverso.",
+            "label": "Apellido"
           },
           "last-participation-date": {
             "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por fecha de participación. Haga clic para ordenar en orden ascendente.",
@@ -1904,17 +1904,17 @@
             "ariaLabelSortUp": "La tabla está ordenada por fecha de participación en orden ascendente. Haga clic para ordenar en orden descendente.",
             "label": "Última participación"
           },
-          "login-method": "Método(s) de conexión",
+          "login-method": "Método(s) de acceso",
           "mainCheckbox": "Seleccionar/deseleccionar toda la columna",
           "participation-count": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de entradas. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortDown": "La tabla está ordenada por número descendente de entradas. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortUp": "La tabla está ordenada por número creciente de entradas. Haga clic para ordenar en orden descendente.",
-            "label": "Número de entradas"
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de participaciones. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortDown": "La tabla está ordenada por número descendente de participaciones. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortUp": "La tabla está ordenada por número ascendente de participaciones. Haz clic para ordenarla en orden descendente.",
+            "label": "Número de participaciones"
           }
         },
-        "description": "Tabla de alumnos ordenada por nombre. Para los estudiantes que han proporcionado un método de conexión, puede utilizar un menú en la columna \"Acciones\" para gestionar los métodos de conexión autorizados y restablecer la contraseña del estudiante.",
-        "empty": "No hay estudiantes."
+        "description": "Tabla de alumnos ordenada por apellido. Para los alumnos que han proporcionado un método de acceso, puedes utilizar un menú en la columna \"Acciones\" para gestionar los métodos de acceso autorizados y restablecer la contraseña del alumno.",
+        "empty": "No hay alumnos."
       },
       "title": "{count, plural, =0 {Estudiantes} =1 {Estudiante ({count})} other {Estudiantes ({count})}}",
       "user-account-blocking-types": {
@@ -1924,17 +1924,17 @@
     },
     "sso-selection": {
       "login": {
-        "button": "Quiero conectar",
-        "message": "Se le redirigirá a la página de inicio de sesión \"{providerName}\" para que se identifique en Pix."
+        "button": "Iniciar sesión",
+        "message": "Serás redirigido(a) a la página de inicio de sesión \"{providerName}\" para que accedas a Pix."
       },
       "signup": {
-        "button": "Deseo inscribirme"
+        "button": "Registrarse"
       },
-      "title": "Elija su método de conexión"
+      "title": "Elige su método de acceso"
     },
     "statistics": {
       "before-date": "en",
-      "description": "La siguiente tabla le permite ver el posicionamiento de sus participantes por asignatura.'<br>' El posicionamiento refleja el nivel medio de sus participantes en comparación con el nivel máximo que podrían haber alcanzado.'<br>' Estos datos tienen en cuenta todas las participaciones compartidas como parte de las campañas de evaluación de su organización que no se han eliminado.",
+      "description": "La siguiente tabla le permite ver el posicionamiento de sus participantes por asignatura.'<br>' El posicionamiento refleja el nivel medio de sus participantes en comparación con el máximo que podrían haber alcanzado.'<br>' Estos datos tienen en cuenta todas las participaciones compartidas como parte de las campañas de evaluación de tu organización que no se han eliminado.",
       "empty-state": "No hay datos disponibles",
       "level": {
         "advanced": "Avanzado",
@@ -1944,12 +1944,12 @@
       },
       "select-label": "Dominio",
       "table": {
-        "caption": "Esta tabla muestra los resultados de todos los participantes por tema. Para cada línea, se indica la habilidad, el tema, la tasa de cobertura y el nivel alcanzado.",
+        "caption": "Esta tabla muestra los resultados de todos los participantes por temática. Para cada línea, se indica la competencia, el temática, la tasa de cobertura y el nivel alcanzado.",
         "headers": {
-          "competences": "Habilidades",
+          "competences": "Competencias",
           "positioning": "Posicionamiento",
           "reached-level": "Nivel alcanzado",
-          "topics": "Temas"
+          "topics": "Temáticas"
         }
       },
       "title": "Estadísticas"
@@ -1959,10 +1959,10 @@
     },
     "sup-organization-participants": {
       "action-bar": {
-        "delete-button": "Borrar",
-        "error-message": "{count, plural, =1 {Se ha producido un error, {firstname} {lastname} no se ha eliminado de la lista de alumnos.} other {Se ha producido un error, los {count} alumnos seleccionados no se han eliminado de la lista.}}.",
-        "information": "{count, plural, =1 {{count} alumno seleccionado} other {{count} alumnos seleccionados}}",
-        "success-message": "{count, plural, =1 {{firstname} {lastname} ha sido eliminado con éxito de la lista de alumnos.} other {Los {count} alumnos seleccionados han sido eliminados con éxito de la lista.}}."
+        "delete-button": "Eliminar",
+        "error-message": "{count, plural, =1 {Se ha producido un error, {firstname} {lastname} no se ha eliminado de la lista de estudiantes.} other {Se ha producido un error, los {count} estudiantes seleccionados no se han eliminado de la lista.}}.",
+        "information": "{count, plural, =1 {{count} estudiante seleccionado} other {{count} estudiantes seleccionados}}",
+        "success-message": "{count, plural, =1 {{firstname} {lastname} ha sido eliminado con éxito de la lista de estudiantes.} other {Los {count} estudiantes seleccionados han sido eliminados con éxito de la lista.}}."
       },
       "actions": {
         "download-template": "Descargar el modelo",
@@ -1971,12 +1971,12 @@
       },
       "deletion-modal": {
         "content": {
-          "footer": "Tenga en cuenta que esta acción es irreversible.",
-          "header": "{count, plural, =1 {Este alumno ya no será visible} other {Estos alumnos ya no serán visibles}} en Pix Orga.",
+          "footer": "Ten en cuenta que esta acción es irreversible.",
+          "header": "{count, plural, =1 {Este estudiante ya no será visible} other {Estos estudiantes ya no serán visibles}} en Pix Orga.",
           "main-campaign-prevent": "Esto repercutirá, por tanto, en los resultados y análisis de las campañas que {count, plural, =1 {ha} other {han}} realizado.",
-          "main-participation-prevent": "Todas {count, plural, =1 {sus} other {sus}} entradas de campaña serán eliminadas."
+          "main-participation-prevent": "Todas {count, plural, =1 {sus} other {sus}} participaciones de campaña serán eliminadas."
         },
-        "title": "{count, plural, =1 {Borra '<strong>'{firstname} {lastname}'</strong>' de tus} other {¿Estás seguro de que quieres borrar '<strong>'{count}'</strong>'}} alumnos?"
+        "title": "{count, plural, =1 {Elimina '<strong>'{firstname} {lastname}'</strong>' de tus} other {¿Estás seguro de que quieres eliminar '<strong>'{count}'</strong>' estudiantes?}}"
       },
       "edit-student-number-modal": {
         "actions": {
@@ -1985,28 +1985,28 @@
         "form": {
           "error": "El número de estudiante no debe estar vacío.",
           "new-student-number-label": "Nuevo número de estudiante",
-          "student-number": "El número de alumno actual de {firstName} {lastName} es :",
-          "success": "El cambio del número de alumno de {firstName} {lastName} se ha realizado correctamente."
+          "student-number": "El número de estudiante actual de {firstName} {lastName} es:",
+          "success": "El cambio del número de estudiante de {firstName} {lastName} se ha realizado correctamente."
         },
-        "title": "Edición de la edición para estudiantes"
+        "title": "Edición del número de estudiantes"
       },
       "empty-state": {
-        "no-participants": "Aún no hay alumnos.",
-        "no-participants-action": "El administrador debe importar los alumnos haciendo clic en el botón importar."
+        "no-participants": "Aún no hay estudiantes.",
+        "no-participants-action": "El administrador debe importar los estudiantes haciendo clic en el botón importar."
       },
       "filter": {
         "aria-label": "Filtrar estudiantes",
         "certificability": {
-          "label": "Búsqueda por certificabilidad",
+          "label": "Buscar por estado de certificación",
           "placeholder": "Certificación"
         },
         "group": {
           "empty": "No hay grupos",
           "label": "Introducir un grupo",
-          "placeholder": "Búsqueda por grupo"
+          "placeholder": "Buscar por grupo"
         },
         "student-number": {
-          "label": "Introduzca un número de estudiante",
+          "label": "Introduce un número de estudiante",
           "placeholder": "1234658P"
         },
         "students-count": "{count, plural, =0 {0 estudiante} =1 {1 estudiante} other {{count} estudiantes}}"
@@ -2014,11 +2014,11 @@
       "page-title": "Estudiantes",
       "replace-students-modal": {
         "confirm": "Sí, estoy reemplazando",
-        "confirmation-checkbox": "Puedo confirmar que comprendo perfectamente el impacto",
-        "footer-content": "Los alumnos existentes en la aplicación y presentes en la nueva importación no se eliminarán y se actualizarán si es necesario.",
-        "last-warning": "Tenga en cuenta que esta acción es irreversible. Los alumnos que no estén presentes en la nueva importación serán eliminados de Pix Orga.",
-        "main-content": "Todas sus contribuciones a la campaña serán eliminadas. Esto repercutirá en los resultados y análisis de las campañas que hayan realizado. Ya no podrán participar en campañas en las que hayan tomado parte en el pasado. Sin embargo, podrán participar en nuevas campañas.",
-        "title": "¿Está seguro de que quiere sustituir a los alumnos actuales?"
+        "confirmation-checkbox": "Confirmar que entiendo perfectamente las consecuencias",
+        "footer-content": "Los estudiantes existentes en la aplicación y presentes en la nueva importación no se eliminarán y se actualizarán si es necesario.",
+        "last-warning": "Ten en cuenta que esta acción es irreversible. Los estudiantes que no estén presentes en la nueva importación serán eliminados de Pix Orga.",
+        "main-content": "Todas sus contribuciones a la campaña serán eliminadas. Esto repercutirá en los resultados y análisis de las campañas que hayan realizado. Ya no podrán participar en campañas en las que hayan sido parte en el pasado. Sin embargo, podrán participar en nuevas campañas.",
+        "title": "¿Estás seguro de que quiere reemplazar a los estudiantes actuales?"
       },
       "table": {
         "column": {
@@ -2029,10 +2029,10 @@
             "label": "Certificación"
           },
           "last-name": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por nombre. Haga clic para ordenar alfabéticamente.",
-            "ariaLabelSortDown": "La tabla está ordenada por nombre, en orden alfabético inverso. Haga clic para ordenar alfabéticamente.",
-            "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por nombre. Haga clic para ordenar en orden alfabético inverso.",
-            "label": "Nombre"
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por apellido. Haga clic para ordenar alfabéticamente.",
+            "ariaLabelSortDown": "La tabla está ordenada por apellido, en orden alfabético inverso. Haz clic para ordenarla alfabéticamente.",
+            "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por apellido. Haz clic para ordenarla en orden alfabético inverso.",
+            "label": "Apellido"
           },
           "last-participation-date": {
             "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por fecha de participación. Haga clic para ordenar en orden ascendente.",
@@ -2041,23 +2041,23 @@
             "label": "Última participación"
           },
           "participation-count": {
-            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de entradas. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortDown": "La tabla está ordenada por número descendente de entradas. Haga clic para ordenar en orden ascendente.",
-            "ariaLabelSortUp": "La tabla está ordenada por número creciente de entradas. Haga clic para ordenar en orden descendente.",
-            "label": "Número de entradas"
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de participaciones. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortDown": "La tabla está ordenada por número descendente de participaciones. Haz clic para ordenarla en orden ascendente.",
+            "ariaLabelSortUp": "La tabla está ordenada por número creciente de participaciones. Haz clic para ordenarla en orden descendente.",
+            "label": "Número de participaciones"
           },
           "student-number": "Número de estudiante"
         },
-        "description": "Tabla de alumnos ordenada por nombre. Puede utilizar un menú en una columna adicional para cambiar el número de estudiante.",
+        "description": "Tabla de estudiantes ordenada por apellido. Puedes utilizar un menú en una columna adicional para cambiar el número de estudiantes.",
         "empty": "No hay estudiantes."
       },
-      "title": "{count, plural, =0 {Estudiantes} =1 {Estudiante ({count})} other {Estudiantes ({count})}}"
+      "title": "{count, plural, =0 {Alumnos} =1 {Alumno ({count})} other {Alumnos ({count})}}"
     },
     "team-invitations": {
-      "cancel-invitation": "Borrar invitación",
+      "cancel-invitation": "Eliminar invitación",
       "empty-table": "No hay invitaciones pendientes.",
       "invitation-cancelled-succeed-message": "La invitación ha sido eliminada.",
-      "invitation-resent-succeed-message": "La invitación ha sido devuelta.",
+      "invitation-resent-succeed-message": "La invitación ha sido reenviada.",
       "resend-invitation": "Reenviar invitación",
       "table": {
         "column": {
@@ -2080,13 +2080,13 @@
     },
     "team-members": {
       "actions": {
-        "edit-organization-membership-role": "Modificar el rol",
+        "edit-organization-membership-role": "Editar el rol",
         "leave-organization": "Salir de esta zona Pix Orga",
-        "manage": "Gestione",
-        "remove-membership": "Borrar",
-        "save": "Regístrese en",
+        "manage": "Gestionar",
+        "remove-membership": "Eliminar",
+        "save": "Regístrate en",
         "select-role": {
-          "label": "Seleccione una función",
+          "label": "Selecciona una función",
           "options": {
             "admin": "Director",
             "member": "Miembro"
@@ -2101,8 +2101,8 @@
       },
       "notifications": {
         "change-member-role": {
-          "error": "Se ha producido un error al modificar el rol del miembro.",
-          "success": "El papel ha cambiado."
+          "error": "Se ha producido un error al editar el rol del miembro.",
+          "success": "El rol ha cambiado."
         },
         "leave-organization": {
           "error": "Se ha producido un error al desactivar el miembro.",
@@ -2118,15 +2118,15 @@
           "remove": "Sí, eliminar el miembro"
         },
         "message": "{memberFirstName} {memberLastName} ya no tendrá acceso a este espacio Pix Orga.'<br>'Sus campañas siguen siendo accesibles para el resto del equipo.",
-        "title": "¿Está confirmando la eliminación?"
+        "title": "¿Confirmas la eliminación?"
       },
       "table": {
         "column": {
           "first-name": "Nombre",
           "last-name": "Nombre",
-          "organization-membership-role": "Papel"
+          "organization-membership-role": "Rol"
         },
-        "empty": "A la espera de los miembros"
+        "empty": "Miembros pendientes"
       },
       "title": "Miembros"
     },
@@ -2141,27 +2141,27 @@
           "400": "El formato de la dirección de correo electrónico es incorrecto.",
           "404": "Este correo electrónico no pertenece a ningún usuario.",
           "412": "Este miembro ya ha sido añadido.",
-          "500": "Algo ha ido mal. Por favor, inténtelo de nuevo."
+          "500": "Algo ha salido mal. Inténtalo de nuevo."
         }
       },
       "invite-form-modal": {
-        "confirm": "Confirme",
-        "question": "¿Quiere continuar?",
+        "confirm": "Confirmar",
+        "question": "¿Quieres continuar?",
         "title": "Confirmar la incorporación de nuevos miembros al equipo",
-        "warning": "Los miembros que añada tendrán acceso a los resultados de los participantes y al análisis de las campañas."
+        "warning": "Los miembros que añadas tendrán acceso a los resultados de los participantes y al análisis de las campañas."
       },
       "invited-members": "Al recibir el correo electrónico, los invitados podrán elegir entre crear una cuenta Pix o iniciar sesión con una cuenta Pix existente.",
-      "several-email-requirement": "Puede invitar a varios miembros separando las direcciones de correo electrónico con comas.",
+      "several-email-requirement": "Puedes invitar a varios miembros separando las direcciones de correo electrónico con comas.",
       "success": {
         "invitation": "Efectivamente, se ha enviado una invitación a la dirección de correo electrónico {email}.",
         "multiple-invitations": "Se ha enviado una invitación a las direcciones de correo electrónico indicadas."
       },
       "title": "Invitar a un miembro",
-      "warning": "Los miembros que añada a continuación tendrán acceso a los resultados de los participantes y al análisis de la campaña. Asegúrese de que los invitados sean miembros de su organización."
+      "warning": "Los miembros que añadas a continuación tendrán acceso a los resultados de los participantes y al análisis de la campaña. Asegúrate de que los invitados sean miembros de tu organización."
     },
     "team-new-item": {
       "input-label": "Dirección(es) de correo electrónico",
-      "invite-button": "Invite a"
+      "invite-button": "Invita a"
     },
     "terms-of-service": {
       "accept": "Acepto las condiciones de uso",

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -174,7 +174,7 @@
         "started": "{count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count, number} partecipanti}} in fase di sperimentazione"
       },
       "labels-legend": {
-        "shared": "Partecipazioni chiuse",
+        "shared": "Partecipazioni chiuse ({count})",
         "started": "In corso ({count})"
       },
       "labels-tooltip": {
@@ -287,7 +287,7 @@
         "without-account": "Accesso senza account"
       },
       "subjects": "Argomenti : {value, number}",
-      "thematic-results": "badge"
+      "thematic-results": "Badge : {value, number}"
     },
     "validation": {
       "password": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -2,11 +2,11 @@
   "api-error-messages": {
     "campaign-creation": {
       "custom-landing-page_too_long": "Il testo di presentazione della campagna è troppo lungo.",
-      "external-user-id-required": "Si prega di specificare la formulazione del campo che i partecipanti dovranno compilare all'inizio del corso.",
+      "external-user-id-required": "Specificare la dicitura del campo richiesto ai partecipanti all'avvio del percorso.",
       "id-pix-type-required": "Selezionare un tipo di identificatore esterno.",
-      "name-required": "Date un nome alla vostra campagna.",
+      "name-required": "Dare un nome alla campagna",
       "owner_not_in_organization": "Il proprietario non fa parte dell'organizzazione.",
-      "purpose-required": "Scegliete l'obiettivo della vostra campagna: valutazione o raccolta di profili.",
+      "purpose-required": "Scegliere l'obiettivo della campagna : valutazione o raccolta di profili",
       "target-profile-required": "Selezionare un percorso per la propria campagna.",
       "title_too_long": "Il titolo della campagna è troppo lungo."
     },
@@ -58,19 +58,19 @@
       "last-name-required": "L'alunno con INE {nationalStudentId} non ha il campo Cognome compilato. È obbligatorio per ogni alunno.",
       "payload-too-large": "La dimensione del file deve essere inferiore a {maxSize}MB.",
       "sex-code-required": "Uno studente con un INE di {nationalStudentId} non ha il campo sesso compilato. È obbligatorio per ogni alunno.",
-      "uai-mismatched": "L'UAI del file SIECLE non corrisponde a quello del vostro stabilimento."
+      "uai-mismatched": "pas de sens en Italie"
     }
   },
   "application": {
-    "description": "La piattaforma dedicata alla valutazione e al monitoraggio educativo. Il vostro spazio Pix Orga vi permette di lanciare una campagna di valutazione o di raccogliere i profili Pix, di seguire i progressi dei vostri studenti o allievi in una campagna o di accedere ai loro risultati."
+    "description": "La piattaforma dedicata alla valutazione e al monitoraggio educativo. Lo spazio Pix Orga consente di avviare campagne di valutazione o raccogliere i profili Pix, monitorare i progressi degli studenti e accedere ai loro risultati"
   },
   "banners": {
     "certification": {
-      "message": "'<strong>'Certificazioni:'</strong>' non dimenticate di '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizzare le sessioni in Pix Certif'</a>' e poi scaricare i certificati tramite la scheda \"Certificazioni\" prima dell'inizio del nuovo anno scolastico {year}."
+      "message": "'<strong>'Certificazioni:'</strong>' non dimenticare di '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finalizzare le sessioni in Pix Certif'</a>' e poi scaricare i certificati tramite la scheda \"Certificazioni\" prima dell'inizio del nuovo anno scolastico {year}."
     },
     "import": {
       "message": "Fasi chiave dell'anno scolastico :",
-      "step1a": "Implementare : '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Guida scarica risultati' class='link link--banner link--bold link--underlined' '>'scarica risultati'</a>' certificazione e",
+      "step1a": "Fase 1: '<'a href='https://cloud.pix.fr/s/TBF97QzSni7SWpc' title='Guida scarica risultati' class='link link--banner link--bold link--underlined' '>'Scaricare i risultati'</a>' della certificazione e",
       "step1b": "Importazione",
       "step1c": "database degli studenti (admin)",
       "step2": "'<'a href='https://cloud.pix.fr/s/RaPpKjFHNX2kSR4' title='guida Avviare percorsi di rientro scolastico' class='link link--banner link--bold link--underlined' '>'Creare campagne'</a>' (ritorno a scuola, prima media, corsi tematici, corsi specifici per materia, corsi mirati, ecc.).",
@@ -80,7 +80,7 @@
       "message": "I biglietti scadono tra {days, number} giorni."
     },
     "maximum-places-exceeded": {
-      "message": "<b>La tua organizzazione non ha più posti disponibili!</b><br />Per beneficiare di tutte le funzionalità, ti preghiamo di liberare posti, di metterti in contatto con il tuo rappresentante Pix o di '<'a href='https://pix.fr/support/form/professionnel-le' title='contact-us(France)' class=\"{linkClasses}\"'>contattarci tramite questo modulo</a>'. <br />Se siete un'organizzazione al di fuori della Francia '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='contact us (outside France)' class=\"{linkClasses}\" '>contattateci tramite questo modulo</a>'."
+      "message": "<b>L'organizzazione non ha più posti disponibili!</b><br />Per usufruire di tutte le funzionalità, è necessario liberare dei posti, contattare il proprio referente Pix o '<'a href='https://pix.fr/support/form/professionnel-le' title='contact-us(France)' class=\"{linkClasses}\"'>contattarci tramite questo modulo</a>'.<br />Per le organizzazioni al di fuori della Francia, '<'a href='https://pix.org/fr/support/form/contactez-le-support-pix' title='contact us (outside France)' class=\"{linkClasses}\" '>utilizzare questo modulo</a>''."
     },
     "over-capacity": {
       "message": "Si noti che si sta utilizzando un numero di posti superiore alla capacità totale."
@@ -95,9 +95,9 @@
       "value": "/{total} posti"
     },
     "badges-acquisitions": {
-      "information": "Qui troverete il numero di badge ottenuti dai vostri partecipanti a questa campagna, nonché la percentuale ottenuta.",
+      "information": "Qui si trova il numero di badge ottenuti dai partecipanti a questa campagna, insieme alla percentuale ottenuta.",
       "obtained": "ottenuto",
-      "title": "Distintivi"
+      "title": "badge"
     },
     "occupied-seats-count": {
       "anonymous": "incluso {count, plural, =1 {1 posto} other {{count, number} posti}} con accesso senza account",
@@ -105,15 +105,15 @@
       "value": "/{total} posti"
     },
     "participants-average-results": {
-      "information": "Qui troverete i risultati medi della vostra campagna. Questo numero comprende tutti i partecipanti che hanno completato il corso e inviato i risultati.",
+      "information": "Qui si trovano i risultati medi della campagna creata. Questo numero comprende tutti i partecipanti che hanno completato il percorso e inviato i risultati.",
       "title": "Risultato medio"
     },
     "participants-average-stages": {
-      "information": "Qui potete vedere il numero medio di partecipanti alla vostra campagna. Questo numero comprende tutti i partecipanti che hanno completato il corso e inviato i risultati.",
-      "title": "Cuscinetto medio"
+      "information": "Qui è possibile vedere il numero medio di partecipanti alla campagna. Questo numero comprende tutti i partecipanti che hanno completato il percorso e inviato i risultati.",
+      "title": "Livello medio"
     },
     "participants-count": {
-      "information": "Qui troverete il numero totale di partecipanti alla vostra campagna. Questo numero comprende tutti i partecipanti che hanno inserito il codice e hanno iniziato il loro viaggio o inviato il loro profilo.",
+      "information": "Qui troverete il numero totale di partecipanti alla vostra campagna. Questo numero comprende tutti i partecipanti che hanno inserito il codice e hanno iniziato il loro percorso o inviato il loro profilo.",
       "loader": "Caricamento del numero totale di partecipanti",
       "title": "Numero totale di partecipanti"
     },
@@ -125,7 +125,7 @@
       },
       "without-account": {
         "heading": "'<strong>'Il partecipante non ha un account Pix'</strong>' (campagna con accesso senza account):",
-        "message-description": "È possibile liberare questi spazi eliminando le voci della campagna senza accesso all'account interessato o cancellando la campagna.",
+        "message-description": "È possibile liberare questi spazi eliminando le partecipazioni della campagna senza accesso all'account interessato o cancellando la campagna.",
         "message-main": "1 partecipazione senza conto = 1 posto occupato."
       }
     },
@@ -168,50 +168,50 @@
       "title": "Ripartizione dei partecipanti per livello"
     },
     "participants-by-status": {
-      "a11y-title": "Ripartizione per stato",
+      "a11y-title": "Stato del percorso",
       "labels-a11y": {
         "shared": "{count, plural, =0 {0 partecipanti} =1 {1 partecipanti} other {{count, number} partecipanti}} che hanno inviato i loro risultati",
         "started": "{count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count, number} partecipanti}} in fase di sperimentazione"
       },
       "labels-legend": {
-        "shared": "Voci chiuse ({count})",
+        "shared": "Partecipazioni chiuse",
         "started": "In corso ({count})"
       },
       "labels-tooltip": {
         "shared": "Iscrizioni chiuse: {percentage, number, ::percent .0}",
         "started": "In corso: {percentage, number, ::percent .0}"
       },
-      "loader": "Proporzioni di carico per stato",
+      "loader": "Caricamento in corso...",
       "title": "Statuto"
     }
   },
   "common": {
     "actions": {
-      "back": "Torna a",
+      "back": "Tornare a",
       "cancel": "Annullamento",
       "close": "Chiudere",
       "confirm": "Confermare",
       "exit": "Esci",
       "global": "Azioni",
-      "link-to-participant": "Visualizza tutte le attività dei partecipanti",
-      "save": "Registro"
+      "link-to-participant": "Visualizzare tutte le attività dei partecipanti",
+      "save": "Registrare"
     },
     "api-error-messages": {
-      "account-conflict": "Questo account è già associato a questa organizzazione. Accedere con un altro account o contattare l'assistenza.",
+      "account-conflict": "L'account utilizzato è già associato a questa organizzazione. Accedere con un altro account o contattare l'assistenza.",
       "bad-request-error": "I dati inviati non sono nel formato corretto.",
       "default": "Si è verificato un errore. Riprovare o contattare l'assistenza.",
       "expired-authentication-key": "La richiesta di autenticazione è scaduta.",
-      "internal-server-error": "Si è verificato un errore interno. I nostri team stanno risolvendo il problema. Si prega di riprovare più tardi.",
+      "internal-server-error": "Si è verificato un errore interno. La nostra squadra sta risolvendo il problema. Si prega di riprovare più tardi.",
       "login-unauthorized-error": "L'indirizzo e-mail o il nome utente e/o la password inseriti non sono corretti.",
-      "login-unauthorized-remaining-attempts-error": "Attenzione: avete ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il vostro account Pix venga bloccato definitivamente.",
-      "login-unauthorized-remaining-attempts-with-user-name-error": "Attenzione: hai ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che il tuo account Pix venga definitivamente bloccato.'<br>'Se lo dimentichi, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare il tuo login.",
-      "login-unauthorized-with-user-name-error": "Il nome utente e/o la password inseriti non sono corretti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare il nome utente.",
-      "login-unexpected-error": "Impossibile connettersi. Riprovare tra qualche istante. Se il problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contattateci tramite il centro assistenza'</a>'.",
-      "login-user-blocked-error": "Il suo account è bloccato perché ha effettuato troppi tentativi di connessione. Per sbloccarlo, '<'a href=\"{url}\"'>'contattaci'</a>'.",
-      "login-user-temporary-blocked-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti. Riprova più tardi o clicca su '<'a href=\"{url}\"'>'password dimenticata'</a>' per resettarla.",
-      "login-user-temporary-blocked-with-username-error": "Hai effettuato troppi tentativi di accesso, il tuo account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contatta il tuo insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso."
+      "login-unauthorized-remaining-attempts-error": "Attenzione: rimangono ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che l'account Pix venga definitivamente bloccato.'<br>'In caso di dimenticanza, '<strong>'contatta un insegnante'</strong>' per reimpostare la password e/o recuperare il tuo login.",
+      "login-unauthorized-remaining-attempts-with-user-name-error": "Attenzione: rimangono ancora {remainingAttempts, plural, =0 {0 tentativi} =1 {1 tentativo} other {# tentativi}} prima che l' account Pix venga definitivamente bloccato.'<br>'In caso di dimenticanza, '<strong>'contattare un insegnante'</strong>' per reimpostare la password e/o recuperare il tuo login.",
+      "login-unauthorized-with-user-name-error": "Il nome utente e/o la password inseriti non sono corretti.'<br>'In caso di dimenticanza, '<strong>'contattare un insegnante'</strong>' per reimpostare la password e/o recuperare il nome utente.",
+      "login-unexpected-error": "Impossibile connettersi. Riprovare tra qualche istante. Se il problema persiste, '<'a href=\"{supportHomeUrl}\" target=\"blank\"'>'contattare il centro assistenza'</a>'.",
+      "login-user-blocked-error": "L'account è bloccato perché troppi tentativi di connessione sono stati realizzati. Per sbloccarlo, '<'a href=\"{url}\"'>'contattare'</a>'.",
+      "login-user-temporary-blocked-error": "Sono stati effettuati troppi tentativi di accesso. L'account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contattare un insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso.",
+      "login-user-temporary-blocked-with-username-error": "Sono stati effettuati troppi tentativi di accesso. L'account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contattare un insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso."
     },
-    "breadcrumb": "Percorso a briciole di pane",
+    "breadcrumb": "????",
     "cgu": {
       "error": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
       "label": "Accetto le condizioni d'uso e l'informativa sulla privacy di Pix",
@@ -239,7 +239,7 @@
       "participantExternalId": {
         "label": "Ricerca di identificatore esterno"
       },
-      "placeholder": "-- Seleziona...",
+      "placeholder": "Selezionare",
       "search-label-list": "Ricerca",
       "title": "Filtri"
     },
@@ -261,7 +261,7 @@
     "loading": "Caricamento in corso",
     "no-content": "Nessun contenuto",
     "notification": {
-      "close": "Chiudi la notifica"
+      "close": "Chiudere la notifica"
     },
     "pagination": {
       "nextPage": "Vai alla pagina successiva",
@@ -287,7 +287,7 @@
         "without-account": "Accesso senza account"
       },
       "subjects": "Argomenti : {value, number}",
-      "thematic-results": "Distintivi: {value, number}"
+      "thematic-results": "badge"
     },
     "validation": {
       "password": {
@@ -315,7 +315,7 @@
       "information": {
         "ASSESSMENT": "Valutazione",
         "COMBINED_COURSE": "Percorso di apprendimento",
-        "EXAM": "Modalità di interrogazione",
+        "EXAM": "Modalità quiz",
         "PROFILES_COLLECTION": "Collezione di profili",
         "campaign": "Valutazione",
         "formation": "Formazione",
@@ -363,12 +363,12 @@
       },
       "oidc-association-confirmation": {
         "authentication-method-to-add": "Aggiunta di una connessione",
-        "confirm": "Continua",
+        "confirm": "Continuare",
         "current-authentication-methods": "I miei metodi di connessione attuali",
         "email": "Indirizzo e-mail",
         "external-connection": "Collegamento esterno",
         "external-connection-via": "Connessione tramite",
-        "return": "Torna a",
+        "return": "Tornare a",
         "title": "Un nuovo metodo di accesso sta per essere aggiunto al vostro account Pix.",
         "username": "Identificatore"
       },
@@ -385,7 +385,7 @@
       "aria-label": "Spiegazione della certificabilità",
       "content": "La certificabilità significa che il partecipante ha raggiunto il livello 1 in almeno 5 competenze diverse.",
       "from-collect-notice": "Le informazioni provengono dalle campagne di raccolta dei profili effettuate dal partecipante. Se il partecipante ha già inviato il proprio profilo, vengono visualizzati la data e lo stato dell'ultimo invio.",
-      "from-compute-certificability": "Questo stato viene aggiornato automaticamente il giorno successivo a ogni accesso del partecipante e durante le raccolte dei profili."
+      "from-compute-certificability": "Questo stato viene aggiornato automaticamente il giorno successivo a ogni accesso del partecipante e durante le raccolte del profilo."
     },
     "cover-rate-gauge": {
       "label": "In questa campagna, i partecipanti hanno raggiunto un livello di {reachedLevel} su un livello massimo raggiungibile di {maxLevel}."
@@ -414,11 +414,11 @@
         "classic": {
           "create-campaign": {
             "buttonText": "Nuova campagna",
-            "description": "Scegliete il corso su cui volete valutare i vostri partecipanti o raccogliere il loro profilo Pix.",
+            "description": "Scegliere il percorso sul quale si vogliono valutare i partecipanti o raccogliere i loro profili Pix.",
             "title": "Creare una campagna"
           },
           "follow-activity": {
-            "buttonText": "Vedi le mie campagne",
+            "buttonText": "Vedere le campagne create",
             "description": "Visualizzare lo stato e i risultati dei partecipanti.",
             "title": "Tracciamento dell'attività"
           }
@@ -438,7 +438,7 @@
             "title": "Gestione di una sessione"
           }
         },
-        "title": "Cosa ti piacerebbe fare?"
+        "title": "Che cosa vorresti fare ?"
       },
       "organization-information": {
         "label": "Nome dell'organizzazione",
@@ -452,16 +452,16 @@
           "title": "Partecipazioni completate"
         },
         "completion-rate": {
-          "description": "{completed} voci completate su {started} voci avviate.",
-          "info": "Il tasso di completamento viene calcolato in base alle campagne attive di cui si è titolari.",
+          "description": "{completed} partecipazioni completate su {started} partecipazioni avviate.",
+          "info": "Il tasso di completamento viene calcolato in base alle campagne attive di cui si è proprietari.",
           "no-activity": "Nessuna attività al momento",
           "title": "Tasso di completamento"
         }
       },
       "welcome": {
         "description": {
-          "classic": "Benvenuti nella vostra piattaforma di valutazione e sviluppo delle competenze digitali! Create e distribuite campagne ai vostri partecipanti. Tracciate i loro progressi e analizzate i loro risultati in modo da poter offrire loro un supporto su misura per le loro esigenze.",
-          "missions": "Benvenuti nella vostra piattaforma per il monitoraggio delle competenze digitali dei vostri alunni! Selezionate i compiti e seguite i loro progressi."
+          "classic": "Benvenuti nella piattaforma di valutazione e sviluppo delle competenze digitali! Create e attribuite campagne ai partecipanti. Monitorate i loro progressi e analizzate i loro risultati per accompagnarli al meglio e in modo personalizzato.",
+          "missions": "Benvenuti nella vostra piattaforma per il monitoraggio delle competenze digitali dei vostri alunni! Selezionate i percorsi e seguite i loro progressi."
         },
         "title": "Ciao {name},"
       }
@@ -492,7 +492,7 @@
       "actions": {
         "accept": "Accettare e continuare",
         "document-link": "Leggere le condizioni di utilizzo",
-        "reject": "Rifiuto e uscita"
+        "reject": "Rifiutare e uscire"
       },
       "message": {
         "requested": "Per continuare a utilizzare Pix, leggere e accettare i nostri Termini e condizioni d'uso.",
@@ -505,7 +505,7 @@
     },
     "ui": {
       "deletion-modal": {
-        "confirm-deletion": "Sì, sto cancellando",
+        "confirm-deletion": "Si, cancellare",
         "confirmation-checkbox": "{count, plural, =1 {Confermo di aver compreso appieno l'impatto della cancellazione.} other {Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.}}"
       },
       "edit-participant-name-modal": {
@@ -580,7 +580,7 @@
       }
     },
     "team-members": {
-      "aria-label": "Navigazione nella sezione del team"
+      "aria-label": "Navigazione nella sezione della squadra"
     },
     "user-logged-menu": {
       "button": "Cambiamento dell'organizzazione",
@@ -593,7 +593,7 @@
       "breadcrumb-current-page-label": "Partecipazione di {firstName} {lastName}",
       "participation-label": "Partecipazione #{participationNumber}",
       "participation-not-shared": "Risultati non inviati",
-      "participation-selector": "Scegliere un paletto",
+      "participation-selector": "Selezionare un livello",
       "participation-shared": "Risultati inviati",
       "progression": "Avanzamento",
       "result": "Risultati",
@@ -699,10 +699,10 @@
       "delete-participation-modal": {
         "actions": {
           "cancel": "No",
-          "confirmation": "Sì, sto cancellando"
+          "confirmation": "Si, cancellare"
         },
-        "error": "Si è verificato un problema durante l'eliminazione della voce.",
-        "success": "La puntata è stata ritirata con successo.",
+        "error": "Si è verificato un problema durante l'eliminazione della partecipazione.",
+        "success": "La partecipazione è stata eliminata con successo.",
         "text": "Se si sta per eliminare una voce, questa non sarà più visibile né inclusa nelle statistiche della campagna.",
         "title": "Eliminare la partecipazione di <strong>{firstName} {lastName}</strong>?",
         "warning": {
@@ -717,13 +717,13 @@
       },
       "table": {
         "column": {
-          "delete": "Eliminare la partecipazione agli utili",
+          "delete": "Eliminare la partecipazione",
           "first-name": "Nome",
           "last-name": "Nome",
           "participationCount": "Numero di voci",
           "status": "Stato"
         },
-        "delete-button-label": "Eliminare la partecipazione agli utili",
+        "delete-button-label": "Eliminare la partecipazione",
         "empty": "Nessun partecipante",
         "see-results": "Visualizza i risultati per {firstName} {lastName}",
         "title": "Elenco dei partecipanti"
@@ -734,18 +734,18 @@
       "description": {
         "explanation": "{count, plural, =1 { Il posizionamento riflette il livello medio raggiunto dal partecipante, rispetto al livello massimo raggiungibile in questa campagna.} other { Il posizionamento riflette il livello medio raggiunto dai partecipanti, rispetto al livello massimo raggiungibile in questa campagna.}}",
         "nota-bene": "{count, plural, =1 {Tutti i dati presentati provengono dalla partecipazione selezionata.} other {Tutti i dati presentati provengono da partecipazioni condivise e non cancellate da campagne di valutazione e vengono aggiornati ad ogni visita.}}",
-        "resume": "{count, plural, =1 {Analizzare per abilità o per materia, il posizionamento del partecipante a questa campagna che copre una selezione di argomenti del quadro di riferimento Pix.} other {Analizzare per abilità o per materia, il posizionamento dei vostri partecipanti a questa campagna che copre una selezione di argomenti del quadro di riferimento Pix.}}"
+        "resume": "{count, plural, =1 {Analizzare per abilità o per materia, il posizionamento del partecipante a questa campagna che copre una selezione di argomenti del quadro di riferimento Pix.} other {Analizzare per abilità o per materia, il posizionamento dei partecipanti a questa campagna che copre una selezione di argomenti del quadro di riferimento Pix.}}"
       },
       "levels-correspondence": {
         "infos": {
           "link": "https://pix.fr/score-et-niveaux",
-          "text": "Per saperne di più sui livelli."
+          "text": "Altre informazioni sui livelli"
         },
         "levels": {
           "advanced": "5 o 6: Avanzato",
-          "beginner": "1 o 2: Novizio",
+          "beginner": "Principiante",
           "expert": "7 o 8: Esperto",
-          "independent": "3 o 4: Lavoratore autonomo"
+          "independent": "Indipendente"
         },
         "title": "Corrispondenza tra i livelli"
       },
@@ -756,8 +756,8 @@
         "create": "Creare la campagna",
         "delete": "Cancellare"
       },
-      "combined-course-blueprints-label": "Seleziona un percorso di apprendimento",
-      "combined-course-blueprints-list-label": "Seleziona un percorso di apprendimento",
+      "combined-course-blueprints-label": "Selezionare un percorso di apprendimento",
+      "combined-course-blueprints-list-label": "Selezionare un percorso di apprendimento",
       "copy-of": "Copia di",
       "course-label": "Seleziona un corso",
       "course-selection-label": "Selezionare un corso",
@@ -777,7 +777,7 @@
           "message": "L'identificativo aggiuntivo ti consente di richiedere, all'inizio della campagna, a ciascun partecipante le informazioni di identificazione che preferisci.'<br>'Selezionando “sì”, potrai filtrare e ordinare i partecipanti in base a questo dato.'<br>'Selezionando “no”, nel monitoraggio della campagna saranno disponibili solo il nome e il cognome dell'account del partecipante."
         },
         "label": "Denominazione dell'identificativo aggiuntivo",
-        "question-label": "Desidera richiedere un identificativo aggiuntivo all'inizio della partecipazione?",
+        "question-label": "Si desidera richiedere un identificatore esterno ?",
         "required": "Il identificativo aggiuntivo è obbligatorio",
         "suggestion": "Esempio: \"Numero dello studente\" o \"Indirizzo e-mail professionale\" *."
       },
@@ -792,11 +792,11 @@
         "label": "Testo della pagina iniziale",
         "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
       },
-      "legal-warning": "* In conformità con la legge francese sulla protezione dei dati, e in qualità di responsabile del trattamento dei dati, si prega di fare attenzione a non chiedere dati particolarmente identificativi o significativi, a meno che non siano assolutamente indispensabili. Il numero di previdenza sociale (NIR) deve essere evitato, così come qualsiasi altro dato sensibile.",
+      "legal-warning": "cela n'est pas pertinent : Il numero di previdenza sociale (NIR) deve essere evitato, così come qualsiasi altro dato sensibile.",
       "multiple-sendings": {
         "assessments": {
-          "info": "Se si sceglie di inviare la campagna più volte, il partecipante potrà ripetere la campagna più volte, inserendo nuovamente il codice. Avrete accesso a tutti i risultati.",
-          "question-label": "Volete consentire ai partecipanti di inviare i loro risultati più di una volta?"
+          "info": "Se si sceglie di inviare la campagna più volte, il partecipante potrà ripetere la campagna più volte, inserendo nuovamente il codice.Tutti i risultati saranno disponibili.",
+          "question-label": "Si autorizzano i partecipanti a inviare i loro risultati più volte?"
         },
         "info-title": "Invio multiplo",
         "knowledge-elements-resettable": "Nell'ambito del corso, i partecipanti possono cercare di migliorare i propri risultati ripetendo tutte le domande del corso.",
@@ -822,9 +822,9 @@
         "assessment-info": "Una campagna di valutazione consente ai partecipanti di essere testati su argomenti specifici.",
         "combined-course": "Sviluppare le competenze dei partecipanti",
         "combined-course-info": "Un percorso di apprendimento aiuta i partecipanti ad acquisire nuove competenze.",
-        "exam": "Modalità di interrogazione",
+        "exam": "Modalità quiz",
         "exam-info": "Una campagna in \"modalità quiz\" consente di sottoporre i partecipanti a test su argomenti specifici, senza tenere conto del loro profilo utente e senza influire su di esso. I test proposti sono personalizzati per ogni partecipante, a seconda del livello di avanzamento del corso.",
-        "label": "Qual è l'obiettivo della vostra campagna?",
+        "label": "Qual é l'obiettivo della campagna creata ?",
         "profiles-collection": "Raccogliere i profili Pix dei partecipanti",
         "profiles-collection-info": "Una campagna di raccolta di profili viene utilizzata per recuperare il profilo dei partecipanti: livelli per abilità e punteggio pix.",
         "profiles-collection-info-certificability-calculation": "Lo stato di certificabilità viene aggiornato automaticamente nella scheda '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'Studenti'</a>'.",
@@ -834,15 +834,15 @@
         "title": "Impostazioni"
       },
       "tags": {
-        "BACK_TO_SCHOOL": "Corso di ritorno a scuola / 6e",
+        "BACK_TO_SCHOOL": "Percorso di ritorno a scuola, prima media",
         "COMPETENCES": "Le 16 competenze",
-        "CUSTOM": "Corsi su misura",
+        "CUSTOM": "Percorsi su misura",
         "DISCIPLINE": "Disciplinare",
         "OTHER": "Altro",
         "PIX_PLUS": "Pix+",
         "PREDEFINED": "Percorsi predefiniti",
         "SUBJECT": "Temi",
-        "TARGETED": "Corsi mirati"
+        "TARGETED": "Percorsi mirati"
       },
       "tags-title": "Filtrare la ricerca :",
       "target-profiles-category-label": "Filtrare i percorsi per categoria",
@@ -888,17 +888,17 @@
         "aria-label": "Filtri sulle partecipazioni",
         "participations-count": "{count, plural, =0 {0 partecipanti} =1 {1 partecipante} other {{count} partecipanti}}",
         "type": {
-          "badges": "Distintivi ottenuti",
+          "badges": "badge ottenuti",
           "groups": {
             "empty": "Nessun gruppo",
             "title": "Gruppi"
           },
-          "stages": "Cuscinetti",
+          "stages": "livelli",
           "status": {
             "empty": "Tutte le voci",
             "title": "Stato"
           },
-          "unacquired-badges": "Distintivi non ottenuti"
+          "unacquired-badges": "badges non ottenuti"
         }
       },
       "result": "Risultati",
@@ -911,20 +911,20 @@
         "column": {
           "ariaSharedResultCount": "Numero di risultati inviati",
           "badges": "Distintivi",
-          "evolution": "L'evoluzione",
+          "evolution": "Evoluzione",
           "first-name": "Nome",
           "last-name": "Nome",
           "results": {
             "label": "Risultati",
-            "on-hold": " In attesa di spedizione",
+            "on-hold": "In attesa di invio",
             "under-test": "Attualmente in fase di test"
           },
           "sharedResultCount": "Numero di risultati inviati"
         },
         "empty": "Nessuna partecipazione",
         "evolution": {
-          "decrease": "In declino",
-          "increase": "In crescita",
+          "decrease": "In diminuzione",
+          "increase": "In aumento",
           "stable": "Costante",
           "unavailable": "Non disponibile"
         },
@@ -949,7 +949,7 @@
       "campaign-type": {
         "assessment": "Campagna di valutazione",
         "exam": "Campagna Quiz",
-        "profiles-collection": "Campagna di raccolta profili",
+        "profiles-collection": "Campagna di raccolta dei profili",
         "title": "Tipo di campagna"
       },
       "delete-confirmation-modal": {
@@ -960,7 +960,7 @@
         },
         "title": "Sei sicuro di voler eliminare la campagna?"
       },
-      "direct-link": "Collegamento diretto",
+      "direct-link": "Campagna di raccolta dei profili",
       "external-user-id-label": "Denominazione dell'identificativo aggiuntivo",
       "external-user-id-types": {
         "email": "Indirizzo e-mail",
@@ -978,7 +978,7 @@
           "text": "Se sono attivati gli invii multipli, i partecipanti possono inviare i loro elaborati più volte inserendo nuovamente il codice della campagna."
         }
       },
-      "personalised-test-title": "Titolo del corso",
+      "personalised-test-title": "Titolo del percorso",
       "reset-to-zero": {
         "status": {
           "disabled": "No",
@@ -986,13 +986,13 @@
         },
         "title": "Azzeramento",
         "tooltip": {
-          "aria-label": "Descrizione di Reset",
-          "text": "Se la funzione di reset è attivata, il partecipante può ripetere l'intero corso e inviare i propri risultati, più volte, inserendo nuovamente il codice della campagna."
+          "aria-label": "Descrizione di azzeramento",
+          "text": "Se la funzione di azzeramento è attivata, il partecipante può ripetere la modalità quiz e inviare i propri risultati, più volte, inserendo nuovamente il codice della campagna."
         }
       },
       "target-profile": {
-        "title": "Corso",
-        "tooltip": "Descrizione del corso"
+        "title": "Percorso",
+        "tooltip": "Descrizione del percorso"
       },
       "title": "Parametri"
     },
@@ -1001,18 +1001,18 @@
         "campaign": {
           "archived": "Archiviato",
           "label": "Visualizzare le campagne attive o archiviate",
-          "ongoing": "Attivo"
+          "ongoing": "Attive"
         },
         "create": "Creare una campagna"
       },
       "action-bar": {
-        "delete-button": "Cancellare",
+        "delete-button": "Eliminare",
         "error-message": "{count, plural, =1 {Si è verificato un errore, la campagna non è stata rimossa dall'elenco.} other {Si è verificato un errore, le {count} campagne selezionate non sono state rimosse dall'elenco.}}",
         "information": "{count, plural, =1 {{count} campagna selezionata} other {{count} campagne selezionate}}",
         "success-message": "{count, plural, =1 {La campagna (insieme ai suoi risultati) è stata effettivamente rimossa dall'elenco.} other {Le {count} campagne selezionate (insieme ai loro risultati) sono state effettivamente rimosse dall'elenco.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "{count, plural, =1 {Confermo di aver compreso appieno l'impatto della cancellazione.} other {Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.}}",
+        "confirmation-checkbox": "Confermare di aver compreso appieno le conseguenze delle {count} eliminazioni",
         "content": {
           "footer": "Si noti che questa azione è irreversibile.",
           "header": "{count, plural, =1 {Questa campagna non sarà più visibile} other {Queste campagne non saranno più visibili}} in Pix Orga.",
@@ -1021,13 +1021,13 @@
         "title": "{count, plural, =1 {Sicuro di voler cancellare la campagna selezionata? } other {Sicuro di voler cancellare le campagne '<strong>'{count}'</strong>' selezionate? }}"
       },
       "filter": {
-        "by-name": "Ricerca di una campagna",
+        "by-name": "Cercare una campagna",
         "by-owner": "Trovare un proprietario",
         "legend": "Filtri per la tabella delle campagne: i campi di input possono essere utilizzati per filtrare la tabella in base al nome della campagna e al nome del proprietario. I pulsanti possono essere utilizzati per filtrare le campagne attive e archiviate.",
         "results": "{total, plural, =0 {0 campagne} =1 {1 campagna} other {{total, number} campagne}}"
       },
       "navigation": "Navigazione nella sezione Campagne",
-      "no-campaign": "Nessuna campagna, per iniziare fare clic sul pulsante \"Crea una campagna\".",
+      "no-campaign": "Nessuna campagna, per iniziare cliccare su \"Creare una campagna\".",
       "table": {
         "column": {
           "code": "Codice",
@@ -1079,7 +1079,7 @@
         },
         "name": {
           "label": "Nome del percorso",
-          "placeholder": "Cerca per titolo"
+          "placeholder": "Ricerca per titolo"
         },
         "nb-result": "{count, plural, =0 {Nessun percorso} =1 {{count} percorso} other {{count} percorsi}}"
       },
@@ -1116,8 +1116,8 @@
       "description": "Selezionare la classe per la quale si desidera esportare i risultati della certificazione (.csv) o scaricare i certificati (.pdf).\n È possibile filtrare questo elenco inserendo il nome della classe direttamente nel campo.",
       "documentation-link": "https://cloud.pix.fr/s/oqnYJWHoSXz8LJk",
       "documentation-link-label": "Interpretazione dei risultati",
-      "documentation-link-notice": "Seguite questo link per scoprire come interpretare i risultati:",
-      "download-attestations-button": "Scarica i certificati",
+      "documentation-link-notice": "Seguire questo link per scoprire come interpretare i risultati:",
+      "download-attestations-button": "Scaricare i certificati",
       "download-button": "Esportazione dei risultati",
       "errors": {
         "invalid-division": "La classe {selectedDivision} non esiste.",
@@ -1185,7 +1185,7 @@
         "column": {
           "code": "Codice",
           "completed": "I partecipanti che hanno completato",
-          "name": "Nome del corso",
+          "name": "Nome del percorso",
           "participants": "Partecipanti"
         }
       }
@@ -1202,17 +1202,17 @@
           "email": {
             "error": "L'indirizzo e-mail non è valido.",
             "label": "Indirizzo e-mail",
-            "placeholder": "Ad esempio, jean.dupont@email.com"
+            "placeholder": "Per esempio : maria.rossi@email.it"
           },
           "firstname": {
-            "error": "Il nome non è compilato.",
+            "error": "Il nome non è stato inserito",
             "label": "Nome",
-            "placeholder": "ex: Jean"
+            "placeholder": "esempio : Maria"
           },
           "lastname": {
-            "error": "Il vostro nome non è stato inserito.",
-            "label": "Nome",
-            "placeholder": "ad esempio Dupont"
+            "error": "Il cognome non è stato inserito",
+            "label": "Cognome",
+            "placeholder": "esempio : Rossi"
           },
           "legend": "Informazioni necessarie per la registrazione.",
           "password": {
@@ -1221,39 +1221,39 @@
             "label": "Password"
           }
         },
-        "submit": "Desidero registrarmi",
+        "submit": "Registrarsi",
         "subtitle": "per accedere allo spazio Pix Orga",
-        "title": "Iscriviti a Pix"
+        "title": "Iscriversi a Pix"
       }
     },
     "join-request-form": {
-      "firstname": "Il vostro nome di battesimo",
-      "lastname": "Il tuo nome",
+      "firstname": "Nome",
+      "lastname": "Cognome",
       "legal-information": {
-        "link-text": "Per saperne di più sui miei diritti.",
+        "link-text": "Per saperne di più sui propri diritti",
         "link-url": "https://pix.fr/dp-formulaire-recuperation-pixorga-sco",
-        "text": "Le informazioni raccolte in questo modulo vengono registrate in un file elaborato da GIP Pix per conto del Ministero dell'Educazione Nazionale, in qualità di responsabile del trattamento dei dati, per consentire alla vostra scuola di accedere al suo spazio Pix Orga, inviandole un invito a entrare in questo spazio."
+        "text": "Le informazioni raccolte in questo modulo vengono registrate in un file elaborato da GIP Pix per conto del Ministero della Pubblica Istruzione, in qualità di responsabile del trattamento dei dati, per consentire alla scuola di accedere al proprio spazio Pix Orga, tramite un invito specifico."
       },
-      "organization-code": "UAI/RNE dello stabilimento"
+      "organization-code": "Codice di identificazione della scuola"
     },
     "login": {
-      "join-invitation": "Siete invitati a partecipare: {organizationName}",
+      "join-invitation": "Invito a partecipare: {organizationName}",
       "signup": {
-        "label": "Registrati con Pix"
+        "label": "Registrarsi con Pix"
       },
       "title": "Accedere a",
-      "with-pix-account": "con il tuo account Pix"
+      "with-pix-account": "con il proprio account Pix"
     },
     "login-form": {
-      "active-or-retrieve": "Attivate o diventate amministratori dello spazio Pix Orga della vostra scuola.",
-      "admin-role-question": "Siete un dirigente o un insegnante?",
-      "associate-account": "Collegare il mio account",
+      "active-or-retrieve": "Attivare o diventare amministratore dello spazio Pix Orga della propria scuola.",
+      "admin-role-question": "Definire il proprio ruolo : dirigente scolastico o insegnante ?",
+      "associate-account": "Collegare il proprio account",
       "email": {
         "label": "Indirizzo e-mail",
-        "placeholder": "Ad esempio, jean.dupont@email.com"
+        "placeholder": "italianizzare ? Maria.Rossi@email.it"
       },
       "errors": {
-        "access-not-allowed": "L'accesso a Pix Orga è limitato ai membri invitati. Ogni area è gestita da un amministratore di Pix Orga specifico per l'organizzazione che la utilizza. Contattatelo per invitarvi.",
+        "access-not-allowed": "L'accesso a Pix Orga è riservato agli utenti invitati. Ogni area è gestita da un amministratore Pix Orga della propria organizzazione. Contattarlo per richiedere un invito",
         "empty-email": "L'indirizzo e-mail non è stato inserito.",
         "empty-password": "La password non è stata inserita.",
         "invalid-email": "L'indirizzo e-mail non è valido.",
@@ -1262,31 +1262,31 @@
           "409": "Questo invito è già stato accettato o annullato."
         }
       },
-      "forgot-password": "Avete dimenticato la password?",
+      "forgot-password": "Password dimenticata ?",
       "invitation-already-accepted": "Questo invito è già stato accettato. Si prega di effettuare il login o di contattare l'amministratore del proprio spazio Pix Orga.",
       "invitation-not-found": "Questo invito non è stato trovato. Contattare l'amministratore del proprio spazio Pix Orga.",
       "invitation-was-cancelled": "Questo invito non è più valido. Contattare l'amministratore del proprio spazio Pix Orga.",
-      "login": "Voglio connettermi",
+      "login": "Connettersi",
       "password": "Password"
     },
     "login-or-register": {
       "login-form": {
-        "button": "Accedi",
+        "button": "Accedere",
         "title": "Ho già un account PIX"
       },
       "register-form": {
-        "button": "Iscriviti",
+        "button": "Iscriversi",
         "errors": {
-          "default": "Il servizio non è temporaneamente disponibile. Si prega di riprovare più tardi.",
+          "default": "Il servizio è temporaneamente indisponibile. Si prega di riprovare più tardi.",
           "email-already-exists": "Questo indirizzo e-mail è già registrato, si prega di effettuare il login.",
           "invalid-or-already-used-email": "Indirizzo e-mail non valido o già utilizzato"
         },
         "fields": {
           "button": {
-            "label": "Desidero registrarmi"
+            "label": "Registrarsi"
           },
           "cgu": {
-            "accept": "Accetto il",
+            "accept": "Accettare il",
             "and": "e il",
             "aria-label": "Accettare le condizioni d'uso di Pix",
             "data-protection-policy": "Informativa sulla privacy",
@@ -1298,38 +1298,38 @@
             "label": "Indirizzo e-mail"
           },
           "first-name": {
-            "error": "Il nome non è compilato.",
+            "error": "Il nome non è stato inserito",
             "label": "Nome"
           },
           "last-name": {
-            "error": "Il vostro nome non è stato inserito.",
-            "label": "Nome"
+            "error": "Il cognome non è stato inserito.",
+            "label": "Cognome"
           },
           "password": {
             "error": "La password deve essere lunga almeno 8 caratteri e contenere almeno una lettera maiuscola, una lettera minuscola e un numero.",
             "label": "Password"
           }
         },
-        "title": "Desidero registrarmi"
+        "title": "Registrarsi"
       },
-      "title": "Siete invitati a unirvi all'organizzazione {organizationName}."
+      "title": "Sei invitato a raggiungere l'organizzazione {organizationName}."
     },
     "missions": {
       "list": {
         "actions": {
-          "see-mission-details": "Vedi dettagli"
+          "see-mission-details": "Vedere i dettagli"
         },
         "aria-label": "Missione",
         "banner": {
           "copypaste-container": {
-            "abstract": "Iniziate le prime missioni con i vostri studenti attivando la sessione tramite il pulsante qui sopra e utilizzando il tasto",
+            "abstract": "Iniziate le prime missioni con gli studenti attivando la sessione tramite il pulsante qui sopra e utilizzando il tasto",
             "button": {
               "success": "copiato!",
               "tooltip": "copiare il codice"
             }
           },
-          "hint": "Non esitate ad aggiungerlo ai vostri preferiti.",
-          "import-text": "link alla scuola",
+          "hint": "Si consiglia di aggiungere questo link ai preferiti del browser",
+          "import-text": "link della scuola",
           "step1": {
             "admin": {
               "head": "Fase 1: <b>Per favore</b>.",
@@ -1339,10 +1339,10 @@
             "non-admin": "Passo 1: <b>Richiedere all'amministratore</b> Pix Orga del proprio spazio per importare gli studenti."
           },
           "step2": {
-            "option1": "utilizzare <b>il link</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Vi verrà richiesto il codice della scuola a ogni accesso.",
+            "option1": "utilizzare <b>il link</b> '<'a href=\"{pixJuniorUrl}\"'>'junior.pix.fr'</a>'. Vi verrà richiesto il codice della scuola a ogni accesso.",
             "option2": {
-              "body": "o utilizzare il link diretto '<'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.fr/schools/{code}'</a>'",
-              "hint": "È possibile salvare questo preferito sui computer."
+              "body": "o utilizzare il link diretto '<'a href=\"{pixJuniorUrl}\" target=_blank >junior.pix.fr/schools/{code}'</a>'",
+              "hint": "E' possibile aggiungere questo link ai preferiti del browser"
             },
             "title": "Fase 2: Per consentire agli studenti di accedere allo spazio Pix Junior della scuola, è possibile :"
           },
@@ -1353,7 +1353,7 @@
         "empty-state": "Non ci sono missioni",
         "headers": {
           "actions": "Azioni",
-          "competences": "Competenze CRCN lavorate",
+          "competences": "Competenze del CRCN trattate",
           "name": "Missione",
           "started-by": "Iniziato da"
         },
@@ -1364,9 +1364,9 @@
       },
       "mission": {
         "details": {
-          "button-label": "Vedi la scheda didattica",
+          "button-label": "Vedere la scheda didattica",
           "competence": {
-            "title": "Competenza CRCN lavorata su :"
+            "title": "Competenza del CRCN trattata"
           },
           "objective": {
             "title": "Obiettivi della missione :"
@@ -1414,7 +1414,7 @@
               "learners-count": "{count, plural, =0 { Nessun alunno} =1 { 1 alunno} other {{count} alunni}}"
             },
             "headers": {
-              "dare-challenge": "Sfida",
+              "dare-challenge": "Missione",
               "division": "Classe",
               "first-name": "Nome",
               "last-name": "Nome",
@@ -1455,7 +1455,7 @@
       "login": {
         "signup-button": "Non ho un account, mi registro con la mia organizzazione",
         "sub-title": "per collegarlo al nuovo metodo di connessione",
-        "title": "Utilizza il tuo account Pix"
+        "title": "Utilizzare il proprio account"
       },
       "signup": {
         "claims": {
@@ -1467,17 +1467,17 @@
           "last-name-label": "Nome :",
           "population": "Popolazione",
           "rne": "Luogo di lavoro",
-          "title": "Funzione"
+          "title": "Ruolo amministrativo"
         },
         "description": "Verrà creato un account utilizzando le informazioni fornite dall'organizzazione.",
         "error": {
           "cgu": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
-          "claims": "Non siamo riusciti a recuperare le informazioni sulla vostra identità dal servizio utilizzato. Si prega di contattare il supporto informatico dell'organizzazione."
+          "claims": "Impossibile recuperare le informazioni sull'identità dal servizio utilizzato. Contattare il supporto informatico di questa organizzazione."
         },
         "login-button": "Ho già un account Pix, vorrei effettuare il login",
         "signup-button": "Desidero iscrivermi a Pix",
         "sub-title": "per accedere allo spazio Pix Orga",
-        "title": "Iscriviti a Pix"
+        "title": "Iscriversi a Pix"
       }
     },
     "organization-learner": {
@@ -1488,7 +1488,7 @@
           "started": "In corso: {count}",
           "title": {
             "assessment": "Valutazioni",
-            "profiles-collection": "Collezione di profili"
+            "profiles-collection": "Raccolta dei profili"
           }
         },
         "empty-state": "Nessuna attività al momento! Inviare una campagna a {organizationLearnerFirstName} {organizationLearnerLastName} e iniziare a seguirne i progressi.",
@@ -1523,18 +1523,18 @@
         "success-message": "{count, plural, =1 {{firstname} {lastname} è stato rimosso dall'elenco dei partecipanti.} other { I {count} partecipanti selezionati sono stati rimossi dall'elenco.}}"
       },
       "deletion-modal": {
-        "confirmation-checkbox": "{count, plural, =1 {Confermo di aver compreso appieno l'impatto della cancellazione.} other {Confermo di aver compreso appieno l'impatto delle {count} cancellazioni.}}",
+        "confirmation-checkbox": "Confermare di aver compreso appieno le conseguenze delle {count} eliminazioni",
         "content": {
           "footer": "Si noti che questa azione è irreversibile.",
           "header": "{count, plural, =1 {Questo partecipante non sarà più visibile} other {Questi partecipanti non saranno più visibili}} in Pix Orga.",
-          "main-campaign-prevent": "Questo avrà quindi un impatto sui risultati e sulle analisi delle campagne che {count, plural, =1 {ha} other {hanno}} realizzato.",
+          "main-campaign-prevent": "Questo influenzerà quindi i risultati e le analisi delle campagne che {count, plural, =1 {ha} other {hanno}} realizzato.",
           "main-participation-prevent": "Tutte le voci della {count, plural, =1 {sua} other {sua}} campagna saranno eliminate."
         },
         "title": "{count, plural, =1 {Cancella '<strong>'{firstname} {lastname}'</strong>' dai tuoi} other {Sei sicuro di voler cancellare '<strong>'{count}'</strong>'}} partecipanti?"
       },
       "empty-state": {
-        "action": "Vedi le mie campagne",
-        "call-to-action": "Invitateli a partecipare a una campagna o a crearne una nuova.",
+        "action": "Vedere le mie campagne",
+        "call-to-action": "Invitarli a partecipare a una campagna esistente o crearne un'altra",
         "message": "Nessun partecipante per ora!"
       },
       "filters": {
@@ -1551,8 +1551,8 @@
       "page-title": "Partecipanti",
       "table": {
         "actions": {
-          "disable-oralization": "Disattivare la lettura del setpoint",
-          "enable-oralization": "Attivare la lettura del setpoint"
+          "disable-oralization": "Disattivare la lettura della consegna",
+          "enable-oralization": "Attivare la lettura della consegna"
         },
         "column": {
           "checkbox": "Selezionare/Deselezionare {firstname} {lastname}",
@@ -1590,7 +1590,7 @@
         "oralization-header-tooltip": "Attivando \"leggi le istruzioni\", lo studente riceverà una trascrizione parlata.",
         "row-value": {
           "oralization": {
-            "false": "Spento",
+            "false": "Disattivato",
             "true": "Attivato"
           }
         }
@@ -1600,7 +1600,7 @@
       "actions": {
         "add-sup": {
           "details": "Consente di aggiungere un elenco di studenti all'elenco già importato e/o di modificare le informazioni degli studenti già importati.",
-          "label": "Aggiungi studenti",
+          "label": "Aggiungere studenti",
           "title": "Aggiungere / modificare"
         },
         "participants": {
@@ -1620,16 +1620,16 @@
       "banner": {
         "anchor-error": "Vedere l'elenco degli errori",
         "fix-error-text": "Correggere gli errori e importare nuovamente il file.",
-        "import-error": "L'importazione dei partecipanti è fallita.",
+        "import-error": "L'importazione dei partecipanti non è andata a buon fine.",
         "import-in-progress": "Il contenuto del file è stato convalidato e i partecipanti sono in fase di importazione.",
         "in-progress-text": "Si prega di aggiornare questa pagina tra qualche istante per verificare lo stato del file.",
-        "retry-error-text": "Si è verificato un errore, si prega di importare più tardi o di scrivere al supporto Pix.",
+        "retry-error-text": "Si è verificato un errore, si prega di importare più tardi o di scrivere all'assistenza Pix.",
         "upload-completed": "Il file è stato importato su {date} da {firstName} {lastName}.",
         "upload-error": "Non è stato possibile importare il file.",
-        "upload-in-progress": "L'importazione del file potrebbe richiedere alcuni minuti. Non lasciare questa pagina.",
+        "upload-in-progress": "L'importazione del file potrebbe richiedere alcuni minuti. Non chiudere la pagina.",
         "validation-error": "Il contenuto del file contiene errori.",
-        "validation-in-progress": "Il contenuto del file è in corso di convalida.",
-        "warning-banner": "Alcuni valori non sono stati riconosciuti. Sono stati sostituiti da \"Non riconosciuto\". Se ritenete che manchino dei valori nell'elenco restrittivo, contattateci all'indirizzo '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'."
+        "validation-in-progress": "Verifica del contenuto del file in corso",
+        "warning-banner": "Alcuni valori non sono stati riconosciuti. Sono stati sostituiti da \"Non riconosciuto\". Se si ritiene che manchino dei valori nell'elenco restrittivo, contattare Pix all'indirizzo '<a href=\"mailto:sup@pix.fr\">'sup@pix.fr'</a></div>'."
       },
       "error-panel": {
         "error-wrapper": "Non è stato importato alcun partecipante. Modificare il file e importarlo nuovamente.",
@@ -1639,23 +1639,23 @@
       "file-type-separator": ",",
       "global-success": "Ultimo file importato con successo su {date} da {firstName} {lastName}.",
       "sco": {
-        "title": "Importazione di studenti"
+        "title": "Importare degli studenti"
       },
       "sup": {
-        "title": "Importazione di studenti"
+        "title": "Importare degli studenti"
       },
       "supported-formats": "(formati supportati: {types})",
       "title": "Importazione",
       "warnings": {
         "diploma": "Diplomi non riconosciuti: {diplomas};",
-        "study-scheme": "Piani non riconosciuti: {studySchemes};"
+        "study-scheme": "Regimi di frequenza non riconosciuti: {studySchemes}"
       }
     },
     "participants-list": {
       "latest-participation-information-tooltip": {
         "aria-label": "Informazioni sull'ultima partecipazione",
         "campaign-ASSESSMENT-type": "Valutazione",
-        "campaign-PROFILES_COLLECTION-type": "Collezione di profili",
+        "campaign-PROFILES_COLLECTION-type": "Raccolta dei profili",
         "campaign-name": "Campagna :",
         "campaign-status": "Stato :",
         "campaign-type": "Tipo :",
@@ -1705,11 +1705,11 @@
       },
       "no-tube-selected": "Scaricare la selezione di argomenti (JSON, { fileSize }ko)",
       "table": {
-        "caption": "Selezione dei soggetti",
+        "caption": "Selezione degli argomenti",
         "column": {
           "compatibility": "Compatibilità",
           "level": "Livello massimo (facoltativo)",
-          "name": "Soggetto",
+          "name": "Nome dell'argomento",
           "theme-name": "Tema"
         },
         "is-responsive": "sì",
@@ -1731,7 +1731,7 @@
           "skill": "Competenza"
         },
         "empty": "In attesa dei risultati",
-        "title": "Risultati per abilità"
+        "title": "Risultati per competenza"
       },
       "title": "Profilo di {firstName} {lastName}"
     },
@@ -1743,23 +1743,23 @@
           "certifiable": "Certificabile",
           "certifiable-tag": "Certificabile",
           "competences-certifiables": "Comp. certificabile",
-          "evolution": "L'evoluzione",
+          "evolution": "Evoluzione",
           "first-name": "Nome",
-          "last-name": "Nome",
+          "last-name": "Cognome",
           "pix-score": {
             "label": "Punteggio Pix",
             "value": "{score, number}"
           },
           "sending-date": {
             "label": "Data di invio",
-            "on-hold": "In attesa di spedizione"
+            "on-hold": "In attesa di invio"
           },
           "sharedProfileCount": "Numero di azioni del profilo"
         },
-        "empty": "In attesa di profili",
+        "empty": "In attesa dei profili",
         "evolution": {
-          "decrease": "In declino",
-          "increase": "In crescita",
+          "decrease": "In diminuzione",
+          "increase": "In aumento",
           "stable": "Costante",
           "unavailable": "Non disponibile"
         },
@@ -1780,8 +1780,8 @@
         "reset-password-button": "Reimpostare le password degli studenti selezionati"
       },
       "actions": {
-        "manage-account": "Gestisci il tuo account",
-        "show-actions": "Azioni di visualizzazione"
+        "manage-account": "Gestire il proprio account",
+        "show-actions": "Visualizzare le azioni"
       },
       "connection-types": {
         "email": "Indirizzo e-mail",
@@ -1805,7 +1805,7 @@
           "label": "Ricerca per nome"
         },
         "last-name": {
-          "label": "Ricerca per nome"
+          "label": "Ricerca per cognome"
         },
         "login-method": {
           "empty-option": "Metodo di connessione",
@@ -1816,15 +1816,15 @@
       "generate-username-password-modal": {
         "content-message-1": "Gli studenti che non hanno ancora un metodo di accesso devono seguire una campagna presso la scuola per creare il loro account PIX.",
         "content-message-2": "Verrà generato un file CSV contenente i login e le password uniche.",
-        "content-message-3": "Condividete queste nuove password una tantum con i vostri studenti. Quando accederanno con questa password, Pix chiederà loro di inserirne una nuova.",
+        "content-message-3": "Condividere queste password temporanee con gli studenti. Al primo accesso, verrà richiesto di impostare una nuova password.",
         "title": "Generare login e/o password per gli studenti selezionati.",
         "warning-message": "Per gli studenti che hanno accesso al Mediacentre e/o un indirizzo e-mail verranno generati un login e una password. Gli studenti che hanno già un login dovranno reimpostare la loro password."
       },
       "manage-authentication-method-modal": {
         "authentication-methods": "Metodi di connessione",
-        "copied": "Ricevuto!",
+        "copied": "Copiato !",
         "error": {
-          "default": "Si è verificato un errore interno. I nostri team stanno risolvendo il problema. Si prega di riprovare più tardi.",
+          "default": "Si è verificato un errore interno. Le nostre squadre stanno risolvendo il problema. Si prega di riprovare più tardi.",
           "unexpected": "Qualcosa è andato storto. Riprovare."
         },
         "section": {
@@ -1842,13 +1842,13 @@
           "password": {
             "copy": "Copiare la password unica",
             "label": "Nuova password unica",
-            "warning-1": "Consegnate allo studente la nuova password.",
+            "warning-1": "Comunicare allo studente la nuova password",
             "warning-2": "Lo studente accede con questa password unica.",
-            "warning-3": "Pix gli chiede di sceglierne uno nuovo."
+            "warning-3": "Pix domanda di creare una nuova password"
           },
           "reset-password": {
             "button": "Reimpostare la password",
-            "warning": "Reset cancella la password corrente dello studente."
+            "warning": "Reset cancella la password attuale dello studente."
           },
           "unblock": {
             "button": "Sbloccare l'account",
@@ -1865,13 +1865,13 @@
       "messages": {
         "password-reset-success": "Le password degli studenti selezionati sono state reimpostate."
       },
-      "no-participants": "Nessun studente per ora!",
-      "no-participants-action": "L'amministratore deve importare il database degli studenti facendo clic sul pulsante Importa.",
+      "no-participants": "Nessuno studente per ora !",
+      "no-participants-action": "L'amministratore deve importare il database degli studenti cliccando su \"Importa\".",
       "page-title": "Studenti",
       "reset-password-modal": {
-        "content-message-1": "Su {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} studente</strong> selezionato} other {<strong>{totalSelectedStudents} studente</strong> selezionato}}, {totalAffectedStudents, plural, =0 {<strong>nessuna password</strong> verrà resettata} =1 { la <strong>{totalAffectedStudents} password dello studente</strong> sarà resettata} other { le password degli <strong>{totalAffectedStudents} studenti</strong> saranno resettate}}.",
+        "content-message-1": "Su {totalSelectedStudents, plural, =1 {<strong>{totalSelectedStudents} studente</strong> selezionato} other {<strong>{totalSelectedStudents} studenti</strong> selezionati}}, {totalAffectedStudents, plural, =0 {<strong>nessuna password</strong> verrà reimpostata} =1 {la password di <strong>{totalAffectedStudents} studente</strong> verrà reimpostata} other {le password di <strong>{totalAffectedStudents} studenti</strong> verranno reimpostate}}",
         "content-message-2": "Verrà generato un file CSV contenente i login e le password uniche.",
-        "content-message-3": "Consegnare queste nuove password una tantum agli studenti. Quando accederanno con questa password, Pix chiederà loro di inserirne una nuova.",
+        "content-message-3": "Attribuire queste password temporanee agli studenti. Al primo accesso, Pix chiederà loro di impostarne una nuova",
         "title": "Ripristino delle <strong>password</strong> degli studenti con <strong>identificatore</strong>.",
         "warning-message": "È possibile reimpostare solo le password di accesso. L'accesso tramite indirizzo e-mail e Mediacentre non sono interessati."
       },
@@ -1914,7 +1914,7 @@
           }
         },
         "description": "Tabella degli studenti ordinata per nome. Per gli studenti che hanno fornito un metodo di connessione, è possibile utilizzare un menu nella colonna 'Azioni' per gestire i metodi di connessione autorizzati e reimpostare la password dello studente.",
-        "empty": "Nessun studente."
+        "empty": "Nessuno studente"
       },
       "title": "{count, plural, =0 {Studenti} =1 {Studente ({count})} other {Studenti ({count})}}",
       "user-account-blocking-types": {
@@ -1924,32 +1924,32 @@
     },
     "sso-selection": {
       "login": {
-        "button": "Voglio connettermi",
-        "message": "Verrete reindirizzati alla pagina di login \"{providerName}\" per identificarvi su Pix."
+        "button": "Accedere",
+        "message": "Trasferimento alla pagina di accesso di \"{providerName}\" per l'autenticazione su Pix."
       },
       "signup": {
-        "button": "Desidero registrarmi"
+        "button": "Registrarsi"
       },
-      "title": "Scegliere il metodo di connessione"
+      "title": "Selezionare la modalità di accesso"
     },
     "statistics": {
       "before-date": "a",
-      "description": "La tabella seguente consente di visualizzare il posizionamento dei partecipanti per argomento.'<br>' Il posizionamento riflette il livello medio dei partecipanti rispetto al livello massimo che avrebbero potuto raggiungere.'<br>' Questi dati tengono conto di tutte le partecipazioni condivise nell'ambito delle campagne di valutazione della vostra organizzazione che non sono state cancellate.",
+      "description": "La tabella seguente mostra il posizionamento dei partecipanti per argomento.'<br>' Il posizionamento riflette il livello medio dei partecipanti rispetto al livello massimo raggiungibile.'<br>' Questi dati tengono conto di tutte le partecipazioni condivise e non eliminate nell'ambito delle campagne di valutazione della vostra organizzazione",
       "empty-state": "Nessun dato disponibile",
       "level": {
         "advanced": "Avanzato",
         "expert": "Esperto",
-        "independent": "Indipendente",
-        "novice": "Novizio"
+        "independent": "Autonomo",
+        "novice": "Principiante"
       },
-      "select-label": "Dominio",
+      "select-label": "Area di competenza",
       "table": {
-        "caption": "Questa tabella mostra i risultati di tutti i partecipanti per argomento. Per ogni riga sono indicati l'abilità, il soggetto, il tasso di copertura e il livello raggiunto.",
+        "caption": "Questa tabella mostra i risultati di tutti i partecipanti per argomento. Per ogni riga sono indicati la competenza, l'argomento, il tasso di copertura e il livello raggiunto",
         "headers": {
           "competences": "Competenze",
           "positioning": "Posizionamento",
           "reached-level": "Livello raggiunto",
-          "topics": "Soggetti"
+          "topics": "Argomenti"
         }
       },
       "title": "Statistiche"
@@ -1967,16 +1967,16 @@
       "actions": {
         "download-template": "Scarica il modello",
         "edit-student-number": "Modifica del numero di studente",
-        "show-actions": "Azioni di visualizzazione"
+        "show-actions": "Visualizzare le azioni"
       },
       "deletion-modal": {
         "content": {
           "footer": "Si noti che questa azione è irreversibile.",
           "header": "{count, plural, =1 {Questo studente non sarà più visibile} other {Questi studenti non saranno più visibili}} in Pix Orga.",
-          "main-campaign-prevent": "Questo avrà quindi un impatto sui risultati e sulle analisi delle campagne che {count, plural, =1 {ha} other {hanno}} realizzato.",
+          "main-campaign-prevent": "Questo influenzerà i risultati e le analisi delle campagne che {count, plural, =1 {ha} other {hanno}} realizzato.",
           "main-participation-prevent": "Tutte le voci della {count, plural, =1 {sua} other {sua}} campagna saranno eliminate."
         },
-        "title": "{count, plural, =1 {Cancella '<strong>'{firstname} {lastname}'</strong>' dai tuoi} other {Sei sicuro di voler cancellare '<strong>'{count}'</strong>'}} studenti?"
+        "title": "{count, plural, =1 {Confermare l'eliminazione di '<strong>'{firstname} {lastname}'</strong>' dai vostri} other {Confermare l'eliminazione degli '<strong>'{count}'</strong>'}} studenti?"
       },
       "edit-student-number-modal": {
         "actions": {
@@ -1988,11 +1988,11 @@
           "student-number": "L'attuale numero di studenti di {firstName} {lastName} è :",
           "success": "La modifica del numero di studente da {firstName} a {lastName} è stata effettuata con successo."
         },
-        "title": "Redazione del numero degli studenti"
+        "title": "Modifica del numero studente"
       },
       "empty-state": {
         "no-participants": "Non ci sono ancora studenti!",
-        "no-participants-action": "L'amministratore deve importare gli studenti facendo clic sul pulsante Importa."
+        "no-participants-action": "L'amministratore deve importare gli studenti cliccando su \"Importare\"."
       },
       "filter": {
         "aria-label": "Filtrare gli studenti",
@@ -2013,12 +2013,12 @@
       },
       "page-title": "Studenti",
       "replace-students-modal": {
-        "confirm": "Sì, sto sostituendo",
-        "confirmation-checkbox": "Confermo di aver compreso appieno l'impatto",
-        "footer-content": "Gli studenti esistenti nell'applicazione e presenti nella nuova importazione non saranno cancellati e saranno aggiornati se necessario.",
+        "confirm": "Si, sostituire",
+        "confirmation-checkbox": "Confermo di aver compreso le conseguenze",
+        "footer-content": "Mieux : \"Gli studenti già esistenti e inclusi nella nuova importazione non verranno eliminati, ma aggiornati se necessario\"",
         "last-warning": "Si noti che questa azione è irreversibile. Gli studenti non presenti nella nuova importazione saranno cancellati da Pix Orga.",
-        "main-content": "Tutti i loro contributi alle campagne saranno cancellati. Questo avrà un impatto sui risultati e sulle analisi delle campagne che hanno realizzato. Non potranno più partecipare alle campagne a cui hanno preso parte in passato. Tuttavia, potranno partecipare a nuove campagne.",
-        "title": "Siete sicuri di voler sostituire gli studenti esistenti?"
+        "main-content": "Tutti i loro contributi alle campagne verranno eliminati. Questo influenzerà i risultati e le analisi delle campagne che hanno realizzato. Non potranno più accedere alle campagne a cui hanno partecipato, ma potranno comunque prendere parte a nuove campagne.",
+        "title": "Sicuro di voler sostituire gli studenti esistenti?"
       },
       "table": {
         "column": {
@@ -2032,7 +2032,7 @@
             "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per nome. Fare clic per ordinare in ordine alfabetico.",
             "ariaLabelSortDown": "La tabella è ordinata per nome, in ordine alfabetico inverso. Fare clic per ordinare in ordine alfabetico.",
             "ariaLabelSortUp": "La tabella è ordinata alfabeticamente per nome. Fare clic per ordinare in ordine alfabetico inverso.",
-            "label": "Nome"
+            "label": "Cognome"
           },
           "last-participation-date": {
             "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per data di partecipazione. Fare clic per ordinare in ordine crescente.",
@@ -2044,12 +2044,12 @@
             "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per numero di voci. Fare clic per ordinare in ordine crescente.",
             "ariaLabelSortDown": "La tabella è ordinata per numero decrescente di voci. Fare clic per ordinare in ordine crescente.",
             "ariaLabelSortUp": "La tabella è ordinata per numero crescente di voci. Fare clic per ordinare in ordine decrescente.",
-            "label": "Numero di voci"
+            "label": "Numero di partecipazioni"
           },
           "student-number": "Numero dello studente"
         },
         "description": "Tabella degli studenti ordinati per nome. È possibile utilizzare un menu in una colonna aggiuntiva per cambiare il numero di studente.",
-        "empty": "Nessun studente."
+        "empty": "Nessuno studente"
       },
       "title": "{count, plural, =0 {Studenti} =1 {Studente ({count})} other {Studenti ({count})}}"
     },
@@ -2057,7 +2057,7 @@
       "cancel-invitation": "Cancellare l'invito",
       "empty-table": "Non ci sono inviti in attesa.",
       "invitation-cancelled-succeed-message": "L'invito è stato cancellato.",
-      "invitation-resent-succeed-message": "L'invito è stato restituito.",
+      "invitation-resent-succeed-message": "L'invito è stato nuovamente inviato",
       "resend-invitation": "Reinvio dell'invito",
       "table": {
         "column": {
@@ -2071,7 +2071,7 @@
       "title": "Inviti"
     },
     "team-list": {
-      "add-member-button": "Invita un membro",
+      "add-member-button": "Invitare un membro",
       "tabs": {
         "invitation": "Inviti ({count, plural, =0 {-} other {{count}}})",
         "member": "Membri ({count, plural, =0 {-} other {{count}}})"
@@ -2081,10 +2081,10 @@
     "team-members": {
       "actions": {
         "edit-organization-membership-role": "Modificare il ruolo",
-        "leave-organization": "Lasciando quest'area Pix Orga",
+        "leave-organization": "Lasciare questo spazio Pix Orga",
         "manage": "Gestire",
         "remove-membership": "Cancellare",
-        "save": "Registro",
+        "save": "Registrare",
         "select-role": {
           "label": "Selezionare un ruolo",
           "options": {
@@ -2095,8 +2095,8 @@
       },
       "modals": {
         "leave-organization": {
-          "message": "Sei sicuro di voler lasciare questo spazio Pix Orga? Non avrai più accesso a <strong>{organizationName}</strong>.<br/><br/>Le tue campagne resteranno accessibili al resto del team, non saranno archiviate.<br/><br/>Il tuo accesso agli altri spazi Pix Orga non subirà conseguenze.<br/><br/>Sarai disconnesso.",
-          "title": "Lasciando quest'area Pix Orga"
+          "message": "Confermare l'uscita da questo spazio Pix Orga? L'accesso a <strong>{organizationName}</strong> non sarà più consentito.<br/><br/>Le campagne rimarranno accessibili al resto della squadra e non verranno archiviate.<br/><br/>L'accesso agli altri spazi Pix Orga non subirà variazioni.<br/><br/>Verrà effettuata la disconnessione.",
+          "title": "Lasciare questo spazio Pix Orga"
         }
       },
       "notifications": {
@@ -2106,7 +2106,7 @@
         },
         "leave-organization": {
           "error": "Si è verificato un errore durante la disattivazione del membro.",
-          "success": "Sei stato rimosso con successo dall'organizzazione {organizationName}. Sarai disconnesso da Pix Orga..."
+          "success": "Rimozione dall'organizzazione {organizationName} completata con successo. Verrà effettuata la disconnessione da Pix Orga."
         },
         "remove-membership": {
           "error": "Si è verificato un errore durante la disattivazione del membro.",
@@ -2118,12 +2118,12 @@
           "remove": "Sì, eliminare il membro"
         },
         "message": "{memberFirstName} {memberLastName} non avrà più accesso a questo spazio Pix Orga.'<br>'Le sue campagne rimangono accessibili al resto della squadra.",
-        "title": "Stai confermando la cancellazione?"
+        "title": "Si, cancellare"
       },
       "table": {
         "column": {
           "first-name": "Nome",
-          "last-name": "Nome",
+          "last-name": "Cognome",
           "organization-membership-role": "Ruolo"
         },
         "empty": "In attesa dei membri"
@@ -2141,30 +2141,30 @@
           "400": "Il formato dell'indirizzo e-mail non è corretto.",
           "404": "Questa e-mail non appartiene a nessun utente.",
           "412": "Questo membro è già stato aggiunto.",
-          "500": "Qualcosa è andato storto. Riprovare."
+          "500": "Qualcosa è andato storto. Si prega di riprovare."
         }
       },
       "invite-form-modal": {
         "confirm": "Confermare",
-        "question": "Vuole continuare?",
+        "question": "Continuare ?",
         "title": "Confermare l'aggiunta di nuovi membri del team",
         "warning": "I membri aggiunti avranno accesso ai risultati dei partecipanti e all'analisi della campagna."
       },
-      "invited-members": "Al ricevimento dell'e-mail, gli ospiti potranno scegliere se creare un account Pix o accedere con un account Pix esistente.",
+      "invited-members": "Al ricevimento dell'e-mail, le persone invitate potranno scegliere se creare un account Pix o accedere con un account Pix esistente.",
       "several-email-requirement": "È possibile invitare più membri separando gli indirizzi e-mail con delle virgole.",
       "success": {
         "invitation": "È stato effettivamente inviato un invito all'indirizzo e-mail {email}.",
         "multiple-invitations": "È stato inviato un invito agli indirizzi e-mail elencati."
       },
-      "title": "Invita un membro",
+      "title": "Invitare un membro",
       "warning": "I membri aggiunti di seguito avranno accesso ai risultati dei partecipanti e all'analisi della campagna. Assicuratevi che le persone invitate siano membri della vostra organizzazione."
     },
     "team-new-item": {
       "input-label": "Indirizzo/i e-mail",
-      "invite-button": "Invito"
+      "invite-button": "Invitare"
     },
     "terms-of-service": {
-      "accept": "Accetto le condizioni di utilizzo",
+      "accept": "Accettare le condizioni d'uso",
       "title": "Termini e condizioni d'uso"
     }
   }

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -58,7 +58,7 @@
       "last-name-required": "L'alunno con INE {nationalStudentId} non ha il campo Cognome compilato. È obbligatorio per ogni alunno.",
       "payload-too-large": "La dimensione del file deve essere inferiore a {maxSize}MB.",
       "sex-code-required": "Uno studente con un INE di {nationalStudentId} non ha il campo sesso compilato. È obbligatorio per ogni alunno.",
-      "uai-mismatched": "pas de sens en Italie"
+      "uai-mismatched": "L'UAI del file SIECLE non corrisponde a quello del tuo istituto."
     }
   },
   "application": {
@@ -211,7 +211,7 @@
       "login-user-temporary-blocked-error": "Sono stati effettuati troppi tentativi di accesso. L'account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contattare un insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso.",
       "login-user-temporary-blocked-with-username-error": "Sono stati effettuati troppi tentativi di accesso. L'account Pix è temporaneamente bloccato per {blockingDurationMinutes} minuti.'<br>'In caso di dimenticanza, '<strong>'contattare un insegnante'</strong>' per reimpostare la password e/o recuperare l'accesso."
     },
-    "breadcrumb": "????",
+    "breadcrumb": "Percorso di navigazione",
     "cgu": {
       "error": "Per creare un account è necessario accettare le condizioni d'uso e l'informativa sulla privacy di Pix.",
       "label": "Accetto le condizioni d'uso e l'informativa sulla privacy di Pix",
@@ -792,7 +792,7 @@
         "label": "Testo della pagina iniziale",
         "sublabel": "Questo campo verrà visualizzato dai partecipanti alla campagna."
       },
-      "legal-warning": "cela n'est pas pertinent : Il numero di previdenza sociale (NIR) deve essere evitato, così come qualsiasi altro dato sensibile.",
+      "legal-warning": "* In conformità con la legge francese sulla protezione dei dati, e in qualità di responsabile del trattamento dei dati, si prega di fare attenzione a non chiedere dati particolarmente identificativi o significativi, a meno che non siano assolutamente indispensabili. Il numero di previdenza sociale (NIR) deve essere evitato, così come qualsiasi altro dato sensibile.",
       "multiple-sendings": {
         "assessments": {
           "info": "Se si sceglie di inviare la campagna più volte, il partecipante potrà ripetere la campagna più volte, inserendo nuovamente il codice.Tutti i risultati saranno disponibili.",


### PR DESCRIPTION
## ☀️ Problème

Dans le cadre de Digiclass, l'équipe international a reporté des traductions imprécises dans les locale 'de', 'it' et 'es'.

## ⛱️ Proposition

Implémentation des retours dans les fichiers concernés.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

Au vu du nombre de modifications, il est compliqué de tester de manière exhaustive.
Nous pouvons néanmoins lancer Pix Orga en RA et se rendre compte qu'il n'y a pas de traduction manquante en changeant la langue avec les locales concernées.

On peut également constater qu'il n'y a pas de différences comparé aux fichiers de la branche `dev` sur :
1. Le nombre de lignes
2. Le nom des clés : seules les valeurs / chaînes de caractères changent 