### PR TITLE
[TECH] Ajouter des events Plausible sur la page de résultats des campagnes moteur de reco (PIX-24061)

### DIFF
--- a/api/db/seeds/data/team-devcomp/build-campaigns.js
+++ b/api/db/seeds/data/team-devcomp/build-campaigns.js
@@ -34,8 +34,7 @@ async function _createScoCampaigns(databaseBuilder, trainingIds, participantCoun
       recommendedTrainingsIds: trainingIds,
     },
     recommendationEngine: true,
-    // trainingIds[9] is frFrTrainingId2 (DEVCOMP_BASE_TRAINING_ID + 9), built by buildTrainings.
-    highlightedTrainingIds: [trainingIds[9]],
+    highlightedTrainingIds: [trainingIds[0]],
   });
 }
 

--- a/api/db/seeds/data/team-devcomp/build-trainings.js
+++ b/api/db/seeds/data/team-devcomp/build-trainings.js
@@ -5,71 +5,70 @@ export function buildTrainings(databaseBuilder) {
   let trainingId = DEVCOMP_BASE_TRAINING_ID;
   const frTrainingId1 = databaseBuilder.factory.buildTraining({
     id: trainingId++,
-    title: 'Apprendre à manger un croissant comme les français',
-    internalTitle: 'Apprendre à manger un croissant comme les français',
+    title: 'Apprendre à broder comme BenjiX',
+    internalTitle: 'Apprendre à broder comme BenjiX',
     duration: { days: 0, hours: 0, minutes: 0 },
-    locales: ['fr'],
-    objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+    locales: ['fr', 'fr-fr'],
+    objectives: ['Repérer si l‘aiguille est de bonne qualité', 'Rechercher un canevas pour le broder'],
     description:
-      "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
+      "Qui ne rêve pas d'un magnifique Picsou brodé main comme décoration ? Aujourd'hui, vous pouvez devenir maître de votre fil !",
   }).id;
 
   _buildTargetProfileTrainingAndTrigger(databaseBuilder, frTrainingId1);
 
   const eLearningTraining = databaseBuilder.factory.buildTraining({
     id: trainingId++,
-    title: 'Apprendre à manger un croissant comme les français',
-    internalTitle: 'Apprendre à manger un croissant comme les français',
+    title: 'Apprendre à dessiner comme Andy',
+    internalTitle: 'Apprendre à dessiner comme Andy',
     duration: { days: 0, hours: 0, minutes: 0 },
-    locales: ['fr'],
+    locales: ['fr', 'fr-fr'],
     type: 'e-learning',
-    objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+    objectives: ['Repérer si vous avez du bon papier', 'Dessiner votre voisin de bureau'],
     deliveryMode: Training.modes.REMOTE,
-    description:
-      "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
+    description: "Oubliez Mona Lisa, à vous de dessiner le prochain chef-d'oeuvre du louvre. Pour ça, suivez Andy ! ",
   }).id;
 
   _buildTargetProfileTrainingAndTrigger(databaseBuilder, eLearningTraining);
 
   const inPersonTraining = databaseBuilder.factory.buildTraining({
     id: trainingId++,
-    title: 'Apprendre à manger un croissant comme les français',
-    internalTitle: 'Apprendre à manger un croissant comme les français',
-    duration: { days: 0, hours: 0, minutes: 0 },
-    locales: ['fr'],
+    title: 'Apprendre à faire des puzzles',
+    internalTitle: 'Apprendre à faire des puzzles',
+    duration: { days: 0, hours: 10, minutes: 0 },
+    locales: ['fr', 'fr-fr'],
     type: 'in-person-training',
-    objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+    objectives: ['Repérer les pièces de puzzle pertinentes', 'Choisir le bon podcast à mettre en fond'],
     deliveryMode: Training.modes.ONSITE,
     description:
-      "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
+      'Marre des écrans ? Choisissez le puzzle pour vous vider la tête et faire de nouveaux amis au travail !',
   }).id;
 
   _buildTargetProfileTrainingAndTrigger(databaseBuilder, inPersonTraining);
 
   const externalServiceTraining = databaseBuilder.factory.buildTraining({
     id: trainingId++,
-    title: 'Apprendre à manger un croissant comme les français',
-    internalTitle: 'Apprendre à manger un croissant comme les français',
+    title: 'Apprendre à courir avec Coach Eric',
+    internalTitle: 'Apprendre à courir avec Coach Eric',
     duration: { days: 0, hours: 0, minutes: 0 },
-    locales: ['fr'],
+    locales: ['fr', 'fr-fr'],
     type: 'external-service',
-    objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+    objectives: ['Repérer si le terrain est de bonne qualité', 'Rechercher un bro pour s‘entraîner'],
     description:
-      "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
+      "Quoi de mieux que courir en pleine nature pour se reposer l'esprit ? Lacez vos chaussures et partez vers l'aventure !",
   }).id;
 
   _buildTargetProfileTrainingAndTrigger(databaseBuilder, externalServiceTraining);
 
   const autoformationTraining = databaseBuilder.factory.buildTraining({
     id: trainingId++,
-    title: 'Apprendre à manger un croissant comme les français',
-    internalTitle: 'Apprendre à manger un croissant comme les français',
-    duration: { days: 0, hours: 0, minutes: 0 },
-    locales: ['fr'],
-    objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
+    title: 'Apprendre à faire de l‘impro avec Dianonino',
+    internalTitle: 'Apprendre à faire de l‘impro avec Dianonino',
+    duration: { days: 3, hours: 0, minutes: 0 },
+    locales: ['fr', 'fr-fr'],
+    objectives: ['Repérer si le public est réceptif', 'Rechercher la réplique qui aidera votre partenaire'],
     type: 'autoformation',
     description:
-      "Aujourd'hui, manger un croissant est tout un art en France. De nombreux touristes viennent en France et font le tour des meilleures boulangeries pour en manger, mais sans connaître les différentes manières de le savourer pleinement.",
+      'Sortez de votre zone de confort et découvrez que votre imagination est bien plus riche que vous ne le pensez.',
   }).id;
 
   _buildTargetProfileTrainingAndTrigger(databaseBuilder, autoformationTraining);
@@ -79,7 +78,7 @@ export function buildTrainings(databaseBuilder) {
     title: 'Apprendre à manger un croissant comme les français',
     internalTitle: 'Apprendre à manger un croissant comme les français',
     duration: { days: 0, hours: 0, minutes: 0 },
-    locales: ['fr'],
+    locales: ['fr', 'fr-fr'],
     objectives: ['Repérer si le croissant est de bonne qualité', 'Rechercher un croissant pour le manger'],
     type: 'hybrid-training',
     description:
@@ -97,7 +96,7 @@ export function buildTrainings(databaseBuilder) {
     editorName: 'Pix',
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
-    locales: ['fr'],
+    locales: ['fr', 'fr-fr'],
     objectives: [
       'Comprendre que les conversations avec les IA génératives sont réutilisées',
       'Savoir rédiger un prompt qui n’inclut pas d’informations personnelles',
@@ -118,7 +117,7 @@ export function buildTrainings(databaseBuilder) {
     editorName: 'Pix',
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
-    locales: ['fr'],
+    locales: ['fr', 'fr-fr'],
     objectives: ['Connaître les principaux risques liés aux mots de passe', 'Savoir créer un mot de passe solide'],
     deliveryMode: Training.modes.ONSITE,
     description:
@@ -131,7 +130,7 @@ export function buildTrainings(databaseBuilder) {
     id: trainingId++,
     title: 'Apprendre à peindre comme Monet',
     internalTitle: 'Apprendre à peindre comme Monet',
-    locales: ['fr-fr'],
+    locales: ['fr', 'fr-fr'],
     objectives: ['Connaître Monet', 'Avoir les bases pour peindre'],
     deliveryMode: Training.modes.REMOTE,
     registrationRequired: true,
@@ -148,7 +147,7 @@ export function buildTrainings(databaseBuilder) {
     editorName: 'Pix',
     editorLogoUrl: 'https://assets.pix.org/contenu-formatif/editeur/pix-logo.svg',
     type: 'modulix',
-    locales: ['fr-fr'],
+    locales: ['fr', 'fr-fr'],
     objectives: [
       'Comprendre que les conversations avec les IA génératives sont réutilisées',
       'Savoir rédiger un prompt qui n’inclut pas d’informations personnelles',

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/trainings.gjs
@@ -82,11 +82,13 @@ export default class Trainings extends Component {
 
   @action
   scrollToPreviousTrainings() {
+    this.args.onNavigationButtonClick('previous');
     this.goToCardIndex(Math.max(this.currentPageFirstCardIndex - TRAININGS_PER_PAGE, 0));
   }
 
   @action
   scrollToNextTrainings() {
+    this.args.onNavigationButtonClick('next');
     this.goToCardIndex(Math.min(this.currentPageFirstCardIndex + TRAININGS_PER_PAGE, this.args.trainings.length - 1));
   }
 

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -44,6 +44,10 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     });
   }
 
+  @action onNavigationButtonClick(_) {
+    this.pixMetrics.trackEvent('Moteur de reco - scroll dans les contenus formatifs', {});
+  }
+
   trackTrainingsDisplayed(trainings) {
     trainings.forEach((training, index) => {
       this.pixMetrics.trackEvent('Moteur de reco - Affichage du contenu formatif sur la page de résultats', {
@@ -136,6 +140,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
           @onCardClick={{this.onCardClick}}
           @onModalButtonClick={{this.onModalButtonClick}}
           @onModalAccordionClick={{this.onModalAccordionClick}}
+          @onNavigationButtonClick={{this.onNavigationButtonClick}}
           @onFullyVisible={{this.revealDrawer}}
         />
       {{/if}}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -100,6 +100,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
 
   @action onSeeRecommendationsButtonClicked() {
     if (this.hasTrainings) {
+      this.pixMetrics.trackEvent('Moteur de reco - Clic sur le bouton "Voir mes recommandations"', {});
       const trainingsList = document.getElementById(TRAININGS_LIST_ID);
       trainingsList.focus({ preventScroll: true, focusVisible: true });
       trainingsList.scrollIntoView({ behavior: this.scrollBehavior });

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -130,6 +130,55 @@ module(
         });
       });
 
+      module('when clicking on navigation button', function () {
+        test('should send a tracking event', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const training2 = store.createRecord('training', {
+            title: 'Super training 2',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const training3 = store.createRecord('training', {
+            title: 'Super training 3',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const training4 = store.createRecord('training', {
+            title: 'Super training 4',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training, training2, training3, training4],
+          };
+
+          // when
+          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          const navigationNextButton = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+          });
+          await click(navigationNextButton);
+
+          // then
+          sinon.assert.calledWith(pixMetrics.trackEvent, 'Moteur de reco - scroll dans les contenus formatifs');
+          assert.ok(true);
+        });
+      });
+
       module('tracking', function (hooks) {
         hooks.afterEach(function () {
           delete window.IntersectionObserver;

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -97,6 +97,37 @@ module(
           }).parentElement.parentElement.parentElement;
           assert.strictEqual(document.activeElement, trainings);
         });
+
+        test('should send a tracking event', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          // when
+          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          await click(screen.getByRole('button', { name: t('pages.skill-review.hero.see-my-recommendations') }));
+
+          // then
+          sinon.assert.calledWith(
+            pixMetrics.trackEvent,
+            'Moteur de reco - Clic sur le bouton "Voir mes recommandations"',
+          );
+          assert.ok(true);
+        });
       });
 
       module('tracking', function (hooks) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/trainings-test.gjs
@@ -169,9 +169,14 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         // given
         const store = this.owner.lookup('service:store');
         const trainings = createManyTrainings(store, 10);
+        const onNavigationButtonClick = sinon.stub();
 
         // when
-        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+        const screen = await render(
+          <template>
+            <Trainings @trainings={{trainings}} @onNavigationButtonClick={{onNavigationButtonClick}} />
+          </template>,
+        );
 
         // then
         const previousButton = screen.getByRole('button', {
@@ -197,17 +202,54 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         assert.dom(lists[0]).hasClass('results-recommendation-engine-training__list--hidden');
       });
 
+      module('when clicking the previous button', function () {
+        test('it should call onNavigationButtonClick function passed as argument', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const trainings = createManyTrainings(store, 10);
+          const onNavigationButtonClick = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <Trainings @trainings={{trainings}} @onNavigationButtonClick={{onNavigationButtonClick}} />
+            </template>,
+          );
+          const nextButton = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+          });
+
+          await click(nextButton);
+          const lists = screen.getAllByRole('list');
+          await waitUntil(() => lists[0].scrollLeft !== 0);
+
+          const previousButton = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.previous-button-aria-label'),
+          });
+          await click(previousButton);
+
+          // then
+          sinon.assert.calledWith(onNavigationButtonClick, 'previous');
+          assert.ok(true);
+        });
+      });
+
       module('when clicking the next button', function () {
         test('it scrolls the list forward and enables the previous button', async function (assert) {
           // given
           const store = this.owner.lookup('service:store');
           const trainings = createManyTrainings(store, 10);
-          const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+          const onNavigationButtonClick = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <Trainings @trainings={{trainings}} @onNavigationButtonClick={{onNavigationButtonClick}} />
+            </template>,
+          );
           const nextButton = screen.getByRole('button', {
             name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
           });
-
-          // when
           await click(nextButton);
           const lists = screen.getAllByRole('list');
           await waitUntil(() => lists[0].scrollLeft !== 0);
@@ -219,13 +261,41 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
           });
           assert.dom(previousButton).doesNotHaveAttribute('aria-disabled');
         });
+        test('it should call onNavigationButtonClick function passed as argument', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const trainings = createManyTrainings(store, 10);
+          const onNavigationButtonClick = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <Trainings @trainings={{trainings}} @onNavigationButtonClick={{onNavigationButtonClick}} />
+            </template>,
+          );
+          const nextButton = screen.getByRole('button', {
+            name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
+          });
+          await click(nextButton);
+
+          // then
+          sinon.assert.calledWith(onNavigationButtonClick, 'next');
+          assert.ok(true);
+        });
       });
 
       test('it announces the visible page to assistive technologies', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const trainings = createManyTrainings(store, 10);
-        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+        const onNavigationButtonClick = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <Trainings @trainings={{trainings}} @onNavigationButtonClick={{onNavigationButtonClick}} />
+          </template>,
+        );
         const nextButton = screen.getByRole('button', {
           name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
         });
@@ -264,7 +334,14 @@ module('Integration | Components | Campaigns | Assessment | ResultsRecommendatio
         // given
         const store = this.owner.lookup('service:store');
         const trainings = createManyTrainings(store, 7);
-        const screen = await render(<template><Trainings @trainings={{trainings}} /></template>);
+        const onNavigationButtonClick = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <Trainings @trainings={{trainings}} @onNavigationButtonClick={{onNavigationButtonClick}} />
+          </template>,
+        );
         const nextButton = screen.getByRole('button', {
           name: t('pages.skill-review.recommended-engine.trainings.next-button-aria-label'),
         });


### PR DESCRIPTION
## ☀️ Problème

On voudrait traquer certains clics de bouton sur la page de résultats des campagnes moteur de reco.

## ⛱️ Proposition
Ajouter cela sur : 
- le clic sur le bouton "Voir mes recommandations"
- le clic sur les boutons de navigations du carrousel de contenus formatifs.

## 🧴 Remarques

RAS

## 🏊 Pour tester

**⚠️ Ne pas oublier de désactiver votre ad-blocker avant de tester** 

- Se connecter à la [RA](https://app-pr17342.review.pix.fr/) avec le compte `dave-comp@example.net`
- Passer la campagne EDUMULTIP pour arriver sur la page de résultats.
- Ouvrir la console navigateur et aller à l'onglet network.
- Cliquer sur le bouton "Voir mes recommandations"
- Constater qu'un event Plausible  avec le nom "Moteur de reco - Clic sur le bouton "Voir mes recommandations"" part bien. 
- Cliquer sur les flèches dans le carrousel 
- Constater qu'un event Plausible  avec le nom "Moteur de reco - scroll dans les contenus formatifs" part bien. 
