### PR TITLE
[BUGFIX] Correction de 2 tests KO sur le usecase revoke-access-for-users

### DIFF
--- a/api/tests/identity-access-management/integration/domain/usecases/revoke-access-for-users.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/revoke-access-for-users.usecase.test.js
@@ -30,7 +30,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-a
 
     // then
     const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
-    expect(revokedUserAccess.revokeTimeStamp).to.be.a('number');
+    expect(revokedUserAccess.revokedAllTimeStamp).to.be.a('number');
 
     const refreshTokens = await refreshTokenRepository.findAllByUserId(userId);
     expect(refreshTokens).to.have.lengthOf(0);
@@ -60,7 +60,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-a
 
       // then
       const revokedUserAccess = await revokedUserAccessRepository.findByUserId(userId);
-      expect(revokedUserAccess.revokeTimeStamp).to.be.a('number');
+      expect(revokedUserAccess.revokedAllTimeStamp).to.be.a('number');
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

2 tests en échec ont été fusionnés dans la branche principale (via #17307), sans que ce soit bloqué par la CI.

## ⛱️ Proposition

Corriger les 2 tests dans un premier temps.

Une correction pour que la CI ne laisse pas passer de tests en échec pourra être faite dans une PR suivante.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Vérifier que les tests sont vraiments verts dans la CI.