### PR TITLE
[BUGFIX] Deadlock pgboss dans les tests

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -54,7 +54,9 @@ export class JobClient {
             max: config.pgBoss.workerConnexionPoolMaxSize,
             persistWarnings: config.pgBoss.persistWarnings,
             warningRetentionDays: 30,
-            useListenNotify: config.pgBoss.useListenNotify,
+            useListenNotify: config.pgBoss.useListenNotify && !isTestOnly,
+            supervise: !isTestOnly,
+            schedule: !isTestOnly,
           });
     } else {
       this.#pgBoss = pgBossFactory
@@ -204,11 +206,11 @@ export class JobClient {
   async #ensureQueue(name) {
     await this.#pgBoss.createQueue(name, {
       retentionSeconds: config.pgBoss.retentionSeconds,
-      notify: config.pgBoss.useListenNotify,
+      notify: config.pgBoss.useListenNotify && !this.#isTestOnly,
     });
     await this.#pgBoss.updateQueue(name, {
       retentionSeconds: config.pgBoss.retentionSeconds,
-      notify: config.pgBoss.useListenNotify,
+      notify: config.pgBoss.useListenNotify && !this.#isTestOnly,
     });
   }
 


### PR DESCRIPTION
## ☀️ Problème

Dans les CI on a eu des cas où des tests de `api_integration_tests` qui échouent mais la CI reste verte.

## ⛱️ Proposition

Après analyse, ça semble lié à un deadlock lors du flush des jobs de pgboss.

```
1) "after each" hook for "should log the error and the request result when there is an unexpected error":

error: deadlock detected

at pix/api/node_modules/pg-pool/index.js:45:11
at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
at async Db.executeSql (file:///pix/api/node_modules/pg-boss/dist/db.js:49:16)
at async Manager.deleteAllJobs (file:///pix/api/node_modules/pg-boss/dist/manager.js:1499:13)
at async JobClient.flushJobs (file:///pix/api/src/shared/infrastructure/jobs/JobClient.js:234:5)
at async mochaHooks.afterEach (file:///pix/api/tests/setup/integration.js:47:7)
```

Le deadlock est causé par le flush pgboss alors qu'il y a des traitements en cours sur les tables pgboss flushées. On soupçonne les jobs de supervision et schedule de causer ce deadlock.

On désactive les jobs de supervision et schedule dans les tests.

## 🧴 Remarques

N/A

## 🏊 Pour tester

La CI doit passer.
