### PR TITLE
[TECH] Utilise des contextes CircleCI pour les jobs e2e.

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -1,4 +1,3 @@
-# .circleci/jobs.yml
 #
 #
 # Caching notes:
@@ -16,16 +15,16 @@ version: 2.1
 parameters:
   GHA_Actor:
     type: string
-    default: ''
+    default: ""
   GHA_Action:
     type: string
-    default: ''
+    default: ""
   GHA_Event:
     type: string
-    default: ''
+    default: ""
   GHA_Meta:
     type: string
-    default: ''
+    default: ""
   # Set by path-filtering orb based on changed files
   run-api:
     type: boolean
@@ -86,15 +85,15 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>
       - image: postgres:16.9-alpine
-        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
+        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: '--nosync'
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.1.0@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2
         environment:
-          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: 'pix-import-test,pix-answers-history-export-test'
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test,pix-answers-history-export-test"
     resource_class: medium
   node-browsers-docker:
     parameters:
@@ -116,11 +115,11 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
       - image: postgres:16.9-alpine
-        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
+        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: '--nosync'
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
     resource_class: medium
   node-postgres-docker:
@@ -132,11 +131,11 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>
       - image: postgres:16.9-alpine
-        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
+        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: '--nosync'
+          POSTGRES_INITDB_ARGS: "--nosync"
     resource_class: medium
   playwright-executor-medium:
     docker:
@@ -145,15 +144,15 @@ executors:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - image: postgres:16.9-alpine
-        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
+        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: '--nosync'
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.1.0@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2
         environment:
-          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: 'pix-import-test,pix-answers-history-export-test'
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test,pix-answers-history-export-test"
     resource_class: medium
   playwright-executor-large:
     docker:
@@ -162,15 +161,15 @@ executors:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - image: postgres:16.9-alpine
-        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
+        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: '--nosync'
+          POSTGRES_INITDB_ARGS: "--nosync"
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.1.0@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2
         environment:
-          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: 'pix-import-test,pix-answers-history-export-test'
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test,pix-answers-history-export-test"
     resource_class: large
 
 # ---------------------------------------------------------------------------
@@ -287,125 +286,102 @@ workflows:
   build-and-test:
     when: << pipeline.parameters.GHA_Action >>
     jobs:
-      - checkout:
-          context: Pix
-
       # --- API ---
+      - checkout
       - api_install:
-          context: Pix
           requires:
             - checkout
       - api_lint:
-          context: Pix
           requires:
             - api_install
       - api_unit_test:
-          context: Pix
           requires:
             - api_install
       - api_integration_test:
-          context: Pix
           requires:
             - api_install
       - api_acceptance_test:
-          context: Pix
           requires:
             - api_install
 
       # --- Audit Logger ---
       - audit_logger_test:
-          context: Pix
           requires:
             - checkout
 
       # --- Mon Pix ---
       - mon_pix_install:
-          context: Pix
           requires:
             - checkout
       - mon_pix_lint:
-          context: Pix
           requires:
             - mon_pix_install
       - mon_pix_test:
-          context: Pix
           requires:
             - mon_pix_install
       - e2e_test_mon_pix:
-          context: Pix
+          context: pix-e2e-secrets
           requires:
             - mon_pix_install
 
       # --- Orga ---
       - orga_install:
-          context: Pix
           requires:
             - checkout
       - orga_lint:
-          context: Pix
           requires:
             - orga_install
       - orga_test:
-          context: Pix
           requires:
             - orga_install
       - e2e_test_orga:
-          context: Pix
+          context: pix-e2e-secrets
           requires:
             - orga_install
 
       # --- Certif ---
       - certif_install:
-          context: Pix
           requires:
             - checkout
       - certif_lint:
-          context: Pix
           requires:
             - certif_install
       - certif_test:
-          context: Pix
           requires:
             - certif_install
 
       # --- Admin ---
       - admin_install:
-          context: Pix
           requires:
             - checkout
       - admin_lint:
-          context: Pix
           requires:
             - admin_install
       - admin_test:
-          context: Pix
           requires:
             - admin_install
 
       # --- Junior ---
       - junior_install:
-          context: Pix
           requires:
             - checkout
       - junior_lint:
-          context: Pix
           requires:
             - junior_install
       - junior_test:
-          context: Pix
           requires:
             - junior_install
 
       # --- E2E Playwright ---
       - e2e_playwright_test:
-          context: Pix
+          context: pix-e2e-secrets
           requires:
             - api_install
             - mon_pix_install
             - orga_install
             - certif_install
       - e2e_playwright_test_recette_certif:
-          context: Pix
+          context: pix-e2e-secrets
           requires:
             - api_install
             - mon_pix_install
@@ -641,7 +617,6 @@ jobs:
           command: npm run test:api:integration -- --reporter-option=showRelativePaths --reporter-option output=/home/circleci/test-results/test-results.xml
           environment:
             NODE_ENV: test
-            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
             MOCHA_REPORTER: xunit
             MOCHA_RETRIES: 2
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_integration
@@ -702,7 +677,6 @@ jobs:
           command: npm run test:api:acceptance -- --reporter-option=showRelativePaths --reporter-option output=/home/circleci/test-results/test-results.xml
           environment:
             NODE_ENV: test
-            MOCHA_FILE: /home/circleci/test-results/test-results.[hash].xml
             MOCHA_REPORTER: xunit
             MOCHA_RETRIES: 2
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci_acceptance
@@ -1023,13 +997,13 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           command: npm run db:prepare
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1042,11 +1016,16 @@ jobs:
           name: Start Pix API
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
             DATAMART_DATABASE_URL: postgres://circleci@localhost:5432/circleci_datamart
-            REDIS_URL: 'redis://localhost:6379'
-            START_JOB_IN_WEB_PROCESS: 'true'
+            REDIS_URL: "redis://localhost:6379"
+            START_JOB_IN_WEB_PROCESS: "true"
+            AUTH_SECRET: "the-password-must-be-at-least-32-characters-long"
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
+            LOG_ENABLED: "true"
+            LOG_LEVEL: "trace"
+            REDIRECTION_URL_SECRET: "secret"
           background: true
           command: npm start
       - run:
@@ -1057,8 +1036,8 @@ jobs:
       - run:
           name: Run tests
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           command: npm run test:ci:app
       - store_test_results:
           path: /home/circleci/test-results
@@ -1107,13 +1086,13 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           command: npm run db:prepare
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1126,11 +1105,16 @@ jobs:
           name: Start Pix API
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
             DATAMART_DATABASE_URL: postgres://circleci@localhost:5432/circleci_datamart
-            REDIS_URL: 'redis://localhost:6379'
-            START_JOB_IN_WEB_PROCESS: 'true'
+            REDIS_URL: "redis://localhost:6379"
+            START_JOB_IN_WEB_PROCESS: "true"
+            AUTH_SECRET: "the-password-must-be-at-least-32-characters-long"
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
+            LOG_ENABLED: "true"
+            LOG_LEVEL: "trace"
+            REDIRECTION_URL_SECRET: "secret"
           background: true
           command: npm start
       - run:
@@ -1141,8 +1125,8 @@ jobs:
       - run:
           name: Run tests
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           command: npm run test:ci:orga
       - store_test_results:
           path: /home/circleci/test-results
@@ -1181,15 +1165,12 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
-            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            REDIS_URL: 'redis://localhost:6379'
-            START_JOB_IN_WEB_PROCESS: 'true'
-            AUTH_SECRET: 'secret'
-            LCMS_API_RELEASE_ID: '2509?forCI'
-            IS_RUNNING_PLAYWRIGHT: 'true'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
+            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            LCMS_API_RELEASE_ID: "2509?forCI"
+            IS_RUNNING_PLAYWRIGHT: "true"
           command: npm run db:prepare && npm run datamart:prepare && npm run datawarehouse:prepare
       - run:
           name: Start Pix API
@@ -1197,17 +1178,26 @@ jobs:
           command: npm start
           background: true
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
-            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            REDIS_URL: 'redis://localhost:6379'
-            START_JOB_IN_WEB_PROCESS: 'true'
-            MAILING_ENABLED: 'false'
-            AUTH_SECRET: 'secret'
-            LCMS_API_RELEASE_ID: '2509?forCI'
-            IS_RUNNING_PLAYWRIGHT: 'true'
-            PIX_ASSETS_MANAGER_URL: 'https://assets.pix.org'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
+            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            REDIS_URL: "redis://localhost:6379"
+            START_JOB_IN_WEB_PROCESS: "true"
+            MAILING_ENABLED: "false"
+            AUTH_SECRET: "secret"
+            LCMS_API_RELEASE_ID: "2509?forCI"
+            IS_RUNNING_PLAYWRIGHT: "true"
+            PIX_ASSETS_MANAGER_URL: "https://assets.pix.org"
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
+            LOG_ENABLED: "true"
+            LOG_LEVEL: "trace"
+            REDIRECTION_URL_SECRET: "secret"
+            IMPORT_STORAGE_ENDPOINT: "http://localhost:9090"
+            IMPORT_STORAGE_BUCKET_NAME: "pix-import-test"
+            IMPORT_STORAGE_ACCESS_KEY_ID: "nothing"
+            IMPORT_STORAGE_SECRET_ACCESS_KEY: "nothing"
+            IMPORT_STORAGE_REGION: "nothing"
       - run:
           name: Start Pix Orga
           working_directory: ~/pix/orga
@@ -1226,9 +1216,9 @@ jobs:
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            LCMS_API_RELEASE_ID: '2509?forCI'
-            IS_RUNNING_PLAYWRIGHT: 'true'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            LCMS_API_RELEASE_ID: "2509?forCI"
+            IS_RUNNING_PLAYWRIGHT: "true"
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1251,11 +1241,11 @@ jobs:
             PIX_APP_URL: http://localhost:4200
             PIX_ORGA_URL: http://localhost:4201
             PIX_CERTIF_URL: http://localhost:4203
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            AUTH_SECRET: 'secret'
-            REDIRECTION_URL_SECRET: 'secret'
-            NODE_OPTIONS: '--no-experimental-strip-types'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            AUTH_SECRET: "secret"
+            REDIRECTION_URL_SECRET: "secret"
+            NODE_OPTIONS: "--no-experimental-strip-types"
       - store_test_results:
           path: ./node_modules/.playwright/junit
       - store_artifacts:
@@ -1289,15 +1279,12 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
-            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            REDIS_URL: 'redis://localhost:6379'
-            START_JOB_IN_WEB_PROCESS: 'true'
-            AUTH_SECRET: 'secret'
-            LCMS_API_RELEASE_ID: '2509?forCI'
-            IS_RUNNING_PLAYWRIGHT: 'true'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
+            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            LCMS_API_RELEASE_ID: "2509?forCI"
+            IS_RUNNING_PLAYWRIGHT: "true"
           command: npm run db:prepare && npm run datamart:prepare && npm run datawarehouse:prepare
       - run:
           name: Start Pix API
@@ -1305,18 +1292,27 @@ jobs:
           command: npm start
           background: true
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
-            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            REDIS_URL: 'redis://localhost:6379'
-            START_JOB_IN_WEB_PROCESS: 'true'
-            MAILING_ENABLED: 'false'
-            AUTH_SECRET: 'secret'
-            LCMS_API_RELEASE_ID: '2509?forCI'
-            IS_RUNNING_PLAYWRIGHT: 'true'
-            PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED: 'true'
-            PIX_ASSETS_MANAGER_URL: 'https://assets.pix.org'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
+            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            REDIS_URL: "redis://localhost:6379"
+            START_JOB_IN_WEB_PROCESS: "true"
+            MAILING_ENABLED: "false"
+            AUTH_SECRET: "secret"
+            LCMS_API_RELEASE_ID: "2509?forCI"
+            IS_RUNNING_PLAYWRIGHT: "true"
+            PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED: "true"
+            PIX_ASSETS_MANAGER_URL: "https://assets.pix.org"
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
+            LOG_ENABLED: "true"
+            LOG_LEVEL: "trace"
+            REDIRECTION_URL_SECRET: "secret"
+            IMPORT_STORAGE_ENDPOINT: "http://localhost:9090"
+            IMPORT_STORAGE_BUCKET_NAME: "pix-import-test"
+            IMPORT_STORAGE_ACCESS_KEY_ID: "nothing"
+            IMPORT_STORAGE_SECRET_ACCESS_KEY: "nothing"
+            IMPORT_STORAGE_REGION: "nothing"
       - run:
           name: Start Pix App
           working_directory: ~/pix/mon-pix
@@ -1335,9 +1331,9 @@ jobs:
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            LCMS_API_RELEASE_ID: '2509?forCI'
-            IS_RUNNING_PLAYWRIGHT: 'true'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            LCMS_API_RELEASE_ID: "2509?forCI"
+            IS_RUNNING_PLAYWRIGHT: "true"
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1351,11 +1347,11 @@ jobs:
             PIX_APP_URL: http://localhost:4200
             PIX_ADMIN_URL: http://localhost:4202
             PIX_CERTIF_URL: http://localhost:4203
-            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-            AUTH_SECRET: 'secret'
-            REDIRECTION_URL_SECRET: 'secret'
-            NODE_OPTIONS: '--no-experimental-strip-types'
+            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            AUTH_SECRET: "secret"
+            REDIRECTION_URL_SECRET: "secret"
+            NODE_OPTIONS: "--no-experimental-strip-types"
       - store_test_results:
           path: ./node_modules/.playwright/junit
       - store_artifacts:


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Les variables d'environnement nécessaires aux jobs e2e sont définis dans un contexte CircleCI `Pix`, dans les variables d'environnement du projet Pix de Circle CI et dans le fichier `jobs.yml`.
Il est compliqué de s'y retrouver, de plus certaines variables sont communes à plusieurs jobs.

## ⛱️ Proposition

On déclare un contexte `pix-e2e-secrets` pour stocker uniquement les env var correspondant à des secrets.
On supprime tous les usages du contexte `Pix`.
On utilise le contexte `pix-e2e-secrets` uniquement dans les jobs e2e (cypress & playwright).
On déclare toutes les env var nécessaires dans le fichier `jobs.yml`, dans le but de supprimer toutes les env var dans CircleCI.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧴 Remarques

La suppression des env var dans CircleCI sera faite après avoir mergé cette PR pour ne pas perturber les autres branches en cours.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

CI verte
<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
