### PR TITLE
[BUGFIX]: Erreur deadlock  pgboss pendant les tests

### DIFF
--- a/api/src/shared/infrastructure/jobs/JobClient.js
+++ b/api/src/shared/infrastructure/jobs/JobClient.js
@@ -234,7 +234,26 @@ export class JobClient {
 
   async flushJobs() {
     this.#assertIsInitialized();
-    await this.#pgBoss.deleteAllJobs();
+    await this.#retryOnDeadlock(() => this.#pgBoss.deleteAllJobs());
+  }
+
+  // `deleteAllJobs` can collide with another concurrent transaction touching the same
+  // pg-boss tables (its own internal maintenance, another local process, ...) and be aborted
+  // with a Postgres deadlock (40P01). Retrying is safe: Postgres guarantees the other
+  // transaction wins and releases its locks, so the retry succeeds almost immediately.
+  async #retryOnDeadlock(fn, { attempts = 3, delayMs = 50 } = {}) {
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        if (error.code !== '40P01' || attempt === attempts) throw error;
+        logger.warn(
+          { event: 'pg-boss-deadlock-retry', attempt },
+          `Deadlock detected (attempt ${attempt}/${attempts}), retrying`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
   }
 
   async stop(options = { graceful: false, timeout: 1000 }) {

--- a/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
+++ b/api/tests/shared/unit/infrastructure/jobs/JobClient_test.js
@@ -9,6 +9,7 @@ import { config } from '../../../../../src/shared/config.js';
 import { AuditLoggingJob } from '../../../../../src/shared/domain/models/jobs/AuditLoggingJob.js';
 import { JobClient } from '../../../../../src/shared/infrastructure/jobs/JobClient.js';
 import { JobExpireIn } from '../../../../../src/shared/infrastructure/repositories/jobs/job-repository.js';
+import { catchErr } from '../../../../tooling/test-utils/error.js';
 
 class FakePgBoss {
   start() {
@@ -44,6 +45,10 @@ class FakePgBoss {
         return;
       },
     };
+  }
+
+  deleteAllJobs() {
+    return;
   }
 }
 
@@ -346,6 +351,77 @@ describe('Unit | JobClient', function () {
         { name: 'FirstJob', ageInSeconds: 42 },
         { name: 'SecondJob', ageInSeconds: 3600 },
       ]);
+    });
+  });
+
+  context('#flushJobs', function () {
+    it('should delete all jobs', async function () {
+      // given
+      const pgBossStub = new FakePgBoss();
+      sinon.stub(pgBossStub, 'deleteAllJobs').resolves();
+
+      const jobClient = new JobClient();
+      await jobClient.initialize(
+        {
+          jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
+          worker: true,
+        },
+        () => pgBossStub,
+      );
+
+      // when
+      await jobClient.flushJobs();
+
+      // then
+      expect(pgBossStub.deleteAllJobs).to.have.been.calledOnce;
+    });
+
+    it('should retry when a deadlock is detected, then succeed', async function () {
+      // given
+      const pgBossStub = new FakePgBoss();
+      const deadlockError = Object.assign(new Error('deadlock detected'), { code: '40P01' });
+      sinon.stub(pgBossStub, 'deleteAllJobs').onFirstCall().rejects(deadlockError).onSecondCall().resolves();
+
+      const jobClient = new JobClient();
+      await jobClient.initialize(
+        {
+          jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
+          worker: true,
+        },
+        () => pgBossStub,
+      );
+
+      // when
+      await jobClient.flushJobs();
+
+      // then
+      expect(pgBossStub.deleteAllJobs).to.have.been.calledTwice;
+    });
+
+    it('should not retry when the error is not a deadlock', async function () {
+      // given
+      const pgBossStub = new FakePgBoss();
+      const otherError = new Error('connection lost');
+      sinon.stub(pgBossStub, 'deleteAllJobs').rejects(otherError);
+
+      const jobClient = new JobClient();
+      await jobClient.initialize(
+        {
+          jobGroups: [JobGroup.DEFAULT],
+          isTestOnly: true,
+          worker: true,
+        },
+        () => pgBossStub,
+      );
+
+      // when
+      const error = await catchErr(jobClient.flushJobs, jobClient)();
+
+      // then
+      expect(error).to.equal(otherError);
+      expect(pgBossStub.deleteAllJobs).to.have.been.calledOnce;
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème
En lançant les tests on a parfois des erreurs deadlocks sur pgboss 

```
 1) "after each" hook for "should attach organization to parent and network":
     error: deadlock detected
      at ********/pix/api/node_modules/pg-pool/index.js:45:11
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
      at async Db.executeSql (file://********/pix/api/node_modules/pg-boss/dist/db.js:49:16)
      at async Manager.deleteAllJobs (file://********/pix/api/node_modules/pg-boss/dist/manager.js:1499:13)
      at async JobClient.flushJobs (file://********/pix/api/src/shared/infrastructure/jobs/JobClient.js:289:5)
      at async mochaHooks.afterEach (file://********/pix/api/tests/setup/integration.js:47:7)
```

## ⛱️ Proposition
Faire un retry en cas de deadlock

## 🧴 Remarques

Powered by Claude 

## 🏊 Pour tester
Lancer les tests 