### PR TITLE
[FEATURE] mon-pix: Révoquer la session utilisateur lors de la déconnexion (PIX-24078)

### DIFF
--- a/api/src/identity-access-management/application/token/token.controller.js
+++ b/api/src/identity-access-management/application/token/token.controller.js
@@ -83,6 +83,12 @@ const revokeToken = async function (request, h) {
   return h.response().code(204);
 };
 
+async function revokeSession(request, h) {
+  await usecases.revokeSession(request.auth.credentials);
+
+  return h.response().code(204);
+}
+
 const authenticateApplication = async function (request, h) {
   const { client_id: clientId, client_secret: clientSecret, scope } = request.payload;
 
@@ -100,4 +106,10 @@ const authenticateApplication = async function (request, h) {
     .header('Pragma', 'no-cache');
 };
 
-export const tokenController = { authenticateAnonymousUser, createToken, revokeToken, authenticateApplication };
+export const tokenController = {
+  authenticateAnonymousUser,
+  authenticateApplication,
+  createToken,
+  revokeSession,
+  revokeToken,
+};

--- a/api/src/identity-access-management/application/token/token.route.js
+++ b/api/src/identity-access-management/application/token/token.route.js
@@ -132,4 +132,13 @@ export const tokenRoutes = [
       tags: ['identity-access-management', 'api', 'token'],
     },
   },
+  {
+    method: 'POST',
+    path: '/api/logout',
+    config: {
+      handler: tokenController.revokeSession,
+      notes: ['- Cette route permet de révoquer une session utilisateur'],
+      tags: ['identity-access-management', 'api', 'token'],
+    },
+  },
 ];

--- a/api/src/identity-access-management/domain/usecases/index.js
+++ b/api/src/identity-access-management/domain/usecases/index.js
@@ -126,6 +126,7 @@ import { rememberUserHasSeenLastDataProtectionPolicyInformation } from './rememb
 import { removeAuthenticationMethod } from './remove-authentication-method.usecase.js';
 import { revokeAccessForUsers } from './revoke-access-for-users.usecase.js';
 import { revokeRefreshToken } from './revoke-refresh-token.usecase.js';
+import { revokeSession } from './revoke-session.usecase.js';
 import { sendVerificationCode } from './send-verification-code.usecase.js';
 import { unblockUserAccount } from './unblock-user-account.js';
 import { updateExpiredPassword } from './update-expired-password.usecase.js';
@@ -178,6 +179,7 @@ const usecasesWithoutInjectedDependencies = {
   removeAuthenticationMethod,
   revokeAccessForUsers,
   revokeRefreshToken,
+  revokeSession,
   sendVerificationCode,
   unblockUserAccount,
   updateExpiredPassword,

--- a/api/src/identity-access-management/domain/usecases/revoke-session.usecase.js
+++ b/api/src/identity-access-management/domain/usecases/revoke-session.usecase.js
@@ -1,0 +1,14 @@
+import { config } from '../../../shared/config.js';
+
+/**
+ * @param {{
+ *   userId: string,
+ *   sessionId: string,
+ *   revokedUserAccessRepository: typeof import('../../infrastructure/repositories/revoked-user-access.repository.js').revokedUserAccessRepository,
+ * }} params
+ */
+export async function revokeSession({ userId, sessionId, revokedUserAccessRepository }) {
+  const revokeUntil = new Date(Date.now() + config.authentication.revokedUserAccessLifespanMs);
+
+  await revokedUserAccessRepository.revokeSession({ userId, sessionId, revokeUntil });
+}

--- a/api/src/identity-access-management/infrastructure/server-authentication.js
+++ b/api/src/identity-access-management/infrastructure/server-authentication.js
@@ -88,7 +88,7 @@ async function validateUserAccessToken(decodedAccessToken, { request, revokedUse
     return { isValid: false };
   }
 
-  return { isValid: true, credentials: { userId: decodedAccessToken.user_id } };
+  return { isValid: true, credentials: { userId: decodedAccessToken.user_id, sessionId: decodedAccessToken.sid } };
 }
 
 async function validateClientApplicationAccessToken(decodedAccessToken) {

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { UserAccessToken } from '../../../../src/identity-access-management/domain/models/UserAccessToken.js';
 import { config } from '../../../../src/shared/config.js';
 import { PIX_ADMIN } from '../../../../src/shared/constants.js';
+import { temporaryStorage } from '../../../../src/shared/infrastructure/key-value-storages/index.js';
 import { databaseBuilder, knex } from '../../../tooling/databases.js';
 import { getServer } from '../../../tooling/server/shared-server.js';
 import { generateInjectOptions } from '../../../tooling/test-utils/http-server.js';
@@ -634,6 +635,42 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
         detail: 'The scope is not allowed.',
         status: '403',
       });
+    });
+  });
+
+  describe('POST /api/logout', function () {
+    let revokedUserAccessTemporaryStorage;
+
+    beforeEach(async function () {
+      revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
+      await revokedUserAccessTemporaryStorage.flushAll();
+    });
+
+    it('returns 204 and revokes access token’s session', async function () {
+      // given
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      await databaseBuilder.commit();
+
+      const sessionId = crypto.randomUUID();
+
+      const options = generateInjectOptions({
+        url: '/api/logout',
+        method: 'POST',
+        audience: 'https://app.pix.fr',
+        authorizationData: {
+          userId,
+          sessionId,
+        },
+      });
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+
+      const revokeSessionTimestamp = await revokedUserAccessTemporaryStorage.get(`${userId}:${sessionId}`);
+      expect(revokeSessionTimestamp).to.be.a('number');
     });
   });
 });

--- a/api/tests/identity-access-management/integration/domain/usecases/revoke-session.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/revoke-session.usecase.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+
+import { usecases } from '../../../../../src/identity-access-management/domain/usecases/index.js';
+import { temporaryStorage } from '../../../../../src/shared/infrastructure/key-value-storages/index.js';
+
+const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
+
+describe('Integration | Identity Access Management | Domain | UseCase | revoke-session', function () {
+  it('revokes user’s session given a user ID and session ID', async function () {
+    // given
+    const userId = '713705';
+    const sessionId = crypto.randomUUID();
+
+    // when
+    await usecases.revokeSession({ userId, sessionId });
+
+    // then
+    const revokeTimeStamp = await revokedUserAccessTemporaryStorage.get(`${userId}:${sessionId}`);
+    expect(revokeTimeStamp).to.be.a('number');
+  });
+});

--- a/api/tests/identity-access-management/unit/infrastructure/server-authentication.test.js
+++ b/api/tests/identity-access-management/unit/infrastructure/server-authentication.test.js
@@ -252,6 +252,7 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
           tokenService.getDecodedToken.withArgs('token', 'dummy-secret').returns({
             user_id: 'user_id',
             aud: 'https://app.pix.fr',
+            sid: 'sid',
           });
 
           // when
@@ -266,7 +267,9 @@ describe('Unit | Identity Access Management | Infrastructure | serverAuthenticat
           await authenticate(request, h);
 
           // then
-          expect(h.authenticated).to.have.been.calledWithExactly({ credentials: { userId: 'user_id' } });
+          expect(h.authenticated).to.have.been.calledWithExactly({
+            credentials: { userId: 'user_id', sessionId: 'sid' },
+          });
         });
       });
     });

--- a/mon-pix/app/authenticators/oauth2.js
+++ b/mon-pix/app/authenticators/oauth2.js
@@ -1,3 +1,4 @@
+import { service } from '@ember/service';
 import OAuth2PasswordGrant from 'ember-simple-auth/authenticators/oauth2-password-grant';
 import ENV from 'mon-pix/config/environment';
 import { decodeToken } from 'mon-pix/helpers/jwt';
@@ -6,6 +7,8 @@ export default class OAuth2 extends OAuth2PasswordGrant {
   serverTokenEndpoint = `${ENV.APP.API_HOST}/api/token`;
   serverTokenRevocationEndpoint = `${ENV.APP.API_HOST}/api/revoke`;
   refreshAccessTokensWithScope = true;
+
+  @service featureToggles;
 
   authenticate({ login, password, token }) {
     if (token) {
@@ -22,5 +25,18 @@ export default class OAuth2 extends OAuth2PasswordGrant {
     }
 
     return super.authenticate(login, password);
+  }
+
+  async invalidate(data) {
+    if (!this.featureToggles.featureToggles.isSessionLogoutEnabled) {
+      return super.invalidate(data);
+    }
+
+    await fetch(`${ENV.APP.API_HOST}/api/logout`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${data.access_token}`,
+      },
+    });
   }
 }

--- a/mon-pix/tests/unit/authenticators/oauth2-test.js
+++ b/mon-pix/tests/unit/authenticators/oauth2-test.js
@@ -1,5 +1,6 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import ENV from '../../../config/environment';
 
@@ -17,5 +18,62 @@ module('Unit | Authenticator | oauth2', function (hooks) {
     // Then
     assert.strictEqual(authenticator.serverTokenEndpoint, serverTokenEndpoint);
     assert.strictEqual(authenticator.serverTokenRevocationEndpoint, serverTokenRevocationEndpoint);
+  });
+
+  module('#invalidate', function (hooks) {
+    hooks.beforeEach(function () {
+      sinon.stub(window, 'fetch').resolves();
+    });
+
+    module('when isSessionLogoutEnabled feature toggle is true', function () {
+      test('sends POST request on /api/logout to invalidate user’s session', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:oauth2');
+        authenticator.featureToggles = {
+          featureToggles: {
+            isSessionLogoutEnabled: true,
+          },
+        };
+
+        // when
+        await authenticator.invalidate({ access_token: 'test_access_token', refresh_token: 'test_refresh_token' });
+
+        // then
+        assert.true(true);
+        sinon.assert.calledOnceWithExactly(window.fetch, 'http://localhost:3000/api/logout', {
+          headers: { Authorization: 'Bearer test_access_token' },
+          method: 'POST',
+        });
+      });
+    });
+
+    module('when isSessionLogoutEnabled feature toggle is false', function () {
+      test('calls default invalidate implementation', async function (assert) {
+        // given
+        const authenticator = this.owner.lookup('authenticator:oauth2');
+        authenticator.featureToggles = {
+          featureToggles: {
+            isSessionLogoutEnabled: false,
+          },
+        };
+
+        // when
+        await authenticator.invalidate({ access_token: 'test_access_token', refresh_token: 'test_refresh_token' });
+
+        // then
+        assert.true(true);
+        sinon.assert.calledTwice(window.fetch);
+        sinon.assert.calledWithExactly(window.fetch.firstCall, 'http://localhost:3000/api/revoke', {
+          body: 'token_type_hint=access_token&token=test_access_token',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          method: 'POST',
+        });
+        sinon.assert.calledWithExactly(window.fetch.secondCall, 'http://localhost:3000/api/revoke', {
+          body: 'token_type_hint=refresh_token&token=test_refresh_token',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          method: 'POST',
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

Lorsque l’utilisateur se déconnecte de PixApp, on souhaite que sa session soit révoquée.

## ⛱️ Proposition

 - Créer une nouvelle route `POST /api/logout` permettant de révoquer une session d’un utilisateur
 - Quand le feature toggle `isSessionLogoutEnabled` est actif, appeler cette route au lieu de `POST /api/revoke`

Contrairement à `POST /api/revoke` la nouvelle route `POST /api/logout` est authentifiée.

## 🧴 Remarques

Côté API, l’identifiant de session a été ajouté dans `request.auth.credentials` afin de pouvoir révoquer la session dans le handler de la nouvelle route `POST /api/logout`.

## 🏊 Pour tester

Le feature toggle `isSessionLogoutEnabled` a été activé sur la review app.

 - Aller sur PixApp
 - Ouvrir le panneau "Réseau" de la console du navigateur
 - Se connecter avec n’importe quel compte
 - Faire un rejeu de la requête `GET /api/users/me` (clic droit sur la requête, puis renvoyer...) et constater que le statut est bien 200
 - Se déconnecter
 - Vérifier qu’il y a bien une et une seule requête `POST /api/logout`
 - Faire un nouveau rejeu de la requête `GET /api/users/me` et constater que le statut est bien 401

Faire également de la non régression avec le feature toggle inactif.
