### PR TITLE
[FEATURE] Permettre de trier par date de dernière participation dans la liste des étudiants et élèves (PIX-17778)

### DIFF
--- a/api/src/prescription/organization-learner/application/sco-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sco-learner-list-route.js
@@ -37,6 +37,7 @@ const register = async function (server) {
               participationCount: Joi.string().empty(''),
               lastnameSort: Joi.string().empty(''),
               divisionSort: Joi.string().empty(''),
+              latestParticipationSort: Joi.string().empty(''),
             },
           }),
         },

--- a/api/src/prescription/organization-learner/application/sup-learner-list-route.js
+++ b/api/src/prescription/organization-learner/application/sup-learner-list-route.js
@@ -36,6 +36,7 @@ const register = async function (server) {
             sort: Joi.object({
               participationCount: Joi.string().empty(''),
               lastnameSort: Joi.string().empty(''),
+              latestParticipationSort: Joi.string().empty(''),
             }).default({}),
           }).default({}),
         },

--- a/api/src/prescription/organization-learner/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/sco-organization-participant-repository.js
@@ -75,6 +75,7 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
       order: sort.participationCount == 'desc' ? 'desc' : 'asc',
     });
   }
+
   if (sort?.lastnameSort) {
     orderByClause.unshift({
       column: 'lastName',
@@ -86,6 +87,13 @@ const findPaginatedFilteredScoParticipants = async function ({ organizationId, f
     orderByClause.unshift({
       column: 'division',
       order: sort.divisionSort == 'desc' ? 'desc' : 'asc',
+    });
+  }
+
+  if (sort?.latestParticipationSort) {
+    orderByClause.unshift({
+      column: 'lastParticipationDate',
+      order: sort.latestParticipationSort === 'desc' ? 'desc' : 'asc',
     });
   }
 

--- a/api/src/prescription/organization-learner/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/src/prescription/organization-learner/infrastructure/repositories/sup-organization-participant-repository.js
@@ -52,6 +52,13 @@ const findPaginatedFilteredSupParticipants = async function ({ organizationId, f
     });
   }
 
+  if (sort?.latestParticipationSort) {
+    orderByClause.unshift({
+      column: 'lastParticipationDate',
+      order: sort.latestParticipationSort === 'desc' ? 'desc' : 'asc',
+    });
+  }
+
   const query = knexConn
     .with(
       'participants',

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -1377,6 +1377,133 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           expect(participants[2].id).to.equal(narutoId);
         });
       });
+
+      describe('by lastest participation', function () {
+        context('latest participation sort', function () {
+          let organizationId, organizationLearnerId1, organizationLearnerId2, organizationLearnerId3;
+
+          beforeEach(async function () {
+            organizationId = databaseBuilder.factory.buildOrganization().id;
+            const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+            const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+            const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+            const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+            const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+
+            organizationLearnerId1 = organizationLearner1.id;
+            organizationLearnerId2 = organizationLearner2.id;
+            organizationLearnerId3 = organizationLearner3.id;
+
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId,
+              organizationLearnerId: organizationLearnerId1,
+              userId: organizationLearner1.userId,
+              createdAt: '2022-01-01',
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: otherCampaignId,
+              organizationLearnerId: organizationLearnerId2,
+              userId: organizationLearner2.userId,
+              createdAt: '2020-01-01',
+            });
+            databaseBuilder.factory.buildCampaignParticipation({
+              campaignId: campaignId,
+              organizationLearnerId: organizationLearnerId3,
+              userId: organizationLearner3.userId,
+              createdAt: '2021-01-01',
+            });
+
+            await databaseBuilder.commit();
+          });
+
+          it('should return sco participants sorted by ascendant', async function () {
+            // when
+            const { data: participants } =
+              await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+                organizationId,
+                sort: {
+                  latestParticipationSort: 'asc',
+                },
+              });
+
+            // then
+            expect(participants).to.have.lengthOf(3);
+            expect(participants[0].id).to.equal(organizationLearnerId2);
+            expect(participants[1].id).to.equal(organizationLearnerId3);
+            expect(participants[2].id).to.equal(organizationLearnerId1);
+          });
+
+          it('should return sco participants sorted by descendant', async function () {
+            // when
+            const { data: participants } =
+              await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+                organizationId,
+                sort: {
+                  latestParticipationSort: 'desc',
+                },
+              });
+
+            // then
+            expect(participants).to.have.lengthOf(3);
+            expect(participants[0].id).to.equal(organizationLearnerId1);
+            expect(participants[1].id).to.equal(organizationLearnerId3);
+            expect(participants[2].id).to.equal(organizationLearnerId2);
+          });
+        });
+
+        it('should return sco participants sorted by name if identical latest participation', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Aaaah',
+          });
+          const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Dupont',
+          });
+          const { id: organizationLearnerId3, userId: userId3 } = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Dupond',
+          });
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId1,
+            userId: userId1,
+            createdAt: '2024-01-01',
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId2,
+            userId: userId2,
+            createdAt: '2022-01-01',
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId3,
+            userId: userId3,
+            createdAt: '2022-01-01',
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const { data: participants } =
+            await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+              organizationId,
+              sort: {
+                latestParticipationSort: 'asc',
+              },
+            });
+
+          // then
+          expect(participants).to.have.lengthOf(3);
+          expect(participants[0].id).to.equal(organizationLearnerId3);
+          expect(participants[1].id).to.equal(organizationLearnerId2);
+          expect(participants[2].id).to.equal(organizationLearnerId1);
+        });
+      });
     });
 
     context('#lastParticipationDate', function () {

--- a/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/prescription/organization-learner/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -822,6 +822,130 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         expect(participants[1].id).to.equal(skywalkerId);
         expect(participants[2].id).to.equal(kenobiId);
       });
+
+      context('sorting latest participation', function () {
+        let organizationId, organizationLearnerId1, organizationLearnerId2, organizationLearnerId3;
+
+        beforeEach(async function () {
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+
+          const organizationLearner1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+          const organizationLearner2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+          const organizationLearner3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId });
+
+          organizationLearnerId1 = organizationLearner1.id;
+          organizationLearnerId2 = organizationLearner2.id;
+          organizationLearnerId3 = organizationLearner3.id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId1,
+            userId: organizationLearner1.userId,
+            createdAt: '2022-01-01',
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: otherCampaignId,
+            organizationLearnerId: organizationLearnerId2,
+            userId: organizationLearner2.userId,
+            createdAt: '2020-01-01',
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId,
+            organizationLearnerId: organizationLearnerId3,
+            userId: organizationLearner3.userId,
+            createdAt: '2021-01-01',
+          });
+
+          await databaseBuilder.commit();
+        });
+
+        it('should return sup participants sorted by ascendant', async function () {
+          // when
+          const { data: participants } =
+            await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+              organizationId,
+              sort: {
+                latestParticipationSort: 'asc',
+              },
+            });
+
+          // then
+          expect(participants).to.have.lengthOf(3);
+          expect(participants[0].id).to.equal(organizationLearnerId2);
+          expect(participants[1].id).to.equal(organizationLearnerId3);
+          expect(participants[2].id).to.equal(organizationLearnerId1);
+        });
+
+        it('should return sup participants sorted by descendant', async function () {
+          // when
+          const { data: participants } =
+            await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+              organizationId,
+              sort: {
+                latestParticipationSort: 'desc',
+              },
+            });
+
+          // then
+          expect(participants).to.have.lengthOf(3);
+          expect(participants[0].id).to.equal(organizationLearnerId1);
+          expect(participants[1].id).to.equal(organizationLearnerId3);
+          expect(participants[2].id).to.equal(organizationLearnerId2);
+        });
+      });
+
+      it('should return sup participants sorted by name if identical latest participation', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const { id: organizationLearnerId1, userId: userId1 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Aaaah',
+        });
+        const { id: organizationLearnerId2, userId: userId2 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Dupont',
+        });
+        const { id: organizationLearnerId3, userId: userId3 } = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Dupond',
+        });
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+          userId: userId1,
+          createdAt: '2024-01-01',
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId2,
+          userId: userId2,
+          createdAt: '2022-01-01',
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId3,
+          userId: userId3,
+          createdAt: '2022-01-01',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { data: participants } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+          sort: {
+            latestParticipationSort: 'asc',
+          },
+        });
+
+        // then
+        expect(participants).to.have.lengthOf(3);
+        expect(participants[0].id).to.equal(organizationLearnerId3);
+        expect(participants[1].id).to.equal(organizationLearnerId2);
+        expect(participants[2].id).to.equal(organizationLearnerId1);
+      });
     });
 
     context('#participantCount', function () {

--- a/orga/app/components/sco-organization-participant/list.gjs
+++ b/orga/app/components/sco-organization-participant/list.gjs
@@ -224,6 +224,8 @@ export default class ScoList extends Component {
               @onSortByLastname={{@sortByLastname}}
               @participationCountOrder={{@participationCountOrder}}
               @onSortByParticipationCount={{@sortByParticipationCount}}
+              @latestParticipationSort={{@latestParticipationSort}}
+              @onSortByLatestParticipation={{@sortByLatestParticipation}}
               @divisionSort={{@divisionSort}}
               @onSortByDivision={{@sortByDivision}}
               @allSelected={{allSelected}}

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -104,8 +104,19 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
     <:header>{{t "pages.sco-organization-participants.table.column.participation-count.label"}}</:header>
     <:cell>{{@student.participationCount}}</:cell>
   </PixTableColumn>
-  <PixTableColumn @context={{@context}}>
-    <:header>{{t "pages.sco-organization-participants.table.column.last-participation-date"}}</:header>
+  <PixTableColumn
+    @context={{@context}}
+    @onSort={{@onSortByLatestParticipation}}
+    @sortOrder={{@latestParticipationSnpmort}}
+    @ariaLabelDefaultSort={{t
+      "pages.sco-organization-participants.table.column.last-participation-date.ariaLabelDefaultSort"
+    }}
+    @ariaLabelSortAsc={{t "pages.sco-organization-participants.table.column.last-participation-date.ariaLabelSortUp"}}
+    @ariaLabelSortDesc={{t
+      "pages.sco-organization-participants.table.column.last-participation-date.ariaLabelSortDown"
+    }}
+  >
+    <:header>{{t "pages.sco-organization-participants.table.column.last-participation-date.label"}}</:header>
     <:cell>{{#if @student.lastParticipationDate}}
         <div class="organization-participant__align-element">
           <span>{{formatDate @student.lastParticipationDate format="L"}}</span>

--- a/orga/app/components/sup-organization-participant/list.gjs
+++ b/orga/app/components/sup-organization-participant/list.gjs
@@ -151,9 +151,11 @@ export default class ListItems extends Component {
               @lastnameSort={{@lastnameSort}}
               @hasStudents={{this.hasStudents}}
               @participationCountOrder={{@participationCountOrder}}
+              @latestParticipationSort={{@latestParticipationSort}}
               @onToggleAll={{toggleAll}}
               @sortByLastname={{fn this.addResetOnFunction @sortByLastname reset}}
               @sortByParticipationCount={{fn this.addResetOnFunction @sortByParticipationCount reset}}
+              @sortByLatestParticipation={{fn this.addResetOnFunction @sortByLatestParticipation reset}}
               @hasComputeOrganizationLearnerCertificabilityEnabled={{@hasComputeOrganizationLearnerCertificabilityEnabled}}
             />
           </:columns>

--- a/orga/app/components/sup-organization-participant/table-row.gjs
+++ b/orga/app/components/sup-organization-participant/table-row.gjs
@@ -84,8 +84,19 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
     <:header>{{t "pages.sup-organization-participants.table.column.participation-count.label"}}</:header>
     <:cell>{{@student.participationCount}}</:cell>
   </PixTableColumn>
-  <PixTableColumn @context={{@context}}>
-    <:header>{{t "pages.sup-organization-participants.table.column.last-participation-date"}}</:header>
+  <PixTableColumn
+    @context={{@context}}
+    @onSort={{@sortByLatestParticipation}}
+    @sortOrder={{@latestParticipationSort}}
+    @ariaLabelDefaultSort={{t
+      "pages.sup-organization-participants.table.column.last-participation-date.ariaLabelDefaultSort"
+    }}
+    @ariaLabelSortAsc={{t "pages.sup-organization-participants.table.column.last-participation-date.ariaLabelSortUp"}}
+    @ariaLabelSortDesc={{t
+      "pages.sup-organization-participants.table.column.last-participation-date.ariaLabelSortDown"
+    }}
+  >
+    <:header>{{t "pages.sup-organization-participants.table.column.last-participation-date.label"}}</:header>
     <:cell>{{#if @student.lastParticipationDate}}
         <div class="organization-participant__align-element">
           <span>{{formatDate @student.lastParticipationDate}}</span>

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -20,6 +20,7 @@ export default class ListController extends Controller {
   @tracked pageNumber = null;
   @tracked pageSize = 50;
   @tracked participationCountOrder = null;
+  @tracked latestParticipationSort = null;
   @tracked lastnameSort = 'asc';
   @tracked divisionSort = null;
 
@@ -40,6 +41,7 @@ export default class ListController extends Controller {
     this.divisionSort = null;
     this.pageNumber = null;
     this.lastnameSort = null;
+    this.latestParticipationSort = null;
   }
 
   @action
@@ -50,6 +52,7 @@ export default class ListController extends Controller {
     this.divisionSort = null;
     this.participationCountOrder = null;
     this.pageNumber = null;
+    this.latestParticipationSort = null;
   }
 
   @action
@@ -57,6 +60,18 @@ export default class ListController extends Controller {
     if (!this.divisionSort) this.divisionSort = 'asc';
     else this.divisionSort = this.divisionSort === 'asc' ? 'desc' : 'asc';
 
+    this.participationCountOrder = null;
+    this.lastnameSort = null;
+    this.pageNumber = null;
+    this.latestParticipationSort = null;
+  }
+
+  @action
+  sortByLatestParticipation() {
+    if (!this.latestParticipationSort) this.latestParticipationSort = 'asc';
+    else this.latestParticipationSort = this.latestParticipationSort === 'asc' ? 'desc' : 'asc';
+
+    this.divisionSort = null;
     this.participationCountOrder = null;
     this.lastnameSort = null;
     this.pageNumber = null;

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -16,6 +16,7 @@ export default class ListController extends Controller {
   @tracked pageNumber = null;
   @tracked pageSize = 50;
   @tracked participationCountOrder = null;
+  @tracked latestParticipationSort = null;
   @tracked lastnameSort = 'asc';
 
   get hasComputeOrganizationLearnerCertificabilityEnabled() {
@@ -34,6 +35,7 @@ export default class ListController extends Controller {
 
     this.pageNumber = null;
     this.lastnameSort = null;
+    this.latestParticipationSort = null;
   }
 
   @action
@@ -42,6 +44,17 @@ export default class ListController extends Controller {
     else this.lastnameSort = this.lastnameSort === 'asc' ? 'desc' : 'asc';
 
     this.participationCountOrder = null;
+    this.pageNumber = null;
+    this.latestParticipationSort = null;
+  }
+
+  @action
+  sortByLatestParticipation() {
+    if (!this.latestParticipationSort) this.latestParticipationSort = 'asc';
+    else this.latestParticipationSort = this.latestParticipationSort === 'asc' ? 'desc' : 'asc';
+
+    this.participationCountOrder = null;
+    this.lastnameSort = null;
     this.pageNumber = null;
   }
 

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -15,6 +15,7 @@ export default class ListRoute extends Route {
     participationCountOrder: { refreshModel: true },
     lastnameSort: { refreshModel: true },
     divisionSort: { refreshModel: true },
+    latestParticipationSort: { refreshModel: true },
   };
 
   @service currentUser;
@@ -34,6 +35,7 @@ export default class ListRoute extends Route {
       },
       sort: {
         participationCount: params.participationCountOrder,
+        latestParticipationSort: params.latestParticipationSort,
         lastnameSort: params.lastnameSort,
         divisionSort: params.divisionSort,
       },
@@ -64,6 +66,7 @@ export default class ListRoute extends Route {
       controller.pageNumber = null;
       controller.pageSize = 50;
       controller.participationCountOrder = null;
+      controller.latestParticipationOrder = null;
       controller.lastnameSort = 'asc';
       controller.divisionSort = null;
     }

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -13,6 +13,7 @@ export default class ListRoute extends Route {
     pageSize: { refreshModel: true },
     participationCountOrder: { refreshModel: true },
     lastnameSort: { refreshModel: true },
+    latestParticipationSort: { refreshModel: true },
   };
 
   @service currentUser;
@@ -32,6 +33,7 @@ export default class ListRoute extends Route {
       },
       sort: {
         participationCount: params.participationCountOrder,
+        latestParticipationSort: params.latestParticipationSort,
         lastnameSort: params.lastnameSort,
       },
       page: {
@@ -61,6 +63,7 @@ export default class ListRoute extends Route {
       controller.pageNumber = null;
       controller.pageSize = 50;
       controller.participationCountOrder = null;
+      controller.latestParticipationSort = null;
       controller.lastnameSort = 'asc';
     }
   }

--- a/orga/app/templates/authenticated/sco-organization-participants/list.gjs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.gjs
@@ -23,6 +23,8 @@ import List from 'pix-orga/components/sco-organization-participant/list';
       @sortByDivision={{@controller.sortByDivision}}
       @divisionSort={{@controller.divisionSort}}
       @lastnameSort={{@controller.lastnameSort}}
+      @latestParticipationSort={{@controller.latestParticipationSort}}
+      @sortByLatestParticipation={{@controller.sortByLatestParticipation}}
       @hasComputeOrganizationLearnerCertificabilityEnabled={{@controller.hasComputeOrganizationLearnerCertificabilityEnabled}}
       @refreshValues={{@controller.refresh}}
     />

--- a/orga/app/templates/authenticated/sup-organization-participants/list.gjs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.gjs
@@ -20,6 +20,8 @@ import List from 'pix-orga/components/sup-organization-participant/list';
     @sortByParticipationCount={{@controller.sortByParticipationCount}}
     @sortByLastname={{@controller.sortByLastname}}
     @lastnameSort={{@controller.lastnameSort}}
+    @latestParticipationSort={{@controller.latestParticipationSort}}
+    @sortByLatestParticipation={{@controller.sortByLatestParticipation}}
     @deleteStudents={{@controller.deleteStudents}}
     @hasComputeOrganizationLearnerCertificabilityEnabled={{@controller.hasComputeOrganizationLearnerCertificabilityEnabled}}
   />

--- a/orga/tests/integration/components/sco-organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.gjs
@@ -86,7 +86,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     );
     assert.ok(
       screen.getByRole('columnheader', {
-        name: t('pages.sco-organization-participants.table.column.last-participation-date'),
+        name: t('pages.sco-organization-participants.table.column.last-participation-date.label'),
       }),
     );
     assert.ok(
@@ -654,6 +654,46 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
         // then
         assert.ok(sortByDivision.called);
+      });
+    });
+
+    module('latest participation column', function () {
+      test('it should trigger ascending sort', async function (assert) {
+        // given
+        const latestParticipationSort = null;
+        const sortByLatestParticipation = sinon.spy();
+        const divisions = [];
+        const connectionTypes = [];
+        const certificability = [];
+        const search = null;
+        const noop = this.noop;
+
+        const screen = await render(
+          <template>
+            <ScoOrganizationParticipantList
+              @students={{undefined}}
+              @onFilter={{noop}}
+              @searchFilter={{search}}
+              @divisionsFilter={{divisions}}
+              @connectionTypeFilter={{connectionTypes}}
+              @certificabilityFilter={{certificability}}
+              @onClickLearner={{noop}}
+              @onResetFilter={{noop}}
+              @latestParticipationSort={{latestParticipationSort}}
+              @sortByLatestParticipation={{sortByLatestParticipation}}
+            />
+          </template>,
+        );
+
+        // when
+        await click(
+          screen.getByRole('button', {
+            name: t('pages.sco-organization-participants.table.column.last-participation-date.ariaLabelDefaultSort'),
+          }),
+        );
+
+        // then
+        assert.ok(sortByLatestParticipation.called);
       });
     });
   });

--- a/orga/tests/integration/components/sup-organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/sup-organization-participant/list-test.gjs
@@ -529,6 +529,43 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       // then
       assert.ok(sortByLastname.called);
     });
+
+    test('it should trigger ascending sort on latest participation column', async function (assert) {
+      // given
+      const latestParticipationSort = null;
+      const sortByLatestParticipation = sinon.spy();
+      const certificabilityFilter = [];
+      const groupFilter = [];
+      const searchFilter = null;
+      const studentNumberFilter = null;
+      const noop = this.noop;
+
+      const screen = await render(
+        <template>
+          <SupOrganizationParticipantList
+            @students={{undefined}}
+            @onFilter={{noop}}
+            @onClickLearner={{noop}}
+            @searchFilter={{searchFilter}}
+            @groupsFilter={{groupFilter}}
+            @studentNumberFilter={{studentNumberFilter}}
+            @certificabilityFilter={{certificabilityFilter}}
+            @latestParticipationSort={{latestParticipationSort}}
+            @sortByLatestParticipation={{sortByLatestParticipation}}
+          />
+        </template>,
+      );
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: t('pages.sup-organization-participants.table.column.last-participation-date.ariaLabelDefaultSort'),
+        }),
+      );
+
+      // then
+      assert.ok(sortByLatestParticipation.called);
+    });
   });
 
   module('when filter result does not match current participant information', function () {

--- a/orga/tests/unit/controllers/authenticated/sco-organization-participants/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-organization-participants/list-test.js
@@ -71,6 +71,8 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       controller.participationCountOrder = 'Godzilla';
       controller.lastnameSort = 'Kong';
       controller.pageNumber = 9999;
+      controller.latestParticipationSort = 'asc';
+
       // when
       controller.sortByDivision();
 
@@ -79,6 +81,7 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       assert.strictEqual(controller.participationCountOrder, null);
       assert.strictEqual(controller.lastnameSort, null);
       assert.strictEqual(controller.pageNumber, null);
+      assert.strictEqual(controller.latestParticipationSort, null);
     });
   });
 
@@ -89,6 +92,8 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       controller.divisionSort = 'king';
       controller.participationCountOrder = 'Godzilla';
       controller.pageNumber = 9999;
+      controller.latestParticipationSort = 'asc';
+
       // when
       controller.sortByLastname();
 
@@ -97,6 +102,7 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       assert.strictEqual(controller.divisionSort, null);
       assert.strictEqual(controller.participationCountOrder, null);
       assert.strictEqual(controller.pageNumber, null);
+      assert.strictEqual(controller.latestParticipationSort, null);
     });
   });
 
@@ -107,11 +113,35 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       controller.divisionSort = 'king';
       controller.lastnameSort = 'asc';
       controller.pageNumber = 9999;
+      controller.latestParticipationSort = 'asc';
+
       // when
       controller.sortByParticipationCount();
 
       // then
       assert.strictEqual(controller.participationCountOrder, 'desc');
+      assert.strictEqual(controller.lastnameSort, null);
+      assert.strictEqual(controller.divisionSort, null);
+      assert.strictEqual(controller.pageNumber, null);
+      assert.strictEqual(controller.latestParticipationSort, null);
+    });
+  });
+
+  module('#sortByLatestParticipation', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.latestParticipationSort = null;
+      controller.participationCountOrder = 'asc';
+      controller.divisionSort = 'king';
+      controller.lastnameSort = 'asc';
+      controller.pageNumber = 9999;
+
+      // when
+      controller.sortByLatestParticipation();
+
+      // then
+      assert.strictEqual(controller.latestParticipationSort, 'asc');
+      assert.strictEqual(controller.participationCountOrder, null);
       assert.strictEqual(controller.lastnameSort, null);
       assert.strictEqual(controller.divisionSort, null);
       assert.strictEqual(controller.pageNumber, null);

--- a/orga/tests/unit/controllers/authenticated/sup-organization-participants/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-organization-participants/list-test.js
@@ -144,6 +144,7 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
       // given
       controller.lastnameSort = null;
       controller.participationCountOrder = 'asc';
+      controller.latestParticipationSort = 'asc';
       controller.pageNumber = 9999;
       // when
       controller.sortByLastname();
@@ -151,6 +152,7 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
       // then
       assert.strictEqual(controller.lastnameSort, 'asc');
       assert.strictEqual(controller.participationCountOrder, null);
+      assert.strictEqual(controller.latestParticipationSort, null);
       assert.strictEqual(controller.pageNumber, null);
     });
   });
@@ -160,12 +162,32 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
       // given
       controller.participationCountOrder = null;
       controller.lastnameSort = 'asc';
+      controller.latestParticipationSort = 'asc';
       controller.pageNumber = 9999;
       // when
       controller.sortByParticipationCount();
 
       // then
       assert.strictEqual(controller.participationCountOrder, 'asc');
+      assert.strictEqual(controller.lastnameSort, null);
+      assert.strictEqual(controller.latestParticipationSort, null);
+      assert.strictEqual(controller.pageNumber, null);
+    });
+  });
+
+  module('#sortByLatestParticipation', function () {
+    test('update sorting value and reset other', function (assert) {
+      // given
+      controller.latestParticipationSort = null;
+      controller.participationCountOrder = 'asc';
+      controller.lastnameSort = 'asc';
+      controller.pageNumber = 9999;
+      // when
+      controller.sortByLatestParticipation();
+
+      // then
+      assert.strictEqual(controller.latestParticipationSort, 'asc');
+      assert.strictEqual(controller.participationCountOrder, null);
       assert.strictEqual(controller.lastnameSort, null);
       assert.strictEqual(controller.pageNumber, null);
     });

--- a/orga/tests/unit/routes/authenticated/sco-organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/sco-organization-participants/list-test.js
@@ -17,6 +17,7 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
   const participationCountOrderSymbol = Symbol('participationCountOrder');
   const lastnameSortSymbol = Symbol('lastnameSort');
   const divisionSortSymbol = Symbol('divisionSort');
+  const latestParticipationSortSymbol = Symbol('latestParticipationSort');
   const params = {
     search: searchSymbol,
     divisions: divisionsSymbol,
@@ -27,6 +28,7 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
     participationCountOrder: participationCountOrderSymbol,
     lastnameSort: lastnameSortSymbol,
     divisionSort: divisionSortSymbol,
+    latestParticipationSort: latestParticipationSortSymbol,
   };
 
   hooks.beforeEach(function () {
@@ -48,6 +50,7 @@ module('Unit | Route | authenticated/sco-organization-participants/list', functi
           participationCount: participationCountOrderSymbol,
           lastnameSort: lastnameSortSymbol,
           divisionSort: divisionSortSymbol,
+          latestParticipationSort: latestParticipationSortSymbol,
         },
         page: {
           number: pageNumberSymbol,

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/list-test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/list-test.js
@@ -16,6 +16,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
   const pageSizeSymbol = Symbol('pageSize');
   const participationCountSymbol = Symbol('participationCountOrder');
   const lastnameSortSymbol = Symbol('lastnameSort');
+  const latestParticipationSortSymbol = Symbol('latestParticipationSort');
   const params = {
     search: searchSymbol,
     studentNumber: studentNumberSymbol,
@@ -25,6 +26,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
     pageSize: pageSizeSymbol,
     participationCountOrder: participationCountSymbol,
     lastnameSort: lastnameSortSymbol,
+    latestParticipationSort: latestParticipationSortSymbol,
   };
 
   hooks.beforeEach(function () {
@@ -50,6 +52,7 @@ module('Unit | Route | authenticated/sup-organization-participants/list', functi
         },
         sort: {
           participationCount: participationCountSymbol,
+          latestParticipationSort: latestParticipationSortSymbol,
           lastnameSort: lastnameSortSymbol,
         },
         page: {

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1895,7 +1895,12 @@
             "ariaLabelSortUp": "Die Tabelle wird nach Namen in alphabetischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
             "label": "Name"
           },
-          "last-participation-date": "Letzte Teilnahme",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach dem Datum der Beteiligungen sortiert. Klicken Sie, um aufsteigend zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle wird nach dem Datum der Teilnahme absteigend sortiert. Klicken Sie, um aufsteigend zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle wird nach dem Datum der Teilnahme aufsteigend sortiert. Klicken Sie, um absteigend zu sortieren.",
+            "label": "Letzte Teilnahme"
+          },
           "login-method": "Verbindungsmethode(n)",
           "mainCheckbox": "Die gesamte Spalte auswählen/abwählen",
           "participation-count": {

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -2031,7 +2031,12 @@
             "ariaLabelSortUp": "Die Tabelle wird nach Namen in alphabetischer Reihenfolge sortiert. Klicken Sie, um in umgekehrter alphabetischer Reihenfolge zu sortieren.",
             "label": "Name"
           },
-          "last-participation-date": "Letzte Teilnahme",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach dem Datum der Beteiligungen sortiert. Klicken Sie, um aufsteigend zu sortieren.",
+            "ariaLabelSortDown": "Die Tabelle wird nach dem Datum der Teilnahme absteigend sortiert. Klicken Sie, um aufsteigend zu sortieren.",
+            "ariaLabelSortUp": "Die Tabelle wird nach dem Datum der Teilnahme aufsteigend sortiert. Klicken Sie, um absteigend zu sortieren.",
+            "label": "Letzte Teilnahme"
+          },
           "participation-count": {
             "ariaLabelDefaultSort": "Die Tabelle ist derzeit nicht nach der Anzahl der Teilnahmen sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",
             "ariaLabelSortDown": "Die Tabelle wird nach der Anzahl der Teilnahmen absteigend sortiert. Klicken Sie, um in aufsteigender Reihenfolge zu sortieren.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -2031,7 +2031,12 @@
             "ariaLabelSortUp": "The table is sorted by last name, in alphabetical order. Click to sort by reverse alphabetical order.",
             "label": "Last name"
           },
-          "last-participation-date": "Latest participation",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "The array is not yet sorted by latest participations. Click to sort ascending.",
+            "ariaLabelSortDown": "The array is sorted by descending latest participations. Click to sort ascending.",
+            "ariaLabelSortUp": "The array is sorted by ascending latest participations. Click to sort descending.",
+            "label": "Latest participation"
+          },
           "participation-count": {
             "ariaLabelDefaultSort": "The array is not yet sorted by number of participations. Click to sort ascending.",
             "ariaLabelSortDown": "The array is sorted by descending number of participations. Click to sort ascending.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1895,7 +1895,12 @@
             "ariaLabelSortUp": "The table is sorted by last name, in alphabetical order. Click to sort by reverse alphabetical order.",
             "label": "Last name"
           },
-          "last-participation-date": "Latest participation",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "The array is not yet sorted by latest participations. Click to sort ascending.",
+            "ariaLabelSortDown": "The array is sorted by descending latest participations. Click to sort ascending.",
+            "ariaLabelSortUp": "The array is sorted by ascending latest participations. Click to sort descending.",
+            "label": "Latest participation"
+          },
           "login-method": "Log in method(s)",
           "mainCheckbox": "Select/Unselect whole column",
           "participation-count": {

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -2031,7 +2031,12 @@
             "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por nombre. Haga clic para ordenar en orden alfabético inverso.",
             "label": "Nombre"
           },
-          "last-participation-date": "Última participación",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por fecha de participación. Haga clic para ordenar en orden ascendente.",
+            "ariaLabelSortDown": "La tabla está ordenada por fecha de participación descendente. Haga clic para ordenar en orden ascendente.",
+            "ariaLabelSortUp": "La tabla está ordenada por fecha de participación en orden ascendente. Haga clic para ordenar en orden descendente.",
+            "label": "Última participación"
+          },
           "participation-count": {
             "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por número de entradas. Haga clic para ordenar en orden ascendente.",
             "ariaLabelSortDown": "La tabla está ordenada por número descendente de entradas. Haga clic para ordenar en orden ascendente.",

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1895,7 +1895,12 @@
             "ariaLabelSortUp": "La tabla está ordenada alfabéticamente por nombre. Haga clic para ordenar en orden alfabético inverso.",
             "label": "Nombre"
           },
-          "last-participation-date": "Última participación",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "La tabla no está actualmente ordenada por fecha de participación. Haga clic para ordenar en orden ascendente.",
+            "ariaLabelSortDown": "La tabla está ordenada por fecha de participación descendente. Haga clic para ordenar en orden ascendente.",
+            "ariaLabelSortUp": "La tabla está ordenada por fecha de participación en orden ascendente. Haga clic para ordenar en orden descendente.",
+            "label": "Última participación"
+          },
           "login-method": "Método(s) de conexión",
           "mainCheckbox": "Seleccionar/deseleccionar toda la columna",
           "participation-count": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -2031,7 +2031,12 @@
             "ariaLabelSortUp": "Le tableau est trié par nom, dans l'ordre alphabétique. Cliquez pour trier par ordre alphabétique inverse.",
             "label": "Nom"
           },
-          "last-participation-date": "Dernière participation",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par date de participations. Cliquez pour trier par ordre croissant.",
+            "ariaLabelSortDown": "Le tableau est trié par date de participation décroissante. Cliquez pour trier en ordre croissant.",
+            "ariaLabelSortUp": "Le tableau est trié par date de participation croissante. Cliquez pour trier en ordre décroissant.",
+            "label": "Dernière participation"
+          },
           "participation-count": {
             "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par nombre de participations. Cliquez pour trier par ordre croissant.",
             "ariaLabelSortDown": "Le tableau est trié par nombre de participation décroissant. Cliquez pour trier en ordre croissant.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1895,7 +1895,12 @@
             "ariaLabelSortUp": "Le tableau est trié par nom, dans l'ordre alphabétique. Cliquez pour trier par ordre alphabétique inverse.",
             "label": "Nom"
           },
-          "last-participation-date": "Dernière participation",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par date de participations. Cliquez pour trier par ordre croissant.",
+            "ariaLabelSortDown": "Le tableau est trié par date de participation décroissante. Cliquez pour trier en ordre croissant.",
+            "ariaLabelSortUp": "Le tableau est trié par date de participation croissante. Cliquez pour trier en ordre décroissant.",
+            "label": "Dernière participation"
+          },
           "login-method": "Méthode(s) de connexion",
           "mainCheckbox": "Selectionner/Deselectionner toute la colonne",
           "participation-count": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1895,7 +1895,12 @@
             "ariaLabelSortUp": "La tabella è ordinata alfabeticamente per nome. Fare clic per ordinare in ordine alfabetico inverso.",
             "label": "Nome"
           },
-          "last-participation-date": "Ultima partecipazione",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per data di partecipazione. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortDown": "La tabella è ordinata per data di partecipazione decrescente. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortUp": "La tabella è ordinata per data di partecipazione in ordine crescente. Fare clic per ordinare in ordine decrescente.",
+            "label": "Ultima partecipazione"
+          },
           "login-method": "Metodo/i di connessione",
           "mainCheckbox": "Selezionare/deselezionare l'intera colonna",
           "participation-count": {

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -2031,7 +2031,12 @@
             "ariaLabelSortUp": "La tabella è ordinata alfabeticamente per nome. Fare clic per ordinare in ordine alfabetico inverso.",
             "label": "Nome"
           },
-          "last-participation-date": "Ultima partecipazione",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per data di partecipazione. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortDown": "La tabella è ordinata per data di partecipazione decrescente. Fare clic per ordinare in ordine crescente.",
+            "ariaLabelSortUp": "La tabella è ordinata per data di partecipazione in ordine crescente. Fare clic per ordinare in ordine decrescente.",
+            "label": "Ultima partecipazione"
+          },
           "participation-count": {
             "ariaLabelDefaultSort": "La tabella non è attualmente ordinata per numero di voci. Fare clic per ordinare in ordine crescente.",
             "ariaLabelSortDown": "La tabella è ordinata per numero decrescente di voci. Fare clic per ordinare in ordine crescente.",

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1895,7 +1895,12 @@
             "ariaLabelSortUp": "De tabel is gesorteerd op naame, in alfabetisch volgorde. Klik op om in omgekeerde alfabetische volgorde te sorteren.",
             "label": "Achternaam"
           },
-          "last-participation-date": "Laatste deelname",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "De tabel is momenteel niet gesorteerd op datum van deelname. Klik om in oplopende volgorde te sorteren.",
+            "ariaLabelSortDown": "De tabel is gesorteerd op aflopende datum van deelname. Klik om in oplopende volgorde te sorteren.",
+            "ariaLabelSortUp": "De tabel is gesorteerd op datum van deelname in oplopende volgorde. Klik om aflopend te sorteren.",
+            "label": "Laatste deelname"
+          },
           "login-method": "Inlogmethode(n)",
           "mainCheckbox": "Hele kolom selecteren/deselecteren",
           "participation-count": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -2031,7 +2031,12 @@
             "ariaLabelSortUp": "De tabel is gesorteerd op naam, in alfabetisch volgorde. Klik op om in omgekeerde alfabetische volgorde te sorteren.",
             "label": "Achternaam"
           },
-          "last-participation-date": "Laatste deelname",
+          "last-participation-date": {
+            "ariaLabelDefaultSort": "De tabel is momenteel niet gesorteerd op datum van deelname. Klik om in oplopende volgorde te sorteren.",
+            "ariaLabelSortDown": "De tabel is gesorteerd op aflopende datum van deelname. Klik om in oplopende volgorde te sorteren.",
+            "ariaLabelSortUp": "De tabel is gesorteerd op datum van deelname in oplopende volgorde. Klik om aflopend te sorteren.",
+            "label": "Laatste deelname"
+          },
           "participation-count": {
             "ariaLabelDefaultSort": "De tabel is momenteel niet gesorteerd op aantal deelnames. Klik om op oplopende volgorde te sorteren.",
             "ariaLabelSortDown": "De tabel is gesorteerd op aflopend aantal deelnames. Klik om op oplopende volgorde te sorteren.",


### PR DESCRIPTION
## ☀️ Problème
Sur la page Participants, le prescripteur doit pouvoir trier sur la colonne “Dernière participation” pour l’aider dans son suivi et ses relances. 
Ce tri manque pour les orgas avec SIECLE/FREGATA et SUP avec import

## ⛱️ Proposition
Ajouter le tri par date de dernière participation dans:
- La liste des étudiants d'une une organisation SUP
- La liste des élèves d'une une organisation SCO

## 🧴 Remarques
J'ai fait le SCO, Claude à fait le SUP

## 🏊 Pour tester
- Se connecter à Pix Orga
- Aller sur la page listant les élèves d'une organisation SCO et vérifier que le tri sur la colonne `Dernière participation` fonctionne
- Aller sur la page listant les étudiants d'une organisation SUP et vérifier que le tri sur la colonne `Dernière participation` fonctionne