### PR TITLE
[BUGFIX] corrige le partage d'attestation (PIX-24107)

### DIFF
--- a/api/src/profile/domain/usecases/share-profile-reward.js
+++ b/api/src/profile/domain/usecases/share-profile-reward.js
@@ -16,7 +16,7 @@ export const shareProfileReward = async function ({
   }
 
   if (campaignParticipationId) {
-    organizationId = await campaignParticipationRepository.getCampaignByParticipationId({ campaignParticipationId })
+    organizationId = (await campaignParticipationRepository.getCampaignByParticipationId({ campaignParticipationId }))
       .organizationId;
   }
 

--- a/api/tests/profile/integration/domain/usecases/share-profile-reward_test.js
+++ b/api/tests/profile/integration/domain/usecases/share-profile-reward_test.js
@@ -54,6 +54,7 @@ describe('Profile | Integration | Domain | Usecases | share-profile-reward', fun
     describe('if the reward belongs to the user', function () {
       let profileRewardId;
       let campaignParticipationId;
+      let organizationId;
       let userId;
 
       before(async function () {
@@ -62,8 +63,11 @@ describe('Profile | Integration | Domain | Usecases | share-profile-reward', fun
           rewardId: 1,
           userId: userId,
         }).id;
+        organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           userId,
+          campaignId,
         }).id;
 
         await databaseBuilder.commit();
@@ -80,6 +84,7 @@ describe('Profile | Integration | Domain | Usecases | share-profile-reward', fun
 
         expect(organizationsProfileRewards).to.have.lengthOf(1);
         expect(organizationsProfileRewards[0].profileRewardId).to.equal(profileRewardId);
+        expect(organizationsProfileRewards[0].organizationId).to.equal(organizationId);
       });
     });
 


### PR DESCRIPTION
## ☀️ Problème

On a cassé le partage d'attestation. Suite à une mise à jour de shareProfileReward, on a oublié de rajouter des parenthèses autour de la récupération de la campagne (qu'on await bien). cela à pour effet d'avoir un `organizationId` toujours `undefined`. 

## ⛱️ Proposition

On rajoute les parenthèses. 

## 🧴 Remarques

On a rajouter une assertion dans le test pour s'assurer qu'on ait pas de regression.

## 🏊 Pour tester


- Ajouter le parcours de rattrapage à l'orga Pro
- créer une campagne et passer le parcours
- valider que l'attestation est bien partagé avec l'orga
