### PR TITLE
[FEATURE] Corrections mineures sur la création d'une version

### DIFF
--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-edit-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-edit-form.gjs
@@ -180,6 +180,8 @@ export default class CertificationVersionEditForm extends Component {
         <PixInput
           name="defaultProbabilityToPickChallenge"
           type="number"
+          min="0"
+          max="100"
           required={{true}}
           @requiredLabel={{t "common.forms.mandatory"}}
           @subLabel={{this.getInputSubLabel @activeVersion.defaultProbabilityToPickChallenge}}
@@ -202,8 +204,10 @@ export default class CertificationVersionEditForm extends Component {
           <PixInput
             name="variationPercent"
             type="number"
+            min="0"
+            max="1"
             required={{true}}
-            step="any"
+            step="0.01"
             @requiredLabel={{t "common.forms.mandatory"}}
             @subLabel={{this.getInputSubLabel @activeVersion.variationPercent}}
             @errorMessage={{t
@@ -244,6 +248,7 @@ export default class CertificationVersionEditForm extends Component {
           <PixInput
             name="maximumAssessmentLength"
             type="number"
+            min="0"
             required={{true}}
             @requiredLabel={{t "common.forms.mandatory"}}
             @subLabel={{this.getInputSubLabel @activeVersion.maximumAssessmentLength}}
@@ -265,6 +270,7 @@ export default class CertificationVersionEditForm extends Component {
           <PixInput
             name="minimumAnswersRequiredForValidation"
             type="number"
+            min="0"
             required={{true}}
             @requiredLabel={{t "common.forms.mandatory"}}
             @subLabel={{this.getInputSubLabel @activeVersion.minimumAnswersRequiredForValidation}}
@@ -287,6 +293,7 @@ export default class CertificationVersionEditForm extends Component {
         <PixInput
           name="challengesBetweenSameCompetence"
           type="number"
+          min="0"
           required={{true}}
           @requiredLabel={{t "common.forms.mandatory"}}
           @subLabel={{this.getInputSubLabel @activeVersion.challengesBetweenSameCompetence}}

--- a/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
+++ b/admin/app/components/certification-frameworks/certification-framework/versions/certification-version-global-scoring-form.gjs
@@ -26,10 +26,11 @@ export default class GlobalScoringForm extends Component {
   updateValue(name, index, event) {
     const isMax = name === 'max';
     const newArray = [...this.globalScoringConfiguration];
-    newArray.at(index).bounds[name] = Number(event.target.value);
+    const value = event.target.value === '' ? null : Number(event.target.value);
+    newArray.at(index).bounds[name] = value;
 
     if (isMax && newArray.at(index + 1)) {
-      newArray.at(index + 1).bounds.min = Number(event.target.value);
+      newArray.at(index + 1).bounds.min = value;
     }
     this.args.editVersion.globalScoringConfiguration = newArray;
   }
@@ -40,18 +41,29 @@ export default class GlobalScoringForm extends Component {
   }
 
   @action
-  isFirstRow(index) {
-    return index === 0;
+  lastMaxValue(index) {
+    return this.#boundsAt(index - 1)?.max;
   }
 
-  @action
-  lastMaxValue(index) {
-    return this.globalScoringConfiguration.at(index - 1)?.bounds.max;
+  #boundsAt(index) {
+    return this.globalScoringConfiguration.at(index).bounds;
   }
 
   @action
   isGreaterThanMin(index) {
-    return this.globalScoringConfiguration.at(index).bounds.max > this.globalScoringConfiguration.at(index).bounds.min;
+    const { max, min } = this.#boundsAt(index);
+    return max == null || min == null || max > min;
+  }
+
+  @action
+  minValidationStatus(index) {
+    return this.#boundsAt(index).min == null ? 'error' : 'default';
+  }
+
+  @action
+  maxValidationStatus(index) {
+    const { max } = this.#boundsAt(index);
+    return max == null || !this.isGreaterThanMin(index) ? 'error' : 'default';
   }
 
   @action
@@ -78,8 +90,12 @@ export default class GlobalScoringForm extends Component {
               type="number"
               step="0.0000000001"
               readonly={{this.isNotFirstRow mesh.meshLevel}}
-              required={{this.isFirstRow mesh.meshLevel}}
-              @requiredLabel={{if (this.isFirstRow mesh.meshLevel) (t "common.forms.mandatory") false}}
+              required="true"
+              @requiredLabel={{t "common.forms.mandatory"}}
+              @errorMessage={{t
+                "components.certification-frameworks.certification-framework.versions.scoring.required-error"
+              }}
+              @validationStatus={{this.minValidationStatus mesh.meshLevel}}
               @value={{if (this.isNotFirstRow mesh.meshLevel) (this.lastMaxValue mesh.meshLevel) mesh.bounds.min}}
               {{on "change" (fn this.updateValue "min" mesh.meshLevel)}}
             >
@@ -92,12 +108,12 @@ export default class GlobalScoringForm extends Component {
             <PixInput
               type="number"
               step="0.0000000001"
-              required={{this.isFirstRow mesh.meshLevel}}
-              @requiredLabel={{if (this.isFirstRow mesh.meshLevel) (t "common.forms.mandatory") false}}
+              required="true"
+              @requiredLabel={{t "common.forms.mandatory"}}
               @errorMessage={{t
                 "components.certification-frameworks.certification-framework.versions.scoring.cannot-be-lower-error"
               }}
-              @validationStatus={{if (this.isGreaterThanMin mesh.meshLevel) "default" "error"}}
+              @validationStatus={{this.maxValidationStatus mesh.meshLevel}}
               @value={{mesh.bounds.max}}
               {{on "change" (fn this.updateValue "max" mesh.meshLevel)}}
             >

--- a/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-global-scoring-form.scss
+++ b/admin/app/styles/components/certification-frameworks/certification-frameworks/versions/certification-version-global-scoring-form.scss
@@ -17,7 +17,9 @@
       margin-bottom: 1.5rem;
 
       .pix-label {
-        font-size: 0.9rem;
+        color: var(--pix-neutral-500);
+        font-weight: var(--pix-font-normal);
+        font-size: 0.85rem;
       }
     }
 

--- a/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/calibration-test.js
+++ b/admin/tests/acceptance/authenticated/certification-frameworks/certification-framework/versions/calibration-test.js
@@ -129,7 +129,7 @@ module('Acceptance | Certification Framework | item | Framework | calibration', 
           minute: 'numeric',
           second: 'numeric',
         });
-        assert.dom(screen.getByText(`Rapport de la calibration d'ID 1 générée le ${displayedGeneratedAt}`)).exists();
+        assert.dom(screen.getByText(`Rapport de la calibration d'ID 1 généré le ${displayedGeneratedAt}`)).exists();
       });
 
       test('saves the calibrationId when the user validates the report', async function (assert) {

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -590,14 +590,14 @@
           },
           "calibration": {
             "label-for-CALIBRATED_CHALLENGE_COUNT": "Count of calibrated challenges",
-            "label-for-CALIBRATION_SCOPE": "Target scope",
-            "label-for-CALIBRATION_STARTED_AT": "Started calibration at",
+            "label-for-CALIBRATION_SCOPE": "Calibrated scope",
+            "label-for-CALIBRATION_STARTED_AT": "Calibration started at",
             "label-for-CALIBRATION_STATUS": "Status",
             "label-for-COMPETENCE_SCORING_PRESENCE": "Validated competences scoring present",
             "label-for-ENGLISH_CALIBRATED_CHALLENGE_COUNT": "Count of calibrated challenges in English",
             "label-for-MESH_SCORING_PRESENCE": "Validated mesh scoring present",
-            "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Tubes in calibration only",
-            "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Tubes in version only",
+            "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Calibrated tubes not selected in version",
+            "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Non-calibrated tubes selected in version",
             "no-report-message": "No calibration could be retrieved for this scope.",
             "report-title": "Calibration report of ID {calibrationId} generated at",
             "save-button-already-saved-tooltip": "ID {id} already saved on this version",
@@ -644,7 +644,7 @@
           },
           "page-title": "Creation of a new version of the certification in {scope} framework",
           "scoring": {
-            "cannot-be-lower-error": "The maximal capacity for a given level has to be strictly greater than its minimal capacity.",
+            "cannot-be-lower-error": "The maximal capacity must be set and strictly greater than the minimal capacity.",
             "competences": {
               "level": "Level",
               "maximum-input-label": "Maximal capacity ",
@@ -653,14 +653,15 @@
               "title": "Bounds of capacities by competence"
             },
             "level": "Level {index}",
-            "previous-version-capacity": "Previous value: {previousVersionCapacity}",
+            "previous-version-capacity": "Value in previous version: {previousVersionCapacity}",
+            "required-error": "This field is required.",
             "save-error": "An error occurred while saving the scoring.",
-            "save-scoring-button": "Save scoring",
+            "save-scoring-button": "Activate scoring",
             "save-scoring-modal": {
               "content": "This action will save the scoring configuration on the active version.",
-              "title": "Confirm scoring save"
+              "title": "Confirm scoring activation"
             },
-            "success-notification": "The scoring has been successfully updated",
+            "success-notification": "The scoring has been successfully activated",
             "title": "Bounds of capacity by mesh"
           },
           "title": "Creating a Certification Release"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -598,16 +598,16 @@
           },
           "calibration": {
             "label-for-CALIBRATED_CHALLENGE_COUNT": "Nombre d'épreuves calibrées",
-            "label-for-CALIBRATION_SCOPE": "Prévue pour le référentiel",
-            "label-for-CALIBRATION_STARTED_AT": "Démarrée le",
+            "label-for-CALIBRATION_SCOPE": "Référentiel calibré",
+            "label-for-CALIBRATION_STARTED_AT": "Date de la calibration",
             "label-for-CALIBRATION_STATUS": "Statut",
             "label-for-COMPETENCE_SCORING_PRESENCE": "Présence d'un scoring par compétences validé",
             "label-for-ENGLISH_CALIBRATED_CHALLENGE_COUNT": "Nombre d'épreuves calibrées en anglais",
             "label-for-MESH_SCORING_PRESENCE": "Présence d'un scoring par maille validé",
-            "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Sujets présents uniquement dans la calibration",
-            "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Sujets présents uniquement dans la version",
+            "label-for-TUBE_ONLY_IN_CALIBRATION_COUNT": "Sujets calibrés non sélectionnés dans la version",
+            "label-for-TUBE_ONLY_IN_VERSION_COUNT": "Sujets sélectionnés dans la version non calibrés",
             "no-report-message": "Aucune calibration n'a pu être récupérée pour ce référentiel.",
-            "report-title": "Rapport de la calibration d'ID {calibrationId} générée le",
+            "report-title": "Rapport de la calibration d'ID {calibrationId} généré le",
             "save-button-already-saved-tooltip": "ID {id} déjà enregistré sur ce millésime",
             "save-button-high-alert-tooltip": "Une alerte bloquante du rapport empêche d'enregistrer cette calibration",
             "save-button-label": "Enregistrer l'ID {id} de calibration",
@@ -652,21 +652,24 @@
           },
           "page-title": "Création d’une nouvelle version du référentiel de certification pour {scope}",
           "scoring": {
-            "cannot-be-lower-error": "La capacité maximale d'un niveau doit être strictement supérieur à sa capacité minimale.",
+            "cannot-be-lower-error": "La capacité maximale doit être renseignée et strictement supérieure à la capacité minimale.",
             "competences": {
               "level": "Niveau",
+              "maximum-input-label": "Capacité maximale",
+              "minimum-input-label": "Capacité minimale",
               "no-configuration": "Aucune configuration disponible pour cette compétence.",
               "title": "Bornes de capacités par compétences"
             },
             "level": "Niveau {index}",
-            "previous-version-capacity": "Ancienne valeur : {previousVersionCapacity}",
+            "previous-version-capacity": "Valeur dans la version précédente : {previousVersionCapacity}",
+            "required-error": "Ce champ est obligatoire.",
             "save-error": "Une erreur s'est produite lors de l'enregistrement du scoring.",
-            "save-scoring-button": "Enregistrer le scoring",
+            "save-scoring-button": "Activer le scoring",
             "save-scoring-modal": {
               "content": "Cette action va enregistrer la configuration de scoring sur la version active.",
-              "title": "Confirmation de l'enregistrement du scoring"
+              "title": "Confirmation de l'activation du scoring"
             },
-            "success-notification": "Le scoring a bien été mis à jour",
+            "success-notification": "Le scoring a bien été activé",
             "title": "Bornes de capacités par mailles"
           },
           "title": "Création d'une version de certification"

--- a/api/src/certification/configuration/application/certification-version-route.js
+++ b/api/src/certification/configuration/application/certification-version-route.js
@@ -81,7 +81,7 @@ async function register(server) {
             data: Joi.object({
               id: Joi.number(),
               attributes: Joi.object({
-                'start-date': Joi.date().allow(null).optional(),
+                'start-date': Joi.date().required(),
                 'assessment-duration': Joi.number().required(),
                 'external-calibration-id': Joi.number().allow(null).required(),
                 'minimum-answers-required-for-validation': Joi.number().required(),

--- a/api/src/certification/configuration/domain/usecases/activate-version.js
+++ b/api/src/certification/configuration/domain/usecases/activate-version.js
@@ -32,8 +32,11 @@ export async function activateVersion({
   if (!calibration) {
     throw new NotFoundError(`No certification version found for id: ${draftVersion.externalCalibrationId}`);
   }
+
+  const filteredChallenges = calibration.calibratedChallenges.filter((c) => draftVersion.tubeIds.includes(c.tubeId));
+
   await calibratedChallengesRepository.saveMany({
-    calibratedChallenges: calibration.calibratedChallenges,
+    calibratedChallenges: filteredChallenges,
     versionId: draftVersion.id,
   });
 

--- a/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/activate-version_test.js
@@ -147,6 +147,33 @@ describe('Certification | Configuration | Unit | UseCase | activate-version', fu
       });
     });
 
+    it('only persists calibrated challenges whose tube is selected for the version', async function () {
+      // given
+      const challengeInVersion = { challengeId: 'chalA', tubeId: 'tubeA', alpha: 1.5, delta: -0.5 };
+      const challengeOutsideVersion = { challengeId: 'chalB', tubeId: 'tubeB', alpha: 1.2, delta: 0.3 };
+      const calibration = { calibratedChallenges: [challengeInVersion, challengeOutsideVersion] };
+      const draftVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asDraft({ startDate: new Date('2025-01-01') })
+        .withParameters({ scope: SCOPES.CORE, tubeIds: ['tubeA'], id: 42, externalCalibrationId: 7 })
+        .withRealisticScoringConfigurations()
+        .build();
+      versionRepository.getById.resolves(draftVersion);
+      versionRepository.findActiveByScope.resolves(null);
+      versionRepository.save.resolves(draftVersion.id);
+      calibrationRepository.find.resolves(calibration);
+      calibratedChallengesRepository.saveMany.resolves();
+
+      // when
+      await activateVersion({ id: 42, versionRepository, calibrationRepository, calibratedChallengesRepository });
+
+      // then
+      sinon.assert.calledWithExactly(calibratedChallengesRepository.saveMany, {
+        calibratedChallenges: [challengeInVersion],
+        versionId: 42,
+      });
+    });
+
     it('activates the draft version', async function () {
       // given
       const now = new Date('2025-09-01');


### PR DESCRIPTION
## ☀️ Problème

Suite à une revue fonctionnelle de l'ensemble du workflow avec @elisepvt, quelques bugs et améliorations possibles sont ressortis.

## ⛱️ Proposition

- à l'étape 4, absence de certaines erreurs dans les champs des bornes de capacités
- plusieurs corrections/améliorations de traductions
- Vérifier que les exigences front (resp. back) sont bien répercutées dans le back (resp. front) : 
	- à l'étape 2 : 
		- rendre la startDate obligatoire dans le back
		- configurer min et max des input pour ne pas permettre d'entrer des valeurs refusées par le back (ex: nombre de question négatif)
- Filtrer les challenges calibrés sur les tubes sélectionnés pour la version

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
