### PR TITLE
[FEATURE] Déclencher les jobs de scoring lors de l'activation du scoring sur une version Pix+ déjà active (PIX-24086)

### DIFF
--- a/admin/app/components/certifications/certification/informations/global-actions.gjs
+++ b/admin/app/components/certifications/certification/informations/global-actions.gjs
@@ -56,7 +56,11 @@ export default class CertificationInformationGlobalActions extends Component {
   }
 
   get displayRescoringCertificationButton() {
-    return Boolean(!this.args.certification.isPublished && this.args.session.finalizedAt);
+    return Boolean(
+      this.args.certification.status !== 'pending-scoring' &&
+      !this.args.certification.isPublished &&
+      this.args.session.finalizedAt,
+    );
   }
 
   @action

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -14,6 +14,7 @@ export const assessmentResultStatus = {
   CANCELLED: 'cancelled',
   CANCELLED_BY_JURY: 'cancelled_by_jury',
   ERROR: 'error',
+  PENDING_SCORING: 'pending-scoring',
   VALIDATED: 'validated',
   REJECTED: 'rejected',
 };
@@ -78,6 +79,12 @@ export default class Certification extends Model {
   }
 
   get statusLabelAndValue() {
+    if (this.status === assessmentResultStatus.PENDING_SCORING) {
+      return {
+        value: assessmentResultStatus.PENDING_SCORING,
+        label: this.intl.t('pages.certifications.certification.details.v3.assessment-result-status.pending-scoring'),
+      };
+    }
     return certificationStatuses.find((certificationStatus) => certificationStatus.value === this.status);
   }
 
@@ -117,6 +124,7 @@ export default class Certification extends Model {
   }
 
   get result() {
+    if (!this.reachedResultKey) return null;
     return this.intl.t(`common.certification.meshLevels.${this.reachedResultKey}`, {
       pixScore: this.pixScore,
     });

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -66,6 +66,7 @@ export default class JuryCertificationSummary extends Model {
   }
 
   get result() {
+    if (!this.reachedResultKey) return null;
     return this.intl.t(`common.certification.meshLevels.${this.reachedResultKey}`, {
       pixScore: this.pixScore,
     });

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -136,6 +136,7 @@ module('Unit | Model | certification', function (hooks) {
   module('#statusLabelAndValue', function () {
     [
       { value: assessmentStates.STARTED, label: 'Démarrée' },
+      { value: assessmentResultStatus.PENDING_SCORING, label: 'En attente de scoring' },
       { value: assessmentResultStatus.ERROR, label: 'En erreur' },
       { value: assessmentResultStatus.VALIDATED, label: 'Validée' },
       { value: assessmentResultStatus.REJECTED, label: 'Rejetée' },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1713,6 +1713,7 @@
               "cancelled_by_jury": "Cancelled",
               "error": "Error",
               "fraud": "Rejected for fraud",
+              "pending-scoring": "Pending scoring",
               "rejected": "Rejected",
               "validated": "Validated"
             },

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -667,10 +667,10 @@
             "save-error": "An error occurred while saving the scoring.",
             "save-scoring-button": "Activate scoring",
             "save-scoring-modal": {
-              "content": "This action will save the scoring configuration on the active version.",
-              "title": "Confirm scoring activation"
+              "content": "This action will save the scoring configuration to the active version and will trigger the scoring that has already been applied to that version. This action is irreversible, the scoring cannot be modified.",
+              "title": "Confirm scoring save"
             },
-            "success-notification": "The scoring has been successfully activated",
+            "success-notification": "The scoring has been successfully activated. Certifications already completed for this version will be scored.",
             "title": "Bounds of capacity by mesh"
           },
           "title": "Creating a Certification Release"
@@ -678,9 +678,9 @@
       },
       "deletion-modal": {
         "action-button": "Confirm deletion",
-        "content": "You are about to delete a certification version !!!!",
+        "content": "You are about to delete a certification version.",
         "error-message": "An error has occured",
-        "success-message": "That version has indeed been removed",
+        "success-message": "That version has indeed been removed.",
         "title": "Confirmation of version deletion"
       },
       "labels": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -675,10 +675,10 @@
             "save-error": "Une erreur s'est produite lors de l'enregistrement du scoring.",
             "save-scoring-button": "Activer le scoring",
             "save-scoring-modal": {
-              "content": "Cette action va enregistrer la configuration de scoring sur la version active.",
-              "title": "Confirmation de l'activation du scoring"
+              "content": "Cette action va enregistrer la configuration de scoring sur la version active et va déclencher le scoring déjà passée sur cette version. Cette action est irréversible, le scoring ne pourra pas être modifié.",
+              "title": "Confirmation de l'enregistrement du scoring"
             },
-            "success-notification": "Le scoring a bien été activé",
+            "success-notification": "Le scoring a bien été activé. Les certifications déjà passées sur la version seront scorées.",
             "title": "Bornes de capacités par mailles"
           },
           "title": "Création d'une version de certification"
@@ -688,7 +688,7 @@
         "action-button": "Confirmer la suppression",
         "content": "Vous vous apprêtez à supprimer une version.",
         "error-message": "Une erreur s'est produite",
-        "success-message": "La version à bien été supprimée",
+        "success-message": "La version à bien été supprimée.",
         "title": "Confirmation de suppression d'une version"
       },
       "labels": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1716,6 +1716,7 @@
               "cancelled_by_jury": "Annulée",
               "error": "Erreur",
               "fraud": "Rejetée pour fraude",
+              "pending-scoring": "En attente de scoring",
               "rejected": "Rejetée",
               "validated": "Validée"
             },

--- a/api/src/certification/configuration/domain/models/ScoreCertificationJob.js
+++ b/api/src/certification/configuration/domain/models/ScoreCertificationJob.js
@@ -1,0 +1,5 @@
+export class ScoreCertificationJob {
+  constructor({ certificationCourseId }) {
+    this.certificationCourseId = certificationCourseId;
+  }
+}

--- a/api/src/certification/configuration/domain/usecases/index.js
+++ b/api/src/certification/configuration/domain/usecases/index.js
@@ -6,10 +6,12 @@ import * as attachableTargetProfileRepository from '../../infrastructure/reposit
 import * as calibratedChallengesRepository from '../../infrastructure/repositories/calibrated-challenges-repository.js';
 import * as calibrationRepository from '../../infrastructure/repositories/calibration-repository.js';
 import * as centerRepository from '../../infrastructure/repositories/center-repository.js';
+import * as certificationCoursesToScoreRepository from '../../infrastructure/repositories/certification-courses-to-score-repository.js';
 import * as certificationInfoRepository from '../../infrastructure/repositories/certification-info-repository.js';
 import * as complementaryCertificationBadgesRepository from '../../infrastructure/repositories/complementary-certification-badge-repository.js';
 import * as complementaryCertificationForTargetProfileAttachmentRepository from '../../infrastructure/repositories/complementary-certification-for-target-profile-attachment-repository.js';
 import * as complementaryCertificationRepository from '../../infrastructure/repositories/complementary-certification-repository.js';
+import { scoreCertificationJobRepository } from '../../infrastructure/repositories/jobs/score-certification-job-repository.js';
 import * as organizationRepository from '../../infrastructure/repositories/organization-repository.js';
 import * as ScoBlockedAccessDatesRepository from '../../infrastructure/repositories/sco-blocked-access-dates-repository.js';
 import * as versionDetailsRepository from '../../infrastructure/repositories/version-details-repository.js';
@@ -56,6 +58,8 @@ import { updateVersionComment } from './update-version-comment.js';
 const dependencies = {
   calibratedChallengesRepository,
   attachableTargetProfileRepository,
+  certificationCoursesToScoreRepository,
+  scoreCertificationJobRepository,
   centerRepository,
   ScoBlockedAccessDatesRepository,
   certificationInfoRepository,

--- a/api/src/certification/configuration/domain/usecases/save-scoring-configuration.js
+++ b/api/src/certification/configuration/domain/usecases/save-scoring-configuration.js
@@ -1,4 +1,5 @@
 import { NotFoundError } from '../../../../shared/domain/errors.js';
+import { ScoreCertificationJob } from '../models/ScoreCertificationJob.js';
 
 /**
  * @param {object} params
@@ -6,12 +7,16 @@ import { NotFoundError } from '../../../../shared/domain/errors.js';
  * @param {Array} params.globalScoringConfiguration
  * @param {Array|null} params.competencesScoringConfiguration
  * @param {object} params.versionRepository
+ * @param {object} params.certificationCoursesToScoreRepository
+ * @param {object} params.scoreCertificationJobRepository
  */
 export async function saveScoringConfiguration({
   id,
   globalScoringConfiguration,
   competencesScoringConfiguration,
   versionRepository,
+  certificationCoursesToScoreRepository,
+  scoreCertificationJobRepository,
 }) {
   const version = await versionRepository.getById({ id });
 
@@ -20,4 +25,9 @@ export async function saveScoringConfiguration({
   }
 
   await versionRepository.updateScoring({ id, globalScoringConfiguration, competencesScoringConfiguration });
+
+  const certificationCourseIds = await certificationCoursesToScoreRepository.findIdsByVersionId({ versionId: id });
+  await scoreCertificationJobRepository.performAsync(
+    ...certificationCourseIds.map((certificationCourseId) => new ScoreCertificationJob({ certificationCourseId })),
+  );
 }

--- a/api/src/certification/configuration/infrastructure/repositories/certification-courses-to-score-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/certification-courses-to-score-repository.js
@@ -1,0 +1,11 @@
+import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
+
+export async function findIdsByVersionId({ versionId }) {
+  const knexConn = DomainTransaction.getConnection();
+  const rows = await knexConn('certification-courses')
+    .select('certification-courses.id')
+    .join('sessions', 'sessions.id', 'certification-courses.sessionId')
+    .whereNotNull('sessions.finalizedAt')
+    .where('certification-courses.versionId', versionId);
+  return rows.map((row) => row.id);
+}

--- a/api/src/certification/configuration/infrastructure/repositories/jobs/score-certification-job-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/jobs/score-certification-job-repository.js
@@ -1,0 +1,10 @@
+import { JobRepository } from '../../../../../shared/infrastructure/repositories/jobs/job-repository.js';
+import { ScoreCertificationJob } from '../../../domain/models/ScoreCertificationJob.js';
+
+class ScoreCertificationJobRepository extends JobRepository {
+  constructor() {
+    super({ name: ScoreCertificationJob.name });
+  }
+}
+
+export const scoreCertificationJobRepository = new ScoreCertificationJobRepository();

--- a/api/src/certification/evaluation/application/jobs/score-certification-job-controller.js
+++ b/api/src/certification/evaluation/application/jobs/score-certification-job-controller.js
@@ -1,0 +1,14 @@
+import { JobController } from '../../../../shared/application/jobs/job-controller.js';
+import { ScoreCertificationJob } from '../../../configuration/domain/models/ScoreCertificationJob.js';
+import { usecases } from '../../domain/usecases/index.js';
+
+export class ScoreCertificationJobController extends JobController {
+  constructor() {
+    super(ScoreCertificationJob.name);
+  }
+
+  async handle({ data }) {
+    const { certificationCourseId } = data;
+    await usecases.scoreV3Certification({ certificationCourseId });
+  }
+}

--- a/api/src/certification/session-management/domain/models/JuryCertification.js
+++ b/api/src/certification/session-management/domain/models/JuryCertification.js
@@ -105,6 +105,10 @@ export class JuryCertification {
       return `${this.certificationFramework}.NONE`;
     }
 
+    if (this.status === 'pending-scoring') {
+      return null;
+    }
+
     const resultKey = this.eduV3ExternalJuryResult || (this.reachedMeshIndex ?? 'BELOW_MINIMUM');
 
     return `${this.certificationFramework}.${resultKey}`;
@@ -154,7 +158,9 @@ export class JuryCertification {
       birthCountry: juryCertificationDTO.birthCountry,
       birthPostalCode: juryCertificationDTO.birthPostalCode,
       createdAt: juryCertificationDTO.createdAt,
-      status: juryCertificationDTO.assessmentResultStatus,
+      status:
+        juryCertificationDTO.assessmentResultStatus ??
+        (juryCertificationDTO.hasScoringConfiguration ? null : 'pending-scoring'),
       isPublished: juryCertificationDTO.isPublished,
       isRejectedForFraud: juryCertificationDTO.isRejectedForFraud,
       juryId: juryCertificationDTO.juryId,

--- a/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
+++ b/api/src/certification/session-management/domain/read-models/JuryCertificationSummary.js
@@ -44,6 +44,10 @@ export class JuryCertificationSummary {
       return `${this.certificationFramework}.NONE`;
     }
 
+    if (this.status === STARTED) {
+      return null;
+    }
+
     const resultKey = this.eduV3ExternalJuryResult || (this.reachedMeshIndex ?? 'BELOW_MINIMUM');
 
     return `${this.certificationFramework}.${resultKey}`;

--- a/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
+++ b/api/src/certification/session-management/infrastructure/repositories/jury-certification-repository.js
@@ -120,6 +120,9 @@ function _selectJuryCertifications(knexConn) {
       commentByAutoJury: 'assessment-results.commentByAutoJury',
       certificationFramework: 'certification-courses.framework',
       lastAnswerAt: 'certification-courses.lastAnswerAt',
+      hasScoringConfiguration: knexConn.raw(
+        `(certification_versions."globalScoringConfiguration" IS NOT NULL AND jsonb_array_length(certification_versions."globalScoringConfiguration") > 0)`,
+      ),
     })
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
@@ -133,7 +136,8 @@ function _selectJuryCertifications(knexConn) {
       'assessment-results.id',
       'certification-courses-last-assessment-results.lastAssessmentResultId',
     )
-    .groupBy('certification-courses.id', 'assessments.id', 'assessment-results.id');
+    .leftJoin('certification_versions', 'certification_versions.id', 'certification-courses.versionId')
+    .groupBy('certification-courses.id', 'assessments.id', 'assessment-results.id', 'certification_versions.id');
 }
 
 async function _toDomainWithComplementaryCertifications({

--- a/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
+++ b/api/tests/certification/configuration/acceptance/application/certification-version-route_test.js
@@ -932,7 +932,7 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
   });
 
   describe('PATCH /api/admin/certification-versions/{certificationVersionId}/scoring', function () {
-    it('updates the scoring configuration of a version', async function () {
+    it('updates the scoring configuration of a version and enqueues scoring jobs for existing certifications', async function () {
       // given
       domainBuilder.certification.configuration
         .versionBuilder()
@@ -944,6 +944,13 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
           competencesScoringConfiguration: null,
         })
         .insertToDB({ databaseBuilder });
+
+      const finalizedSession = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2025-01-01') });
+      const course = databaseBuilder.factory.buildCertificationCourse({
+        sessionId: finalizedSession.id,
+        versionId: 42,
+      });
+
       await databaseBuilder.commit();
 
       const globalScoringConfiguration = [{ meshLevel: 1, bounds: { min: -2, max: 3 } }];
@@ -970,6 +977,9 @@ describe('Acceptance | Certification | Configuration | API | certification-versi
       expect(response.statusCode).to.equal(204);
       const updatedVersion = await knex('certification_versions').where({ id: 42 }).first();
       expect(updatedVersion.globalScoringConfiguration).to.deep.equal(globalScoringConfiguration);
+      await expect('ScoreCertificationJob').to.have.been.performed.withJobPayload(
+        sinon.match({ certificationCourseId: course.id }),
+      );
     });
 
     it('returns 403 when the user is not a super admin', async function () {

--- a/api/tests/certification/configuration/integration/domain/usecases/save-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/integration/domain/usecases/save-scoring-configuration_test.js
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
 
+import { ScoreCertificationJob } from '../../../../../../src/certification/configuration/domain/models/ScoreCertificationJob.js';
 import { usecases } from '../../../../../../src/certification/configuration/domain/usecases/index.js';
 import * as versionRepository from '../../../../../../src/certification/configuration/infrastructure/repositories/version-repository.js';
 import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { EMPTY_CORRELATION_INFO } from '../../../../../../src/shared/infrastructure/execution-context-manager.js';
+import { JobPriority } from '../../../../../../src/shared/infrastructure/jobs/default-config.js';
 import { databaseBuilder } from '../../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
 
@@ -34,5 +37,38 @@ describe('Certification | Configuration | Integration | Domain | UseCase | save-
     const updatedVersion = await versionRepository.getById({ id: 123 });
     expect(updatedVersion.globalScoringConfiguration).to.deep.equal(globalScoringConfiguration);
     expect(updatedVersion.competencesScoringConfiguration).to.be.null;
+  });
+
+  it('enqueues a ScoreCertificationJob for each certification course on a finalized session', async function () {
+    // given
+    const version = domainBuilder.certification.configuration
+      .versionBuilder()
+      .asActive()
+      .withParameters({ id: 456, scope: SCOPES.PIX_PLUS_DROIT, globalScoringConfiguration: [] })
+      .insertToDB({ databaseBuilder });
+
+    const finalizedSession = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2025-01-01') });
+    const course = databaseBuilder.factory.buildCertificationCourse({
+      sessionId: finalizedSession.id,
+      versionId: version.id,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    await usecases.saveScoringConfiguration({
+      id: 456,
+      globalScoringConfiguration: [{ meshLevel: 1, bounds: { min: 0, max: 100 } }],
+      competencesScoringConfiguration: null,
+    });
+
+    // then
+    await expect(ScoreCertificationJob.name).to.have.been.performed.withJob({
+      data: {
+        certificationCourseId: course.id,
+        correlationContext: EMPTY_CORRELATION_INFO,
+      },
+      priority: JobPriority.DEFAULT,
+    });
   });
 });

--- a/api/tests/certification/configuration/integration/infrastructure/repositories/certification-courses-to-score-repository_test.js
+++ b/api/tests/certification/configuration/integration/infrastructure/repositories/certification-courses-to-score-repository_test.js
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import { findIdsByVersionId } from '../../../../../../src/certification/configuration/infrastructure/repositories/certification-courses-to-score-repository.js';
+import { SCOPES } from '../../../../../../src/certification/shared/domain/models/Scopes.js';
+import { databaseBuilder } from '../../../../../tooling/databases.js';
+import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
+
+describe('Certification | Configuration | Integration | Infrastructure | Repositories | certification-courses-to-score-repository', function () {
+  describe('#findIdsByVersionId', function () {
+    it('returns ids of certification courses on finalized sessions for the given version', async function () {
+      // given
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({ id: 1, scope: SCOPES.PIX_PLUS_DROIT })
+        .insertToDB({ databaseBuilder });
+
+      const finalizedSession = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2025-01-01') });
+      const courseOnFinalizedSession = databaseBuilder.factory.buildCertificationCourse({
+        sessionId: finalizedSession.id,
+        versionId: version.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const ids = await findIdsByVersionId({ versionId: version.id });
+
+      // then
+      expect(ids).to.deep.equal([courseOnFinalizedSession.id]);
+    });
+
+    it('excludes certification courses on non-finalized sessions', async function () {
+      // given
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({ id: 2, scope: SCOPES.PIX_PLUS_DROIT })
+        .insertToDB({ databaseBuilder });
+
+      const nonFinalizedSession = databaseBuilder.factory.buildSession({ finalizedAt: null });
+      databaseBuilder.factory.buildCertificationCourse({
+        sessionId: nonFinalizedSession.id,
+        versionId: version.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const ids = await findIdsByVersionId({ versionId: version.id });
+
+      // then
+      expect(ids).to.be.empty;
+    });
+
+    it('excludes certification courses belonging to a different version', async function () {
+      // given
+      const version = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({ id: 3, scope: SCOPES.PIX_PLUS_DROIT })
+        .insertToDB({ databaseBuilder });
+
+      const otherVersion = domainBuilder.certification.configuration
+        .versionBuilder()
+        .asActive()
+        .withParameters({ id: 4, scope: SCOPES.PIX_PLUS_EDU_1ER_DEGRE })
+        .insertToDB({ databaseBuilder });
+
+      const finalizedSession = databaseBuilder.factory.buildSession({ finalizedAt: new Date('2025-01-01') });
+      databaseBuilder.factory.buildCertificationCourse({
+        sessionId: finalizedSession.id,
+        versionId: otherVersion.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const ids = await findIdsByVersionId({ versionId: version.id });
+
+      // then
+      expect(ids).to.be.empty;
+    });
+  });
+});

--- a/api/tests/certification/configuration/unit/domain/usecases/save-scoring-configuration_test.js
+++ b/api/tests/certification/configuration/unit/domain/usecases/save-scoring-configuration_test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { ScoreCertificationJob } from '../../../../../../src/certification/configuration/domain/models/ScoreCertificationJob.js';
 import { saveScoringConfiguration } from '../../../../../../src/certification/configuration/domain/usecases/save-scoring-configuration.js';
 import { NotFoundError } from '../../../../../../src/shared/domain/errors.js';
 import { domainBuilder } from '../../../../../tooling/domain-builder/domain-builder.js';
@@ -8,11 +9,19 @@ import { catchErr } from '../../../../../tooling/test-utils/error.js';
 
 describe('Certification | Configuration | Unit | UseCase | save-scoring-configuration', function () {
   let versionRepository;
+  let certificationCoursesToScoreRepository;
+  let scoreCertificationJobRepository;
 
   beforeEach(function () {
     versionRepository = {
       getById: sinon.stub(),
       updateScoring: sinon.stub(),
+    };
+    certificationCoursesToScoreRepository = {
+      findIdsByVersionId: sinon.stub(),
+    };
+    scoreCertificationJobRepository = {
+      performAsync: sinon.stub(),
     };
   });
 
@@ -27,6 +36,8 @@ describe('Certification | Configuration | Unit | UseCase | save-scoring-configur
         globalScoringConfiguration: [],
         competencesScoringConfiguration: null,
         versionRepository,
+        certificationCoursesToScoreRepository,
+        scoreCertificationJobRepository,
       });
 
       // then
@@ -35,16 +46,22 @@ describe('Certification | Configuration | Unit | UseCase | save-scoring-configur
   });
 
   context('when the version exists', function () {
-    it('calls updateScoring with the right parameters', async function () {
-      // given
-      const version = domainBuilder.certification.configuration
+    let version;
+
+    beforeEach(function () {
+      version = domainBuilder.certification.configuration
         .versionBuilder()
         .asActive()
         .withParameters({ id: 42 })
         .build();
       versionRepository.getById.resolves(version);
       versionRepository.updateScoring.resolves();
+      certificationCoursesToScoreRepository.findIdsByVersionId.resolves([]);
+      scoreCertificationJobRepository.performAsync.resolves();
+    });
 
+    it('calls updateScoring with the right parameters', async function () {
+      // given
       const globalScoringConfiguration = [{ meshLevel: 1, bounds: { min: 0, max: 100 } }];
       const competencesScoringConfiguration = null;
 
@@ -54,6 +71,8 @@ describe('Certification | Configuration | Unit | UseCase | save-scoring-configur
         globalScoringConfiguration,
         competencesScoringConfiguration,
         versionRepository,
+        certificationCoursesToScoreRepository,
+        scoreCertificationJobRepository,
       });
 
       // then
@@ -62,6 +81,48 @@ describe('Certification | Configuration | Unit | UseCase | save-scoring-configur
         globalScoringConfiguration,
         competencesScoringConfiguration,
       });
+    });
+
+    it('enqueues a ScoreCertificationJob for each certification course on finalized sessions', async function () {
+      // given
+      certificationCoursesToScoreRepository.findIdsByVersionId.resolves([10, 20, 30]);
+
+      // when
+      await saveScoringConfiguration({
+        id: 42,
+        globalScoringConfiguration: [],
+        competencesScoringConfiguration: null,
+        versionRepository,
+        certificationCoursesToScoreRepository,
+        scoreCertificationJobRepository,
+      });
+
+      // then
+      sinon.assert.calledWithExactly(certificationCoursesToScoreRepository.findIdsByVersionId, { versionId: 42 });
+      sinon.assert.calledWithExactly(
+        scoreCertificationJobRepository.performAsync,
+        new ScoreCertificationJob({ certificationCourseId: 10 }),
+        new ScoreCertificationJob({ certificationCourseId: 20 }),
+        new ScoreCertificationJob({ certificationCourseId: 30 }),
+      );
+    });
+
+    it('enqueues no job when no certification courses are found', async function () {
+      // given
+      certificationCoursesToScoreRepository.findIdsByVersionId.resolves([]);
+
+      // when
+      await saveScoringConfiguration({
+        id: 42,
+        globalScoringConfiguration: [],
+        competencesScoringConfiguration: null,
+        versionRepository,
+        certificationCoursesToScoreRepository,
+        scoreCertificationJobRepository,
+      });
+
+      // then
+      sinon.assert.calledWithExactly(scoreCertificationJobRepository.performAsync);
     });
   });
 });

--- a/api/tests/certification/evaluation/unit/application/jobs/score-certification-job-controller_test.js
+++ b/api/tests/certification/evaluation/unit/application/jobs/score-certification-job-controller_test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { ScoreCertificationJob } from '../../../../../../src/certification/configuration/domain/models/ScoreCertificationJob.js';
+import { ScoreCertificationJobController } from '../../../../../../src/certification/evaluation/application/jobs/score-certification-job-controller.js';
+import { usecases } from '../../../../../../src/certification/evaluation/domain/usecases/index.js';
+
+describe('Unit | Certification | Evaluation | Application | jobs | ScoreCertificationJobController', function () {
+  it('calls scoreV3Certification with the certificationCourseId', async function () {
+    // given
+    sinon.stub(usecases, 'scoreV3Certification');
+    const controller = new ScoreCertificationJobController();
+    const data = new ScoreCertificationJob({ certificationCourseId: 123 });
+
+    // when
+    await controller.handle({ data });
+
+    // then
+    expect(usecases.scoreV3Certification).to.have.been.calledWithExactly({ certificationCourseId: 123 });
+  });
+});

--- a/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
+++ b/api/tests/certification/session-management/unit/domain/models/JuryCertification_test.js
@@ -183,6 +183,40 @@ describe('Unit | Domain | Models | JuryCertification', function () {
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);
     });
+
+    context('when there is no assessment result', function () {
+      it('should set status to "pending-scoring" when there is no scoring configuration', function () {
+        // given
+        juryCertificationDTO.assessmentResultStatus = null;
+        juryCertificationDTO.hasScoringConfiguration = false;
+
+        // when
+        const juryCertification = JuryCertification.from({
+          juryCertificationDTO,
+          certificationIssueReports: [],
+          competenceMarkDTOs: [],
+        });
+
+        // then
+        expect(juryCertification.status).to.equal('pending-scoring');
+      });
+
+      it('should set status to null when there is a scoring configuration', function () {
+        // given
+        juryCertificationDTO.assessmentResultStatus = null;
+        juryCertificationDTO.hasScoringConfiguration = true;
+
+        // when
+        const juryCertification = JuryCertification.from({
+          juryCertificationDTO,
+          certificationIssueReports: [],
+          competenceMarkDTOs: [],
+        });
+
+        // then
+        expect(juryCertification.status).to.be.null;
+      });
+    });
   });
 
   describe('#get reachedResultKey', function () {
@@ -320,6 +354,18 @@ describe('Unit | Domain | Models | JuryCertification', function () {
             });
           });
         });
+      });
+    });
+
+    context('when status is "pending-scoring"', function () {
+      it('returns null', function () {
+        const juryCertification = domainBuilder.certification.sessionManagement.buildJuryCertification({
+          version: AlgorithmEngineVersion.V3,
+          certificationFramework: Frameworks.EDU_2ND_DEGRE,
+          status: 'pending-scoring',
+        });
+
+        expect(juryCertification.reachedResultKey).to.be.null;
       });
     });
   });

--- a/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/certification/session-management/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -387,6 +387,18 @@ describe('Unit | Domain | Models | JuryCertificationSummary', function () {
           });
         });
       });
+
+      context('when status is "started" (no assessment result)', function () {
+        it('returns null', function () {
+          const juryCertificationSummary = domainBuilder.certification.sessionManagement.buildJuryCertificationSummary({
+            certificationFramework: Frameworks.EDU_2ND_DEGRE,
+            algorithmVersion: AlgorithmEngineVersion.V3,
+            status: null,
+          });
+
+          expect(juryCertificationSummary.reachedResultKey).to.be.null;
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

La création d'une nouvelle version de référentiel était gérée manuellement en interne. Pour gagner en autonomie et en efficacité, on featurise ce processus directement depuis l'espace Admin.
Dans le cas particulier de la création d'une version pour un scope Pix+, on veut permettre une activation en deux temps, où le scoring ne viendrait qu'après.  Dans cette situation, lorsqu'on active le scoring, il faut alors déclencher le scoring de toutes les certifications qui ont déjà été passées sur la version.

## ⛱️ Proposition

Lors de l'activation du scoring, on déclenche un job de scoring par certification à scorer (certifications appartenant à une session finalisée et dont le versionID correspond à celle sur laquelle on vient d'activer le scoring)


## 🧴 Remarques

On en profite pour gérer l'affichage des certifications non scorées dans admin (par défaut, en l'absence d'un assessment-result, la certification était affichée comme non obtenue) 
On cache le bouton "re-scorer" en cas d'absence d'une configuration de scoring, comme il ne va de toute façon pas fonctionner.
En revanche, les boutons "Annuler" et "Rejeter" ne fonctionnent actuellement pas, car on déclenche un scoring mais celui est superflu donc s'il était retiré, les boutons fonctionneraient

## 🏊 Pour tester

- créer une nouvelle version pix +
- l'activer à l'étape 3, sans scoring
- passer une certif
- dans Pix Admin, constater que la certif n'est pas scorée, que la session est dans les sessions "à traiter", que son statut indique "En attente de scoring" et que le bouton rescorer est caché 
- activer un scoring sur la version
- constater que la session est "à publier", que la certification est "Validée" et scorée, le bouton re-scorer est présent