### PR TITLE
[FEATURE] Mettre en avant un contenu formatif sur Pix App (moteur de reco) (PIX-24006).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -11,6 +11,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 import MarkdownToHtml from '../../../../markdown-to-html';
+import HighlightedCard from '../highlighted-card/highlighted-card';
 import AcquiredBadgesCompact from './acquired-badges-compact';
 
 export default class EvaluationResultsHeroRecommendationEngine extends Component {
@@ -174,10 +175,12 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
                 </ul>
               </:footer>
             </PixModal>
-
           {{/if}}
         </div>
       </div>
+      {{#if @highlightedTraining}}
+        <HighlightedCard @highlightedTraining={{@highlightedTraining}} @onCardClick={{@onCardClick}} />
+      {{/if}}
     </div>
     {{#if @campaignParticipationResult.hasReachedStage}}
       <section

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card.gjs
@@ -1,0 +1,18 @@
+import { t } from 'ember-intl';
+
+import Card from '../training/card';
+
+<template>
+  <div class="highlighted-card-container">
+    <div class="highlighted-card-tag">
+      <p class="highlighted-card-tag__text">{{t "pages.skill-review.recommended-engine.highlighted-card.editor-label"}}
+        <span class="highlighted-card-tag__text--bold">{{@highlightedTraining.editorName}}</span>
+      </p>
+    </div>
+    <div class="highlighted-card">
+      <h2 class="highlighted-card__title">{{t "pages.skill-review.recommended-engine.highlighted-card.title"}}</h2>
+      <p class="highlighted-card__subtitle">{{t "pages.skill-review.recommended-engine.highlighted-card.subtitle"}}</p>
+      <Card @isHighlighted={{true}} @training={{@highlightedTraining}} @onCardClick={{@onCardClick}} />
+    </div>
+  </div>
+</template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -1,3 +1,4 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -12,6 +13,7 @@ import RegistrationCardTag from './registration-card-tag';
 export default class Card extends Component {
   @service intl;
   @service locale;
+  @service media;
 
   @tracked modalIsOpen = false;
 
@@ -48,36 +50,67 @@ export default class Card extends Component {
   }
 
   <template>
-    <div class="results-recommendation-engine-training-card">
-      <div class="results-recommendation-engine-training-card-image-hero">
-        <img
-          class="results-recommendation-engine-training-card-image-hero__editor-logo"
-          src="{{@training.editorLogoUrl}}"
-          alt=""
-        />
-        <img
-          class="results-recommendation-engine-training-card-image-hero__illustration"
-          src="{{this.illustrationPath}}"
-          alt=""
-        />
+    {{#if @isHighlighted}}
+      <div class="results-recommendation-engine-highlighted-training-card">
+        <div class="results-recommendation-engine-highlighted-training-card-description">
+          <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
+          <h3
+            class="results-recommendation-engine-highlighted-training-card-description__title"
+          >{{@training.title}}</h3>
+          <ul class="results-recommendation-engine-highlighted-training-card-description__information">
+            <li>{{this.type}}</li>
+            <li>{{this.deliveryMode}}</li>
+            {{#if @training.hasDuration}}
+              <li>{{this.formattedDuration}}</li>
+            {{/if}}
+          </ul>
+          <PixButton
+            @triggerAction={{this.showModal}}
+            class="results-recommendation-engine-highlighted-training-card-description__button"
+          >
+            {{t "pages.skill-review.recommended-engine.highlighted-card.learn-more"}}
+          </PixButton>
+        </div>
+        {{#unless this.media.isMobile}}
+          <img
+            class="results-recommendation-engine-highlighted-training-card-illustration"
+            src="{{this.illustrationPath}}"
+            alt=""
+          />
+        {{/unless}}
       </div>
-      <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
-      <section class="results-recommendation-engine-training-card-content">
-        <p class="results-recommendation-engine-training-card-content__title">{{@training.title}}</p>
-        <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li>
-          <li>{{this.deliveryMode}}</li>
-          {{#if @training.hasDuration}}
-            <li>{{this.formattedDuration}}</li>
-          {{/if}}
-        </ul>
-      </section>
-      <button
-        class="results-recommendation-engine-training-card__button"
-        type="button"
-        aria-label={{t "pages.skill-review.recommended-engine.training-card.aria-label"}}
-        {{on "click" this.showModal}}
-      ></button>
-    </div>
+    {{else}}
+      <div class="results-recommendation-engine-training-card">
+        <div class="results-recommendation-engine-training-card-image-hero">
+          <img
+            class="results-recommendation-engine-training-card-image-hero__editor-logo"
+            src="{{@training.editorLogoUrl}}"
+            alt=""
+          />
+          <img
+            class="results-recommendation-engine-training-card-image-hero__illustration"
+            src="{{this.illustrationPath}}"
+            alt=""
+          />
+        </div>
+        <RegistrationCardTag @registrationRequired={{@training.registrationRequired}} />
+        <section class="results-recommendation-engine-training-card-content">
+          <p class="results-recommendation-engine-training-card-content__title">{{@training.title}}</p>
+          <ul class="results-recommendation-engine-training-card-content__details"><li>{{this.type}}</li>
+            <li>{{this.deliveryMode}}</li>
+            {{#if @training.hasDuration}}
+              <li>{{this.formattedDuration}}</li>
+            {{/if}}
+          </ul>
+        </section>
+        <button
+          class="results-recommendation-engine-training-card__button"
+          type="button"
+          aria-label={{t "pages.skill-review.recommended-engine.training-card.aria-label"}}
+          {{on "click" this.showModal}}
+        ></button>
+      </div>
+    {{/if}}
     <CardModal
       @training={{@training}}
       @deliveryMode={{this.deliveryMode}}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -65,7 +65,9 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     if (this.args.model.campaign.isPartOfCombinedCourse) {
       return [];
     } else {
-      return this.args.model.trainings;
+      return this.highlightedTraining
+        ? this.args.model.trainings.filter((training) => training.id !== this.highlightedTraining.id)
+        : this.args.model.trainings;
     }
   }
 
@@ -88,6 +90,10 @@ export default class EvaluationResultsRecommendationEngine extends Component {
 
   get scrollBehavior() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth';
+  }
+
+  get highlightedTraining() {
+    return this.args.model.trainings.find((training) => training.isHighlighted);
   }
 
   @action revealDrawer() {
@@ -129,7 +135,9 @@ export default class EvaluationResultsRecommendationEngine extends Component {
       <EvaluationResultsHeroRecommendationEngine
         @campaign={{@model.campaign}}
         @campaignParticipationResult={{@model.campaignParticipationResult}}
+        @highlightedTraining={{this.highlightedTraining}}
         @hasTrainings={{this.hasTrainings}}
+        @onCardClick={{this.onCardClick}}
         @onSeeRecommendationsButtonClicked={{this.onSeeRecommendationsButtonClicked}}
         @questResults={{@model.questResults}}
       />

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -18,6 +18,7 @@ export default class Training extends Model {
   @attr('boolean') registrationRequired;
   @attr('string') description;
   @attr('boolean', { allowNull: true }) isRelevant;
+  @attr('boolean') isHighlighted;
 
   @belongsTo('campaign-participation', { async: true, inverse: 'trainings' }) campaignParticipation;
 

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/card.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/card.scss
@@ -1,0 +1,54 @@
+@use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/typography';
+
+.results-recommendation-engine-highlighted-training-card {
+  display: flex;
+  flex-direction: row;
+  gap: var(--pix-spacing-4x);
+  align-items: center;
+  padding: var(--pix-spacing-6x) var(--pix-spacing-3x);
+  background-color: var(--pix-secondary-300);
+  border-radius: 16px;
+
+  @include breakpoints.device-is('desktop') {
+    width: var(--pix-spacing-6x);
+    padding-right: var(--pix-spacing-10x);
+  }
+
+  @include breakpoints.device-is('tablet') {
+    width: 85%;
+  }
+}
+
+.results-recommendation-engine-highlighted-training-card-description {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-2x);
+
+  &__title {
+    @extend %pix-title-xxs;
+
+    font-weight: var(--pix-font-extrabold);
+  }
+
+  &__information {
+    display: flex;
+    gap: var(--pix-spacing-1x);
+    color: var(--pix-neutral-800);
+    font-size: 0.75rem;
+
+    li:not(:first-child)::before {
+      margin-right: var(--pix-spacing-1x);
+      content: '\2022';
+    }
+  }
+
+  &__button {
+    width: fit-content;
+    margin-top: var(--pix-spacing-2x);
+  }
+}
+
+.results-recommendation-engine-highlighted-training-card-illustration {
+  height: 143px;
+}

--- a/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/highlighted-card.scss
+++ b/mon-pix/app/styles/components/campaigns/assessment/results/recommendation-engine/highlighted-card.scss
@@ -1,0 +1,52 @@
+@use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
+
+.highlighted-card-container {
+  max-width: 700px;
+
+}
+
+.highlighted-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-1x);
+  padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
+  color: var(--pix-neutral-900);
+  background-color: var(--pix-secondary-100);
+  border-radius: var(--pix-spacing-6x) 0 var(--pix-spacing-6x) var(--pix-spacing-6x);
+  box-shadow: var(--pix-shadow-default);
+
+  @include breakpoints.device-is('desktop'){
+    padding: var(--pix-spacing-7x);
+  }
+
+  &__title {
+    @extend %pix-title-s;
+  }
+
+  &__subtitle {
+    @extend %pix-subtitle-s;
+
+    margin-bottom: var(--pix-spacing-7x);
+  }
+}
+
+.highlighted-card-tag {
+  display: flex;
+  justify-content: flex-end;
+  text-align: end;
+
+  @extend %pix-body-s;
+
+  &__text {
+    max-width: 75%;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-3x);
+    color: var(--pix-secondary-900);
+    background-color: var(--pix-secondary-300);
+    border-radius: var(--pix-spacing-3x) var(--pix-spacing-3x) 0 0;
+
+    &--bold {
+      font-weight: var(--pix-font-bold);
+    }
+  }
+}

--- a/mon-pix/app/styles/components/campaigns/index.scss
+++ b/mon-pix/app/styles/components/campaigns/index.scss
@@ -4,4 +4,6 @@
 @use 'assessment/results/evaluation-results-tabs/trainings';
 @use 'assessment/results/recommendation-engine/acquired-badges-compact';
 @use 'assessment/results/recommendation-engine/drawer';
+@use 'assessment/results/recommendation-engine/highlighted-card';
+@use 'assessment/results/recommendation-engine/card';
 @use 'invited/learner-reconciliation';

--- a/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
+++ b/mon-pix/app/styles/pages/_evaluation-results-recommendation-engine.scss
@@ -17,8 +17,10 @@
 
 .evaluation-results-hero-recommendation-engine {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: var(--pix-spacing-6x);
+  align-items: center;
+  justify-content: center;
   min-height: 350px;
   padding: var(--pix-spacing-6x) var(--pix-spacing-3x);
   color: var(--pix-neutral-0);
@@ -31,7 +33,6 @@
     gap: var(--pix-spacing-6x);
     align-items: center;
     justify-content: center;
-    width: 100%;
   }
 
   &__title {
@@ -141,18 +142,19 @@
   }
 }
 
-@include breakpoints.device-is('tablet') {
+@include breakpoints.device-is('desktop') {
   .evaluation-results-recommendation-engine {
     padding-right: 0;
     padding-left: 0;
   }
 
   .evaluation-results-hero-recommendation-engine {
-    gap: var(--pix-spacing-10x);
+    flex-direction: row;
+    gap: var(--pix-spacing-1x);
     justify-content: space-between;
     max-width: 80rem;
     margin: 0 auto var(--pix-spacing-1x);
-    padding: var(--pix-spacing-10x) 15%;
+    padding: var(--pix-spacing-5x) var(--pix-spacing-10x) var(--pix-spacing-5x) calc(var(--pix-spacing-9x) * 2);
     background: url('/images/illustrations/results/coupe-resultat.webp') bottom 0 right 60px / 360px no-repeat,
       url('/images/illustrations/results/triangle-result.svg') bottom 0 right 0 / 460px no-repeat,
       var(--pix-gradient-default-dark);
@@ -160,8 +162,8 @@
     &__content {
       gap: var(--pix-spacing-4x);
       align-items: normal;
-      justify-content: normal;
-      min-width: min(28rem, 100%);
+      justify-content: center;
+      min-width: min(18rem, 100%);
     }
 
     &__title {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card-test.gjs
@@ -1,0 +1,79 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import HighlightedCard from 'mon-pix/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
+
+module(
+  'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | EvaluationResultsHeroRecommendationEngine | HighlightedCard',
+  function (hooks) {
+    setupIntlRenderingTest(hooks);
+
+    test('it displays an highlighted card', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      const training = store.createRecord('training', _buildTraining({}));
+
+      // when
+      const screen = await render(<template><HighlightedCard @highlightedTraining={{training}} /></template>);
+
+      // then
+      assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.highlighted-card.editor-label'))).exists();
+      const editorNames = screen.getAllByText(training.editorName);
+      assert.strictEqual(editorNames.length, 2);
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            level: 2,
+            name: t('pages.skill-review.recommended-engine.highlighted-card.title'),
+          }),
+        )
+        .exists();
+      assert.dom(screen.getByText(t('pages.skill-review.recommended-engine.highlighted-card.subtitle'))).exists();
+      const trainingTitles = screen.getAllByText(training.title);
+      assert.strictEqual(trainingTitles.length, 2);
+    });
+
+    module('when user clicks on the button to discover the program', function () {
+      test('should display a modal with training information', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({}));
+        const onCardClickStub = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template><HighlightedCard @highlightedTraining={{training}} @onCardClick={{onCardClickStub}} /></template>,
+        );
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more') }),
+        );
+
+        // then
+        assert.dom(await screen.findByRole('dialog', { name: training.title })).exists();
+      });
+    });
+
+    function _buildTraining({
+      deliveryMode = 'remote',
+      editorName = 'Pix',
+      registrationRequired = true,
+      title = 'Mon super training',
+      type = 'webinaire',
+      duration = { days: 1, hours: 2, minutes: 0 },
+    }) {
+      return {
+        title,
+        editorName,
+        duration,
+        type,
+        deliveryMode,
+        registrationRequired,
+      };
+    }
+  },
+);

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -1,4 +1,5 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 // eslint-disable-next-line no-restricted-imports
 import { click, find } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
@@ -12,6 +13,30 @@ module(
   'Integration | Components | Campaigns | Assessment | ResultsRecommendationEngine | Training | Card',
   function (hooks) {
     setupIntlRenderingTest(hooks);
+
+    module('when card displays an highlighted training', function () {
+      module('when device is mobile', function () {
+        test('should not display training illustration', async function (assert) {
+          // given
+          this.owner.register(
+            'service:media',
+            class MediaService extends Service {
+              isMobile = true;
+            },
+          );
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord('training', _buildTraining({}));
+
+          // when
+          const screen = await render(
+            <template><TrainingCard @isHighlighted={{true}} @training={{training}} /></template>,
+          );
+
+          // then
+          assert.dom(screen.queryByRole('presentation')).doesNotExist();
+        });
+      });
+    });
 
     test('it renders with correct fields', async function (assert) {
       // given

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -2300,6 +2300,12 @@
           },
           "title": "Feedback zu den Empfehlungen"
         },
+        "highlighted-card": {
+          "editor-label": "Inhalt angeboten von",
+          "learn-more": "Mehr über das Programm erfahren",
+          "subtitle": "Vertiefe bestimmte Themen mit ergänzenden Inhalten.",
+          "title": "Weil Neugier eine Stärke ist."
+        },
         "modal": {
           "actions": {
             "discover-module": "Modul starten",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2300,6 +2300,12 @@
           },
           "title": "Feedback on the recommendations"
         },
+        "highlighted-card": {
+          "editor-label": "Content offered by",
+          "learn-more": "Learn more about the programme",
+          "subtitle": "Deepen certain points with additional content.",
+          "title": "Because curiosity is a strength."
+        },
         "modal": {
           "actions": {
             "discover-module": "Start the module",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -2300,6 +2300,12 @@
           },
           "title": "Comentarios sobre las recomendaciones"
         },
+        "highlighted-card": {
+          "editor-label": "Contenido ofrecido por",
+          "learn-more": "Más información sobre el programa",
+          "subtitle": "Profundiza algunos puntos con contenido complementario.",
+          "title": "Porque la curiosidad es una fortaleza."
+        },
         "modal": {
           "actions": {
             "discover-module": "Iniciar el módulo",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2300,6 +2300,12 @@
           },
           "title": "Encart de prise de retours sur les recommandations"
         },
+        "highlighted-card": {
+          "editor-label": "Contenu proposé par",
+          "learn-more": "En savoir plus sur le programme",
+          "subtitle": "Approfondissez certains points avec des contenus complémentaires.",
+          "title": "Parce que la curiosité est une force."
+        },
         "modal": {
           "actions": {
             "discover-module": "Découvrir le module",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -2300,6 +2300,12 @@
           },
           "title": "Feedback sulle raccomandazioni"
         },
+        "highlighted-card": {
+          "editor-label": "Contenuto offerto da",
+          "learn-more": "Scopri di più sul programma",
+          "subtitle": "Approfondisci alcuni punti con contenuti complementari.",
+          "title": "Perché la curiosità è una forza."
+        },
         "modal": {
           "actions": {
             "discover-module": "Avvia il modulo",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -2300,6 +2300,12 @@
           },
           "title": "Feedback over de aanbevelingen"
         },
+        "highlighted-card": {
+          "editor-label": "Inhoud aangeboden door",
+          "learn-more": "Meer informatie over het programma",
+          "subtitle": "Verdiep bepaalde punten met aanvullende inhoud.",
+          "title": "Omdat nieuwsgierigheid een kracht is."
+        },
         "modal": {
           "actions": {
             "discover-module": "Module starten",


### PR DESCRIPTION
## ⛱️ Proposition

Dans la page de fin de parcours avec le moteur de reco, on veut afficher dans le header le CF mis en avant. 

## 🧴 Remarques

- Les seeds ont été mis à jour pour gérer toutes les locales françaises (fr et fr-fr), ainsi que pour avoir des noms différents sur les trainings
- Le layout de la page est dans le format actuel. Il n'a pas été mis à jour car on ne connaît pas encore les impacts.

## 🏊 Pour tester

- [Se connecter](https://app-pr17365.review.pix.fr/) avec Dave
- Saisir le code campagne "EDUMULTIP"
- Afficher la page de fin de parcours
- Vérifier dans le header qu'il y a un bien un CF mis en avant
- Vérifier dans le carrousel que ce même CF n'est pas présent
