### PR TITLE
[TECH] Utiliser uniquement config.redisUrl dans l'API

### DIFF
--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -302,8 +302,8 @@ export const config = {
   // Ne pas utiliser pour d'autres usages
   baseUrl: process.env.BASE_URL ?? 'https://api.pix.fr',
   bcryptNumberOfSaltRounds: _getNumber(process.env.BCRYPT_NUMBER_OF_SALT_ROUNDS, 10),
+  redisUrl: process.env.REDIS_URL,
   caching: {
-    redisUrl: process.env.REDIS_URL,
     redisCacheKeyLockTTL: parseInt(process.env.REDIS_CACHE_KEY_LOCK_TTL, 10) || 60000,
     redisCacheLockedWaitBeforeRetry: parseInt(process.env.REDIS_CACHE_LOCKED_WAIT_BEFORE_RETRY, 10) || 1000,
   },
@@ -516,9 +516,6 @@ export const config = {
     secret: process.env.REDIRECTION_URL_SECRET,
     jsonSchemaCacheMaxAge: _getNumber(process.env.DEVCOMP_MODULE_JSON_SCHEMA_CACHE_MAX_AGE, 900),
   },
-  mutex: {
-    redisUrl: process.env.REDIS_URL,
-  },
   partner: {
     fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
   },
@@ -575,7 +572,6 @@ export const config = {
   },
   temporaryStorage: {
     expirationDelaySeconds: parseInt(process.env.TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 600,
-    redisUrl: process.env.REDIS_URL,
   },
   temporaryStorageForEmailValidationDemands: {
     expirationDelaySeconds: ms(process.env.EMAIL_VALIDATION_DEMAND_TEMPORARY_STORAGE_LIFESPAN || '3d') / 1000,

--- a/api/src/shared/infrastructure/key-value-storages/index.js
+++ b/api/src/shared/infrastructure/key-value-storages/index.js
@@ -1,13 +1,10 @@
 import { config } from '../../config.js';
-
-const redisUrl = config.temporaryStorage.redisUrl;
-
 import { InMemoryKeyValueStorage } from './InMemoryKeyValueStorage.js';
 import { RedisKeyValueStorage } from './RedisKeyValueStorage.js';
 
 function _createKeyValueStorage({ prefix }) {
-  if (redisUrl) {
-    return new RedisKeyValueStorage(redisUrl, prefix);
+  if (config.redisUrl) {
+    return new RedisKeyValueStorage(config.redisUrl, prefix);
   } else {
     return new InMemoryKeyValueStorage();
   }

--- a/api/src/shared/infrastructure/mutex/RedisMutex.js
+++ b/api/src/shared/infrastructure/mutex/RedisMutex.js
@@ -42,7 +42,7 @@ class RedisMutex {
   }
 }
 
-export const redisMutex = new RedisMutex({ redisUrl: config.mutex.redisUrl });
+export const redisMutex = new RedisMutex({ redisUrl: config.redisUrl });
 
 export function quitMutex() {
   return redisMutex.quit();

--- a/api/src/shared/infrastructure/pubsub.js
+++ b/api/src/shared/infrastructure/pubsub.js
@@ -25,15 +25,15 @@ function getPubSub() {
   if (pubSub) return pubSub;
 
   try {
-    if (!config.caching.redisUrl) {
+    if (!config.redisUrl) {
       pubSub = createPubSub();
       return pubSub;
     }
 
-    publishClient = new Redis(config.caching.redisUrl);
+    publishClient = new Redis(config.redisUrl);
     publishClient.on('error', (err) => logger.error({ err }, 'PubSub : error in Publish client'));
 
-    subscribeClient = new Redis(config.caching.redisUrl);
+    subscribeClient = new Redis(config.redisUrl);
     subscribeClient.on('error', (err) => logger.error({ err }, 'PubSub : error in Subscribe client'));
 
     pubSub = createPubSub({

--- a/api/src/shared/infrastructure/utils/redis-monitor.js
+++ b/api/src/shared/infrastructure/utils/redis-monitor.js
@@ -3,8 +3,8 @@ import { RedisClient } from './RedisClient.js';
 
 class RedisMonitor {
   constructor() {
-    if (config.caching.redisUrl) {
-      this._client = new RedisClient(config.caching.redisUrl, { name: 'redis-monitor' });
+    if (config.redisUrl) {
+      this._client = new RedisClient(config.redisUrl, { name: 'redis-monitor' });
     }
   }
 

--- a/api/tests/shared/integration/infrastructure/temporary-storage/RedisKeyValueStorage_test.js
+++ b/api/tests/shared/integration/infrastructure/temporary-storage/RedisKeyValueStorage_test.js
@@ -5,157 +5,151 @@ import { expect } from 'chai';
 import { config } from '../../../../../src/shared/config.js';
 import { RedisKeyValueStorage } from '../../../../../src/shared/infrastructure/key-value-storages/RedisKeyValueStorage.js';
 
-const REDIS_URL = config.caching.redisUrl;
-
 describe('Integration | Infrastructure | KeyValueStorage | RedisKeyValueStorage', function () {
-  // this check is used to prevent failure when redis is not setup
+  describe('#set', function () {
+    it('should set new value', async function () {
+      // given
+      const TWO_MINUTES_IN_SECONDS = 2 * 60;
+      const value = { url: 'url' };
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
+      const key = await storage.save({ value: 'c', expirationDelaySeconds: TWO_MINUTES_IN_SECONDS });
 
-  if (REDIS_URL !== undefined) {
-    describe('#set', function () {
-      it('should set new value', async function () {
-        // given
-        const TWO_MINUTES_IN_SECONDS = 2 * 60;
-        const value = { url: 'url' };
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
-        const key = await storage.save({ value: 'c', expirationDelaySeconds: TWO_MINUTES_IN_SECONDS });
+      // when
+      await storage.update(key, value);
 
-        // when
-        await storage.update(key, value);
-
-        // then
-        const result = await storage.get(key);
-        const expirationDelaySeconds = await storage._client.ttl(key);
-        expect(result).to.deep.equal({ url: 'url' });
-        expect(expirationDelaySeconds).to.equal(TWO_MINUTES_IN_SECONDS);
-      });
-
-      it('should set new value with no expiration', async function () {
-        // given
-        const NO_EXPIRATION = -1; // See https://redis.io/docs/latest/commands/ttl/
-        const value = { url: 'url' };
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
-        const key = await storage.save({ value: 'c' });
-
-        // when
-        await storage.update(key, value);
-
-        // then
-        const result = await storage.get(key);
-        const expirationDelaySeconds = await storage._client.ttl(key);
-        expect(result).to.deep.equal({ url: 'url' });
-        expect(expirationDelaySeconds).to.equal(NO_EXPIRATION);
-      });
+      // then
+      const result = await storage.get(key);
+      const expirationDelaySeconds = await storage._client.ttl(key);
+      expect(result).to.deep.equal({ url: 'url' });
+      expect(expirationDelaySeconds).to.equal(TWO_MINUTES_IN_SECONDS);
     });
 
-    describe('#expire', function () {
-      it('should add an expiration time to the list', async function () {
-        // given
-        const key = randomUUID();
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
+    it('should set new value with no expiration', async function () {
+      // given
+      const NO_EXPIRATION = -1; // See https://redis.io/docs/latest/commands/ttl/
+      const value = { url: 'url' };
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
+      const key = await storage.save({ value: 'c' });
 
-        // when
-        await storage.lpush(key, 'value');
-        const result = await storage.expire({ key, expirationDelaySeconds: 1 });
-        await new Promise((resolve) => setTimeout(resolve, 1200));
-        const list = await storage.lrange(key);
+      // when
+      await storage.update(key, value);
 
-        // then
-        expect(result).to.equal(1);
-        expect(list).to.be.empty;
-      });
+      // then
+      const result = await storage.get(key);
+      const expirationDelaySeconds = await storage._client.ttl(key);
+      expect(result).to.deep.equal({ url: 'url' });
+      expect(expirationDelaySeconds).to.equal(NO_EXPIRATION);
     });
+  });
 
-    describe('#ttl', function () {
-      it('should retrieve the remaining expiration time from a list', async function () {
-        // given
-        const key = randomUUID();
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
+  describe('#expire', function () {
+    it('should add an expiration time to the list', async function () {
+      // given
+      const key = randomUUID();
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
 
-        // when
-        await storage.lpush(key, 'value');
-        await storage.expire({ key, expirationDelaySeconds: 120 });
-        const remainingExpirationSeconds = await storage.ttl(key);
+      // when
+      await storage.lpush(key, 'value');
+      const result = await storage.expire({ key, expirationDelaySeconds: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      const list = await storage.lrange(key);
 
-        // then
-        expect(remainingExpirationSeconds).to.equal(120);
-      });
+      // then
+      expect(result).to.equal(1);
+      expect(list).to.be.empty;
     });
+  });
 
-    describe('#lpush', function () {
-      it('should add a value to a list and return the length of the list', async function () {
-        // given
-        const key = randomUUID();
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
+  describe('#ttl', function () {
+    it('should retrieve the remaining expiration time from a list', async function () {
+      // given
+      const key = randomUUID();
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
 
-        // when
-        const length = await storage.lpush(key, 'value');
+      // when
+      await storage.lpush(key, 'value');
+      await storage.expire({ key, expirationDelaySeconds: 120 });
+      const remainingExpirationSeconds = await storage.ttl(key);
 
-        // then
-        expect(length).to.equal(1);
-        await storage.delete(key);
-      });
+      // then
+      expect(remainingExpirationSeconds).to.equal(120);
     });
+  });
 
-    describe('#lrem', function () {
-      it('should remove a value from a list and return the number of removed elements', async function () {
-        // given
-        const key = randomUUID();
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
+  describe('#lpush', function () {
+    it('should add a value to a list and return the length of the list', async function () {
+      // given
+      const key = randomUUID();
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
 
-        await storage.lpush(key, 'value1');
-        await storage.lpush(key, 'value1');
-        await storage.lpush(key, 'value2');
+      // when
+      const length = await storage.lpush(key, 'value');
 
-        // when
-        const length = await storage.lrem(key, 'value1');
-
-        // then
-        expect(length).to.equal(2);
-        await storage.delete(key);
-      });
+      // then
+      expect(length).to.equal(1);
+      await storage.delete(key);
     });
+  });
 
-    describe('#lrange', function () {
-      it('should return a list of values', async function () {
-        // given
-        const key = randomUUID();
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
+  describe('#lrem', function () {
+    it('should remove a value from a list and return the number of removed elements', async function () {
+      // given
+      const key = randomUUID();
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
 
-        // when
-        await storage.lpush(key, 'value1');
-        await storage.lpush(key, 'value1');
-        const length = await storage.lpush(key, 'value2');
-        const values = await storage.lrange(key);
+      await storage.lpush(key, 'value1');
+      await storage.lpush(key, 'value1');
+      await storage.lpush(key, 'value2');
 
-        // then
-        expect(length).to.equal(3);
-        expect(values).to.deep.equal(['value2', 'value1', 'value1']);
-        await storage.delete(key);
-      });
+      // when
+      const length = await storage.lrem(key, 'value1');
+
+      // then
+      expect(length).to.equal(2);
+      await storage.delete(key);
     });
+  });
 
-    describe('#keys', function () {
-      it('should return matching keys', async function () {
-        // given
-        const oneMinute = 60;
-        const pattern = 'prefix:*';
-        const storage = new RedisKeyValueStorage(REDIS_URL, 'some-prefix:');
-        await storage.save({ key: 'prefix:key1', value: true, expirationDelaySeconds: oneMinute });
-        await storage.save({ key: 'prefix:key2', value: true, expirationDelaySeconds: oneMinute });
-        await storage.save({ key: 'prefix:key3', value: true, expirationDelaySeconds: oneMinute });
-        await storage.save({ key: 'otherprefix:key4', value: true, expirationDelaySeconds: oneMinute });
+  describe('#lrange', function () {
+    it('should return a list of values', async function () {
+      // given
+      const key = randomUUID();
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
 
-        // when
-        const keys = await storage.keys(pattern);
+      // when
+      await storage.lpush(key, 'value1');
+      await storage.lpush(key, 'value1');
+      const length = await storage.lpush(key, 'value2');
+      const values = await storage.lrange(key);
 
-        // then
-        expect(keys).to.exactlyContain(['prefix:key1', 'prefix:key2', 'prefix:key3']);
-
-        await storage.delete('prefix:key1');
-        await storage.delete('prefix:key2');
-        await storage.delete('prefix:key3');
-        await storage.delete('otherprefix:key4');
-      });
+      // then
+      expect(length).to.equal(3);
+      expect(values).to.deep.equal(['value2', 'value1', 'value1']);
+      await storage.delete(key);
     });
-  }
+  });
+
+  describe('#keys', function () {
+    it('should return matching keys', async function () {
+      // given
+      const oneMinute = 60;
+      const pattern = 'prefix:*';
+      const storage = new RedisKeyValueStorage(config.redisUrl, 'some-prefix:');
+      await storage.save({ key: 'prefix:key1', value: true, expirationDelaySeconds: oneMinute });
+      await storage.save({ key: 'prefix:key2', value: true, expirationDelaySeconds: oneMinute });
+      await storage.save({ key: 'prefix:key3', value: true, expirationDelaySeconds: oneMinute });
+      await storage.save({ key: 'otherprefix:key4', value: true, expirationDelaySeconds: oneMinute });
+
+      // when
+      const keys = await storage.keys(pattern);
+
+      // then
+      expect(keys).to.exactlyContain(['prefix:key1', 'prefix:key2', 'prefix:key3']);
+
+      await storage.delete('prefix:key1');
+      await storage.delete('prefix:key2');
+      await storage.delete('prefix:key3');
+      await storage.delete('otherprefix:key4');
+    });
+  });
 });

--- a/api/tests/shared/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/shared/integration/infrastructure/utils/RedisClient_test.js
@@ -7,14 +7,14 @@ import { RedisClient } from '../../../../../src/shared/infrastructure/utils/Redi
 
 describe('Integration | Infrastructure | Utils | RedisClient', function () {
   beforeEach(async function () {
-    const redisClient = new RedisClient(config.caching.redisUrl);
+    const redisClient = new RedisClient(config.redisUrl);
     await redisClient.flushall();
   });
 
   it('stores and retrieve a value for a key', async function () {
     // given
     const key = new Date().toISOString();
-    const redisClient = new RedisClient(config.caching.redisUrl);
+    const redisClient = new RedisClient(config.redisUrl);
 
     // when
     await redisClient.set(key, 'value');
@@ -28,7 +28,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
   it('should delete a value with prefix', async function () {
     // given
     const value = new Date().toISOString();
-    const redisClientWithPrefix = new RedisClient(config.caching.redisUrl, { prefix: 'client-prefix:' });
+    const redisClientWithPrefix = new RedisClient(config.redisUrl, { prefix: 'client-prefix:' });
     await redisClientWithPrefix.set('AVRIL', value);
 
     // when
@@ -40,8 +40,8 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should separate storage for identical keys saved with different prefixes', async function () {
     // given
-    const redisClient1 = new RedisClient(config.caching.redisUrl, { prefix: 'test1' });
-    const redisClient2 = new RedisClient(config.caching.redisUrl, { prefix: 'test2' });
+    const redisClient1 = new RedisClient(config.redisUrl, { prefix: 'test1' });
+    const redisClient2 = new RedisClient(config.redisUrl, { prefix: 'test2' });
     await redisClient1.set('key', 'value1');
     await redisClient2.set('key', 'value2');
 
@@ -56,7 +56,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
     // given
     const keyToAdd = randomUUID();
     const keyToRemove = randomUUID();
-    const redisClient = new RedisClient(config.caching.redisUrl);
+    const redisClient = new RedisClient(config.redisUrl);
 
     await redisClient.lpush(keyToAdd, 'value2');
 
@@ -85,7 +85,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should create value and decrement it to -1', async function () {
     // given
-    const client = new RedisClient(config.caching.redisUrl);
+    const client = new RedisClient(config.redisUrl);
 
     // when
     await client.decr('toto');
@@ -96,7 +96,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should decrement value', async function () {
     // given
-    const client = new RedisClient(config.caching.redisUrl);
+    const client = new RedisClient(config.redisUrl);
     await client.set('toto', 1);
 
     // when
@@ -108,7 +108,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should create value and increment it to 1', async function () {
     // given
-    const client = new RedisClient(config.caching.redisUrl);
+    const client = new RedisClient(config.redisUrl);
 
     // when
     await client.incr('toto');
@@ -119,7 +119,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should increment value', async function () {
     // given
-    const client = new RedisClient(config.caching.redisUrl);
+    const client = new RedisClient(config.redisUrl);
     await client.set('toto', 1);
 
     // when
@@ -131,7 +131,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should flush all values', async function () {
     // given
-    const client = new RedisClient(config.caching.redisUrl);
+    const client = new RedisClient(config.redisUrl);
     await client.set('toto', 'tata');
 
     // when
@@ -143,7 +143,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
 
   it('should ping redis', async function () {
     // given
-    const client = new RedisClient(config.caching.redisUrl);
+    const client = new RedisClient(config.redisUrl);
 
     // when
     const result = await client.ping();
@@ -155,7 +155,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
   describe('quit', function () {
     it('should close the connection', async function () {
       // given
-      const client = new RedisClient(config.caching.redisUrl);
+      const client = new RedisClient(config.redisUrl);
 
       // when
       await client.quit();
@@ -167,7 +167,7 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
     context('when the connection is already closed', function () {
       it('should not throw an error', async function () {
         // given
-        const client = new RedisClient(config.caching.redisUrl);
+        const client = new RedisClient(config.redisUrl);
 
         // when
         await client.quit();


### PR DESCRIPTION
## ☀️ Problème

On a 3 variables de config qui pointent vers la même `redisUrl`:
- `config.temporaryStorage.redisUrl`
- `config.caching.redisUrl`
- `config.mutex.redisUrl`

## ⛱️ Proposition

Utiliser uniquement `config.redisUrl` pour l'URL de Redis.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Tests CI ok
