### PR TITLE
[TECH] Supprimer lodash derechef

### DIFF
--- a/orga/app/components/authentication/login-form.gjs
+++ b/orga/app/components/authentication/login-form.gjs
@@ -8,7 +8,6 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import get from 'lodash/get';
 import { createFormValidation } from 'pix-orga/utils/form-validation';
 
 const VALIDATION_ERRORS = {
@@ -54,7 +53,7 @@ export default class LoginForm extends Component {
       await this.args.onSubmit(login, this.password);
     } catch (error) {
       // Handling error for those different cases: EmberSimpleAuth, JSON:API response, non-JSON:API response
-      const extractedError = get(error, error.responseJSON ? 'responseJSON.errors[0]' : 'errors[0]') ?? error;
+      const extractedError = (error.responseJSON ? error?.responseJSON?.errors?.[0] : error?.errors?.[0]) ?? error;
 
       // TODO: should be managed with a code instead of status only
       const isInvitationAlreadyAcceptedByAnotherUser = extractedError.status === '409';

--- a/orga/app/components/authentication/oidc-signup-form.gjs
+++ b/orga/app/components/authentication/oidc-signup-form.gjs
@@ -8,7 +8,6 @@ import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
-import get from 'lodash/get';
 
 export default class OidcSignupForm extends Component {
   @service intl;
@@ -63,7 +62,7 @@ export default class OidcSignupForm extends Component {
     try {
       await this.args.onSubmit();
     } catch (responseError) {
-      const error = get(responseError, 'errors[0]');
+      const error = responseError?.errors?.[0];
       this.signupErrorMessage = this.authErrorMessages.getAuthenticationErrorMessage(error);
     } finally {
       this.isLoading = false;

--- a/orga/app/components/authentication/signup-form/index.gjs
+++ b/orga/app/components/authentication/signup-form/index.gjs
@@ -7,7 +7,6 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
-import get from 'lodash/get';
 
 import isEmailValid from '../../../utils/email-validator';
 import { createFormValidation } from '../../../utils/form-validation';
@@ -111,7 +110,7 @@ export default class SignupForm extends Component {
 
   #getApiErrorMessage(errorResponse) {
     // EmberAdapter and EmberSimpleAuth use different error formats, so we manage both cases below
-    const error = get(errorResponse, errorResponse?.isAdapterError ? 'errors[0]' : 'responseJSON.errors[0]');
+    const error = errorResponse?.isAdapterError ? errorResponse?.errors?.[0] : errorResponse?.responseJSON?.errors?.[0];
     return this.authErrorMessages.getAuthenticationErrorMessage(error);
   }
 

--- a/orga/app/routes/authentication/oidc/flow.js
+++ b/orga/app/routes/authentication/oidc/flow.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import get from 'lodash/get';
 import ENV from 'pix-orga/config/environment';
 
 import Location from '../../../utils/location';
@@ -119,7 +118,7 @@ export default class LoginOidcRoute extends Route {
 
       return { identityProviderSlug, shouldCreateUserAccount: false };
     } catch (response) {
-      const apiError = get(response, 'errors[0]');
+      const apiError = response?.errors?.[0];
       if (!apiError) {
         throw response;
       }

--- a/orga/app/services/auth-error-messages.js
+++ b/orga/app/services/auth-error-messages.js
@@ -1,5 +1,4 @@
 import Service, { service } from '@ember/service';
-import get from 'lodash/get';
 
 const DEFAULT_MESSAGE = { i18nKey: 'common.api-error-messages.default' };
 
@@ -80,7 +79,7 @@ export default class AuthErrorMessagesService extends Service {
   @service url;
 
   getHttpErrorMessage(originalError, defaultMessage = DEFAULT_MESSAGE) {
-    const error = get(originalError, 'errors[0]') || originalError;
+    const error = originalError?.errors?.[0] || originalError;
 
     const message = HTTP_STATUS_MAPPING[error?.status];
 
@@ -88,7 +87,7 @@ export default class AuthErrorMessagesService extends Service {
   }
 
   getAuthenticationErrorMessage(originalError) {
-    const error = get(originalError, 'errors[0]') || originalError;
+    const error = originalError?.errors?.[0] || originalError;
     const message = AUTHENTICATION_ERROR_CODES_MAPPING[error?.code];
     if (!message) {
       return this.getHttpErrorMessage(originalError, AUTHENTICATION_DEFAULT_MESSAGE);

--- a/orga/app/utils/camel-case.ts
+++ b/orga/app/utils/camel-case.ts
@@ -1,0 +1,3 @@
+export default function toCamelCase(attribute: string): string {
+  return attribute.replace(/[-_](.)/g, (_, char: string) => char.toUpperCase());
+}

--- a/orga/app/utils/form-validation.ts
+++ b/orga/app/utils/form-validation.ts
@@ -1,5 +1,5 @@
 import { tracked } from '@glimmer/tracking';
-import camelCase from 'lodash/camelCase.js';
+import camelCase from 'pix-orga/utils/camel-case';
 
 const COMMON_API_ERROR = 'common.error';
 

--- a/orga/eslint.config.mjs
+++ b/orga/eslint.config.mjs
@@ -60,7 +60,17 @@ export default [
     },
     rules: {
       'no-irregular-whitespace': 'off',
-      'no-restricted-imports': ['error', { paths: ['lodash'] }],
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['lodash', 'lodash/*', 'lodash-es', 'lodash-es/*', 'lodash.*'],
+              message: 'lodash is not a dependency of this app no more. Use native JS or a small helper in app/utils.',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/orga/tests/unit/utils/camel-case-test.ts
+++ b/orga/tests/unit/utils/camel-case-test.ts
@@ -1,0 +1,20 @@
+import { setupTest } from 'ember-qunit';
+import toCamelCase from 'pix-orga/utils/camel-case';
+import { module, test } from 'qunit';
+
+module('Unit | Utils | camel case', function (hooks) {
+  setupTest(hooks);
+
+  [
+    { attribute: 'first-name', expected: 'firstName' },
+    { attribute: 'last_name', expected: 'lastName' },
+    { attribute: 'email', expected: 'email' },
+    { attribute: 'cgu', expected: 'cgu' },
+    { attribute: 'organization-learner-id', expected: 'organizationLearnerId' },
+    { attribute: '', expected: '' },
+  ].forEach(function ({ attribute, expected }) {
+    test(`should convert "${attribute}" to "${expected}"`, function (assert) {
+      assert.strictEqual(toCamelCase(attribute), expected);
+    });
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

On avait déjà supprime Lodash ( https://github.com/1024pix/pix/pull/13822 ) mais la lib a été réintroduite dans l'application sans ajouter de dépendance explicite dans le fichier `package.json`.

## ⛱️ Proposition

- Internaliser  `get` et `toCamelCase`
- Ajouter une règle de lint pour éviter de réintroduire malencontreusement la lib.

## 🏊 Pour tester

- 🟩
- Checkout la branch, utiliser Lodash sur PixOrga, se faire disputer