### PR TITLE
[TECH] Déplace la configuration des seeds dans son propre fichier.

### DIFF
--- a/api/config/seeds-config.js
+++ b/api/config/seeds-config.js
@@ -1,0 +1,34 @@
+const SEEDS_CONTEXTS = [
+  'prescription',
+  'devcomp',
+  'junior',
+  'acces',
+  'contenu',
+  'certification',
+  'evaluation',
+  'acquisition',
+];
+
+export const seedsConfig = getSeedsConfig();
+
+function getSeedsConfig() {
+  const context = buildSeedsContext(process.env.SEEDS_CONTEXT);
+
+  const frameworks = process.env.SEEDS_LEARNING_CONTENT_FRAMEWORKS?.split(',') ?? ['Pix', 'Droit', 'Edu', 'Modulix'];
+  if (context.junior && !frameworks.includes('Pix 1D')) {
+    frameworks.push('Pix 1D');
+  }
+
+  return {
+    context,
+    learningContent: {
+      frameworks,
+      locales: process.env.SEEDS_LEARNING_CONTENT_LOCALES?.split(',') ?? ['fr-fr', 'en', 'nl', 'nl-BE'],
+    },
+  };
+}
+
+function buildSeedsContext(value) {
+  const values = value && value.length ? value.toLowerCase().split('|') : SEEDS_CONTEXTS;
+  return Object.fromEntries(Array.from(SEEDS_CONTEXTS, (v) => [v, values.includes(v)]));
+}

--- a/api/datamart/seeds/populate-calibrations.js
+++ b/api/datamart/seeds/populate-calibrations.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { seedsConfig } from '../../config/seeds-config.js';
 import { knex as apiKnex } from '../../db/knex-database-connection.js';
 import {
   CALIBRATION_SCOPES,
@@ -7,7 +8,6 @@ import {
   fromCalibrationScope,
 } from '../../src/certification/configuration/domain/models/Calibration.js';
 import { VERSION_STATUSES } from '../../src/certification/configuration/domain/models/Version.js';
-import { config } from '../../src/shared/config.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { knex as datamartKnex } from '../knex-database-connection.js';
 
@@ -123,7 +123,7 @@ async function removeExistingCalibrationData() {
 }
 
 export async function seed() {
-  if (!config.seeds.context.certification) {
+  if (!seedsConfig.context.certification) {
     logger.info('Certification seeds are disabled, skipping calibrations');
     return;
   }

--- a/api/db/seeds/data/common/learningcontent-builder.js
+++ b/api/db/seeds/data/common/learningcontent-builder.js
@@ -1,4 +1,4 @@
-import { config } from '../../../../src/shared/config.js';
+import { seedsConfig } from '../../../../config/seeds-config.js';
 import { lcmsClient } from '../../../../src/shared/infrastructure/lcms-client.js';
 import { logger, SCOPES } from '../../../../src/shared/infrastructure/utils/logger.js';
 
@@ -8,7 +8,7 @@ export async function learningContentBuilder({ databaseBuilder }) {
   const totalCounts = Object.entries(learningContent).map(([model, entities]) => [model, entities.length]);
 
   learningContent.frameworks = learningContent.frameworks.filter((framework) =>
-    config.seeds.learningContent.frameworks.includes(framework.name),
+    seedsConfig.learningContent.frameworks.includes(framework.name),
   );
 
   learningContent.areas = learningContent.areas.filter(belongsToOneOfFrameworks(learningContent.frameworks));
@@ -26,7 +26,7 @@ export async function learningContentBuilder({ databaseBuilder }) {
   learningContent.challenges = learningContent.challenges
     .filter(belongsToOneOfSkills(learningContent.skills))
     .filter(isValidatedOrArchived)
-    .filter(hasOneOfLocales(config.seeds.learningContent.locales))
+    .filter(hasOneOfLocales(seedsConfig.learningContent.locales))
     .filter(keepingPrototypeAndOneAlternativeBySkillAndLocale());
 
   learningContent.tutorials = learningContent.tutorials.filter(isUsedByOneOf(learningContent.skills));

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,4 +1,4 @@
-import { config } from '../../src/shared/config.js';
+import { seedsConfig } from '../../config/seeds-config.js';
 import { logger } from '../../src/shared/infrastructure/utils/logger.js';
 import { DatabaseBuilder } from '../database-builder/database-builder.js';
 import { databaseConnection } from '../knex-database-connection.js';
@@ -40,43 +40,43 @@ export async function seed() {
   await organizationBuilder({ databaseBuilder });
 
   // SCOPE
-  if (config.seeds.context.prescription) {
+  if (seedsConfig.context.prescription) {
     logger.info('Seeding : Prescription');
     await teamPrescriptionDataBuilder({ databaseBuilder });
   }
 
-  if (config.seeds.context.devcomp) {
+  if (seedsConfig.context.devcomp) {
     logger.info('Seeding : Devcomp');
     await teamDevcompDataBuilder({ databaseBuilder });
   }
 
-  if (config.seeds.context.acces) {
+  if (seedsConfig.context.acces) {
     logger.info('Seeding : Acces');
     await teamAccesDataBuilder(databaseBuilder);
   }
 
-  if (config.seeds.context.junior) {
+  if (seedsConfig.context.junior) {
     logger.info('Seeding : Junior');
     await team1dDataBuilder(databaseBuilder);
   }
 
-  if (config.seeds.context.contenu) {
+  if (seedsConfig.context.contenu) {
     logger.info('Seeding : Contenu');
     await teamContenuDataBuilder({ databaseBuilder });
   }
 
-  if (config.seeds.context.certification) {
+  if (seedsConfig.context.certification) {
     logger.info('Seeding : Certification');
     await complementaryCertificationBuilder({ databaseBuilder });
     await teamCertificationDataBuilder({ databaseBuilder });
   }
 
-  if (config.seeds.context.evaluation) {
+  if (seedsConfig.context.evaluation) {
     logger.info('Seeding : Evaluation');
     await teamEvaluationDataBuilder({ databaseBuilder });
   }
 
-  if (config.seeds.context.acquisition) {
+  if (seedsConfig.context.acquisition) {
     logger.info('Seeding : Acquisition');
     teamAcquisitionDataBuilder({ databaseBuilder });
   }

--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig([
     files: [
       'tests/setup/*.js',
       'src/shared/config.js',
+      'config/seeds-config.js',
       'db/migrations/*.js',
       'src/shared/infrastructure/validate-environment-variables.js',
       'src/shared/infrastructure/open-telemetry/scalingo-detector.js',

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -82,39 +82,6 @@ function isEnabledByContainerModulo(envVarValue) {
   return containerIndex % modulo === 0;
 }
 
-function getSeedsConfig() {
-  const context = buildSeedsContext(process.env.SEEDS_CONTEXT);
-
-  const frameworks = process.env.SEEDS_LEARNING_CONTENT_FRAMEWORKS?.split(',') ?? ['Pix', 'Droit', 'Edu', 'Modulix'];
-  if (context.junior && !frameworks.includes('Pix 1D')) {
-    frameworks.push('Pix 1D');
-  }
-
-  return {
-    context,
-    learningContent: {
-      frameworks,
-      locales: process.env.SEEDS_LEARNING_CONTENT_LOCALES?.split(',') ?? ['fr-fr', 'en', 'nl', 'nl-BE'],
-    },
-  };
-}
-
-const SEEDS_CONTEXTS = [
-  'prescription',
-  'devcomp',
-  'junior',
-  'acces',
-  'contenu',
-  'certification',
-  'evaluation',
-  'acquisition',
-];
-
-function buildSeedsContext(value) {
-  const values = value && value.length ? value.toLowerCase().split('|') : SEEDS_CONTEXTS;
-  return Object.fromEntries(Array.from(SEEDS_CONTEXTS, (v) => [v, values.includes(v)]));
-}
-
 export const schema = Joi.object({
   MADDO: Joi.boolean().optional().default(false),
   ACCESS_TOKEN_LIFESPAN: Joi.string().optional(),
@@ -565,7 +532,6 @@ export const config = {
     },
     accessTokenLifespanMs: ms(process.env.SAML_ACCESS_TOKEN_LIFESPAN || '7d'),
   },
-  seeds: getSeedsConfig(),
   passwordResetDemand: {
     secret: process.env.AUTH_SECRET,
     lifespan: process.env.PASSWORD_RESET_DEMAND_LIFESPAN || '1h',


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
La configuration des seeds est faite dans la configuration de l'application alors que c'est utile uniquement pour le développpement.

## ⛱️ Proposition

On extrait la configuration des seeds dans son propre fichier `config/seeds-config.js`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧴 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

Seeder avec les commandes `npm run db:seed` et `npm run datamart:seed`.
Essayer en changeant le context (via la variable d'environnement `SEEDS_CONTEXT`).

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
