### PR TITLE
[TECH] Supprime les variables d'environnement `CYPRESS_` et `PLAYWRIGHT_`.

### DIFF
--- a/.circleci/jobs.yml
+++ b/.circleci/jobs.yml
@@ -15,16 +15,16 @@ version: 2.1
 parameters:
   GHA_Actor:
     type: string
-    default: ""
+    default: ''
   GHA_Action:
     type: string
-    default: ""
+    default: ''
   GHA_Event:
     type: string
-    default: ""
+    default: ''
   GHA_Meta:
     type: string
-    default: ""
+    default: ''
   # Set by path-filtering orb based on changed files
   run-api:
     type: boolean
@@ -85,15 +85,15 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>
       - image: postgres:16.9-alpine
-        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
+        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: "--nosync"
+          POSTGRES_INITDB_ARGS: '--nosync'
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.1.0@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2
         environment:
-          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test,pix-answers-history-export-test"
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: 'pix-import-test,pix-answers-history-export-test'
     resource_class: medium
   node-browsers-docker:
     parameters:
@@ -115,11 +115,11 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
       - image: postgres:16.9-alpine
-        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
+        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: "--nosync"
+          POSTGRES_INITDB_ARGS: '--nosync'
       - image: redis:7.2.11-alpine
     resource_class: medium
   node-postgres-docker:
@@ -131,11 +131,11 @@ executors:
     docker:
       - image: cimg/node:<<parameters.node-version>>
       - image: postgres:16.9-alpine
-        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
+        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: "--nosync"
+          POSTGRES_INITDB_ARGS: '--nosync'
     resource_class: medium
   playwright-executor-medium:
     docker:
@@ -144,15 +144,15 @@ executors:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - image: postgres:16.9-alpine
-        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
+        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: "--nosync"
+          POSTGRES_INITDB_ARGS: '--nosync'
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.1.0@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2
         environment:
-          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test,pix-answers-history-export-test"
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: 'pix-import-test,pix-answers-history-export-test'
     resource_class: medium
   playwright-executor-large:
     docker:
@@ -161,15 +161,15 @@ executors:
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - image: postgres:16.9-alpine
-        command: ["postgres", "-c", "fsync=off", "-c", "full_page_writes=off"]
+        command: ['postgres', '-c', 'fsync=off', '-c', 'full_page_writes=off']
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_INITDB_ARGS: "--nosync"
+          POSTGRES_INITDB_ARGS: '--nosync'
       - image: redis:7.2.11-alpine
       - image: adobe/s3mock:5.1.0@sha256:65cf60155a2e235fe7d5bf6c633747d6fc7ed93f9f5a6727d86470026b83c2a2
         environment:
-          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: "pix-import-test,pix-answers-history-export-test"
+          COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS: 'pix-import-test,pix-answers-history-export-test'
     resource_class: large
 
 # ---------------------------------------------------------------------------
@@ -320,7 +320,7 @@ workflows:
           requires:
             - mon_pix_install
       - e2e_test_mon_pix:
-          context: pix-e2e-secrets
+          context: pix-cypress-secrets
           requires:
             - mon_pix_install
 
@@ -335,7 +335,7 @@ workflows:
           requires:
             - orga_install
       - e2e_test_orga:
-          context: pix-e2e-secrets
+          context: pix-cypress-secrets
           requires:
             - orga_install
 
@@ -374,14 +374,14 @@ workflows:
 
       # --- E2E Playwright ---
       - e2e_playwright_test:
-          context: pix-e2e-secrets
+          context: pix-playwright-secrets
           requires:
             - api_install
             - mon_pix_install
             - orga_install
             - certif_install
       - e2e_playwright_test_recette_certif:
-          context: pix-e2e-secrets
+          context: pix-playwright-secrets
           requires:
             - api_install
             - mon_pix_install
@@ -997,13 +997,13 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm run db:prepare
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1016,16 +1016,16 @@ jobs:
           name: Start Pix API
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
             DATAMART_DATABASE_URL: postgres://circleci@localhost:5432/circleci_datamart
-            REDIS_URL: "redis://localhost:6379"
-            START_JOB_IN_WEB_PROCESS: "true"
-            AUTH_SECRET: "the-password-must-be-at-least-32-characters-long"
-            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
-            LOG_ENABLED: "true"
-            LOG_LEVEL: "trace"
-            REDIRECTION_URL_SECRET: "secret"
+            REDIS_URL: 'redis://localhost:6379'
+            START_JOB_IN_WEB_PROCESS: 'true'
+            AUTH_SECRET: 'the-password-must-be-at-least-32-characters-long'
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: '777'
+            LOG_ENABLED: 'true'
+            LOG_LEVEL: 'trace'
+            REDIRECTION_URL_SECRET: 'secret'
           background: true
           command: npm start
       - run:
@@ -1036,9 +1036,9 @@ jobs:
       - run:
           name: Run tests
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            AUTH_SECRET: "the-password-must-be-at-least-32-characters-long"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            AUTH_SECRET: 'the-password-must-be-at-least-32-characters-long'
           command: npm run test:ci:app
       - store_test_results:
           path: /home/circleci/test-results
@@ -1087,13 +1087,13 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm run db:prepare
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1106,16 +1106,16 @@ jobs:
           name: Start Pix API
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
             DATAMART_DATABASE_URL: postgres://circleci@localhost:5432/circleci_datamart
-            REDIS_URL: "redis://localhost:6379"
-            START_JOB_IN_WEB_PROCESS: "true"
-            AUTH_SECRET: "the-password-must-be-at-least-32-characters-long"
-            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
-            LOG_ENABLED: "true"
-            LOG_LEVEL: "trace"
-            REDIRECTION_URL_SECRET: "secret"
+            REDIS_URL: 'redis://localhost:6379'
+            START_JOB_IN_WEB_PROCESS: 'true'
+            AUTH_SECRET: 'the-password-must-be-at-least-32-characters-long'
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: '777'
+            LOG_ENABLED: 'true'
+            LOG_LEVEL: 'trace'
+            REDIRECTION_URL_SECRET: 'secret'
           background: true
           command: npm start
       - run:
@@ -1126,8 +1126,8 @@ jobs:
       - run:
           name: Run tests
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm run test:ci:orga
       - store_test_results:
           path: /home/circleci/test-results
@@ -1166,12 +1166,11 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
-            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            LCMS_API_RELEASE_ID: "2509?forCI"
-            IS_RUNNING_PLAYWRIGHT: "true"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
+            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            LCMS_API_RELEASE_ID: '2509?forCI'
           command: npm run db:prepare && npm run datamart:prepare && npm run datawarehouse:prepare
       - run:
           name: Start Pix API
@@ -1179,26 +1178,25 @@ jobs:
           command: npm start
           background: true
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
-            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            REDIS_URL: "redis://localhost:6379"
-            START_JOB_IN_WEB_PROCESS: "true"
-            MAILING_ENABLED: "false"
-            AUTH_SECRET: "secret"
-            LCMS_API_RELEASE_ID: "2509?forCI"
-            IS_RUNNING_PLAYWRIGHT: "true"
-            PIX_ASSETS_MANAGER_URL: "https://assets.pix.org"
-            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
-            LOG_ENABLED: "true"
-            LOG_LEVEL: "trace"
-            REDIRECTION_URL_SECRET: "secret"
-            IMPORT_STORAGE_ENDPOINT: "http://localhost:9090"
-            IMPORT_STORAGE_BUCKET_NAME: "pix-import-test"
-            IMPORT_STORAGE_ACCESS_KEY_ID: "nothing"
-            IMPORT_STORAGE_SECRET_ACCESS_KEY: "nothing"
-            IMPORT_STORAGE_REGION: "nothing"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
+            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            REDIS_URL: 'redis://localhost:6379'
+            START_JOB_IN_WEB_PROCESS: 'true'
+            MAILING_ENABLED: 'false'
+            AUTH_SECRET: 'secret'
+            LCMS_API_RELEASE_ID: '2509?forCI'
+            PIX_ASSETS_MANAGER_URL: 'https://assets.pix.org'
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: '777'
+            LOG_ENABLED: 'true'
+            LOG_LEVEL: 'trace'
+            REDIRECTION_URL_SECRET: 'secret'
+            IMPORT_STORAGE_ENDPOINT: 'http://localhost:9090'
+            IMPORT_STORAGE_BUCKET_NAME: 'pix-import-test'
+            IMPORT_STORAGE_ACCESS_KEY_ID: 'nothing'
+            IMPORT_STORAGE_SECRET_ACCESS_KEY: 'nothing'
+            IMPORT_STORAGE_REGION: 'nothing'
       - run:
           name: Start Pix Orga
           working_directory: ~/pix/orga
@@ -1217,9 +1215,8 @@ jobs:
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            LCMS_API_RELEASE_ID: "2509?forCI"
-            IS_RUNNING_PLAYWRIGHT: "true"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            LCMS_API_RELEASE_ID: '2509?forCI'
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1242,11 +1239,11 @@ jobs:
             PIX_APP_URL: http://localhost:4200
             PIX_ORGA_URL: http://localhost:4201
             PIX_CERTIF_URL: http://localhost:4203
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            AUTH_SECRET: "secret"
-            REDIRECTION_URL_SECRET: "secret"
-            NODE_OPTIONS: "--no-experimental-strip-types"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            AUTH_SECRET: 'secret'
+            REDIRECTION_URL_SECRET: 'secret'
+            NODE_OPTIONS: '--no-experimental-strip-types'
       - store_test_results:
           path: ./node_modules/.playwright/junit
       - store_artifacts:
@@ -1280,12 +1277,11 @@ jobs:
           name: Prepare database
           working_directory: ~/pix/api
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
-            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            LCMS_API_RELEASE_ID: "2509?forCI"
-            IS_RUNNING_PLAYWRIGHT: "true"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
+            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            LCMS_API_RELEASE_ID: '2509?forCI'
           command: npm run db:prepare && npm run datamart:prepare && npm run datawarehouse:prepare
       - run:
           name: Start Pix API
@@ -1293,27 +1289,26 @@ jobs:
           command: npm start
           background: true
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            DATAMART_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datamart"
-            DATAWAREHOUSE_DATABASE_URL: "postgres://circleci@localhost:5432/circleci_datawarehouse"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            REDIS_URL: "redis://localhost:6379"
-            START_JOB_IN_WEB_PROCESS: "true"
-            MAILING_ENABLED: "false"
-            AUTH_SECRET: "secret"
-            LCMS_API_RELEASE_ID: "2509?forCI"
-            IS_RUNNING_PLAYWRIGHT: "true"
-            PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED: "true"
-            PIX_ASSETS_MANAGER_URL: "https://assets.pix.org"
-            AUTONOMOUS_COURSES_ORGANIZATION_ID: "777"
-            LOG_ENABLED: "true"
-            LOG_LEVEL: "trace"
-            REDIRECTION_URL_SECRET: "secret"
-            IMPORT_STORAGE_ENDPOINT: "http://localhost:9090"
-            IMPORT_STORAGE_BUCKET_NAME: "pix-import-test"
-            IMPORT_STORAGE_ACCESS_KEY_ID: "nothing"
-            IMPORT_STORAGE_SECRET_ACCESS_KEY: "nothing"
-            IMPORT_STORAGE_REGION: "nothing"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            DATAMART_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datamart'
+            DATAWAREHOUSE_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci_datawarehouse'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            REDIS_URL: 'redis://localhost:6379'
+            START_JOB_IN_WEB_PROCESS: 'true'
+            MAILING_ENABLED: 'false'
+            AUTH_SECRET: 'secret'
+            LCMS_API_RELEASE_ID: '2509?forCI'
+            PIX_ADMIN_LOGIN_FROM_PASSWORD_ENABLED: 'true'
+            PIX_ASSETS_MANAGER_URL: 'https://assets.pix.org'
+            AUTONOMOUS_COURSES_ORGANIZATION_ID: '777'
+            LOG_ENABLED: 'true'
+            LOG_LEVEL: 'trace'
+            REDIRECTION_URL_SECRET: 'secret'
+            IMPORT_STORAGE_ENDPOINT: 'http://localhost:9090'
+            IMPORT_STORAGE_BUCKET_NAME: 'pix-import-test'
+            IMPORT_STORAGE_ACCESS_KEY_ID: 'nothing'
+            IMPORT_STORAGE_SECRET_ACCESS_KEY: 'nothing'
+            IMPORT_STORAGE_REGION: 'nothing'
       - run:
           name: Start Pix App
           working_directory: ~/pix/mon-pix
@@ -1332,9 +1327,8 @@ jobs:
       - run:
           name: Refresh cache
           environment:
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            LCMS_API_RELEASE_ID: "2509?forCI"
-            IS_RUNNING_PLAYWRIGHT: "true"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            LCMS_API_RELEASE_ID: '2509?forCI'
           working_directory: ~/pix/api
           command: npm run cache:refresh
       - run:
@@ -1348,11 +1342,11 @@ jobs:
             PIX_APP_URL: http://localhost:4200
             PIX_ADMIN_URL: http://localhost:4202
             PIX_CERTIF_URL: http://localhost:4203
-            DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
-            AUTH_SECRET: "secret"
-            REDIRECTION_URL_SECRET: "secret"
-            NODE_OPTIONS: "--no-experimental-strip-types"
+            DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            JOBS_DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
+            AUTH_SECRET: 'secret'
+            REDIRECTION_URL_SECRET: 'secret'
+            NODE_OPTIONS: '--no-experimental-strip-types'
       - store_test_results:
           path: ./node_modules/.playwright/junit
       - store_artifacts:

--- a/api/src/shared/config.js
+++ b/api/src/shared/config.js
@@ -60,7 +60,7 @@ function _getDate(dateAsString) {
 }
 
 function _removeTrailingSlashFromUrl(url) {
-  return url.replace(/\/$/, '');
+  return url?.replace(/\/$/, '');
 }
 
 function _getLogForHumans() {
@@ -368,16 +368,8 @@ export const config = {
     },
   },
   lcms: {
-    url: _removeTrailingSlashFromUrl(
-      (process.env.IS_RUNNING_PLAYWRIGHT === 'true' && process.env.PLAYWRIGHT_LCMS_API_URL) ||
-        process.env.CYPRESS_LCMS_API_URL ||
-        process.env.LCMS_API_URL ||
-        '',
-    ),
-    apiKey:
-      (process.env.IS_RUNNING_PLAYWRIGHT === 'true' && process.env.PLAYWRIGHT_LCMS_API_KEY) ||
-      process.env.CYPRESS_LCMS_API_KEY ||
-      process.env.LCMS_API_KEY,
+    url: _removeTrailingSlashFromUrl(process.env.LCMS_API_URL),
+    apiKey: process.env.LCMS_API_KEY,
     oauthBasicToken: process.env.LCMS_API_OAUTH_BASIC_TOKEN,
     releaseId: process.env.LCMS_API_RELEASE_ID || null,
   },

--- a/high-level-tests/e2e/README.md
+++ b/high-level-tests/e2e/README.md
@@ -19,34 +19,37 @@ Si tu n'aimes pas les scripts qui font tout, suit le reste de la procédure.
 
 Installer Chrome
 
-**Note** 
+**Note**
 
 Toutes les versions de Chrome sont supportées à partir de la [version 64 (2018)](https://docs.cypress.io/guides/guides/launching-browsers.html#Chrome-Browsers)
 
 Cypress supporte [d'autres navigateurs](https://docs.cypress.io/guides/guides/cross-browser-testing.html#Continuous-Integration-Strategies):
-* Chromium
-* Firefox
-* Edge
+
+- Chromium
+- Firefox
+- Edge
 
 Cependant, la suite de test Pix étant lancée dans la CI sur Chrome, il est suggéré de l'exécuter en local sur Chrome pour des résultats déterministes.
 
 ### Installer Cypress
 
 Installer le module npm cypress
+
 ```
 cd high-level-tests/e2e
 npm ci
-npx cypress install  
+npx cypress install
 ```
 
 Le téléchargment prend quelques minutes
+
 ```
 ╰─$ npx cypress install                                                                                                                            1 ↵
 Installing Cypress (version: 4.6.0)
 
   ⠋  Downloading Cypress      14% 119s
-     Unzipping Cypress      
-     Finishing Installation 
+     Unzipping Cypress
+     Finishing Installation
 ```
 
 **Note**
@@ -55,22 +58,22 @@ Le module npm est un simple [wrapper](https://docs.cypress.io/guides/getting-sta
 
 L'installation proprement dite est effectuée par `npx cypress install` dans un dossier hors du repository (ex. [/.cache/Cypress](https://docs.cypress.io/guides/getting-started/installing-cypress.html#Binary-cache) pour Linux)
 
-
 ### Exécuter les tests
 
 #### Démarrer l'environnement à tester
 
 Pour lancer Cypress sur une plateforme complète, il faut lancer
-* [x] un cache applicatif branché sur le Airtable minimal de Cypress,
-* [x] une base de données Postgres,
-* [x] l'API sur ladite base de données,
-* [x] le front connecté à ladite API.
- 
+
+- [x] un cache applicatif branché sur le Airtable minimal de Cypress,
+- [x] une base de données Postgres,
+- [x] l'API sur ladite base de données,
+- [x] le front connecté à ladite API.
+
 Pour les détails, voir [section dédiée](../INSTALLATION.md#L42-L42) du guide d'installation Pix
 
 ##### Configurer le cache applicatif pour les tests
 
-- Dans `~/api/.env`, renseignez/décommentez les variables `CYPRESS_LCMS_API_URL` et `CYPRESS_LCMS_API_KEY`. Si vous ne possédez pas ces clefs, je vous invite à demander de l'aide à quelqu'un.
+- Dans `~/api/.env`, renseignez/décommentez les variables `LCMS_API_URL` et `LCMS_API_KEY`. Si vous ne possédez pas ces clefs, je vous invite à demander de l'aide à quelqu'un.
 
 - Nettoyez le cache Redis grâce aux commandes suivantes pour que les données du Airtable minimal soient récupérées au lancement des tests :
 
@@ -83,17 +86,22 @@ Pour les détails, voir [section dédiée](../INSTALLATION.md#L42-L42) du guide 
 
 ###### Choisir les tests à lancer
 
-La tâche `cy:open` ouvre un navigateur où il est possible de: 
+La tâche `cy:open` ouvre un navigateur où il est possible de:
+
 - lancer tout ou partie des tests
 - consulter le résultat d'exécution
 - afficher les étapes intermédiaires à des fins d'analyse
 
 Syntaxe:
+
 - avec une connexion à la BDD par défaut `postgres@localhost/pix_test`
+
 ```
 npm run cy:open:local
 ```
+
 - avec une connexion à la BDD modifiable (ex: sur l'instance `pix_test`)
+
 ```
 DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open
 ```
@@ -101,7 +109,8 @@ DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open
 Les étapes intermédiaires ne sont pas visualisables par défaut, pour ne pas consommer de la place sur la CI.
 C'est ce qu'indique le message : `The snapshot is missing. Displaying current state of the DOM.`
 
-Pour les visualiser en local, à des fins d'analyse, modifier `cypress.json` pour passer la variable `"numTestsKeptInMemory"` de 0 à 1 
+Pour les visualiser en local, à des fins d'analyse, modifier `cypress.json` pour passer la variable `"numTestsKeptInMemory"` de 0 à 1
+
 ```
   "numTestsKeptInMemory": 1,
 ```
@@ -110,18 +119,23 @@ Attention: ne pas committer ces modifications
 
 ##### Lancer l'intégralité des tests
 
-La tâche `cy:run` 
+La tâche `cy:run`
+
 - lance l'intégralité des tests dans un navigateur
 - affiche le résultat dans la ligne de commande
 
 Note: le navigateur n'est pas headless, les fenêtres seront ouvertes et fermées automatiquement
 
-Syntaxe: 
+Syntaxe:
+
 - avec une connexion à la BDD par défaut `postgres@localhost/pix_test`
+
 ```
 npm run cy:run:local
 ```
+
 - avec une connexion à la BDD modifiable (ex: sur l'instance `pix_test`)
+
 ```
 DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:run
 ```
@@ -141,5 +155,5 @@ Pour connaître la liste des mots-clés utilisables, exécuter la commande :
 npx cucumber-js --i18n-keywords fr
 ```
 
-La plupart des fonctions natives du navigateur sont accessibles, par exemple l'accès au storage avec `window.localStorage.setItem` 
+La plupart des fonctions natives du navigateur sont accessibles, par exemple l'accès au storage avec `window.localStorage.setItem`
 [Exemple d'utilisation](http://github.com/1024pix/pix/blob/858179613343e238e0f9776374ba4875b688194f/high-level-tests/e2e/cypress/support/commands.js#L5-L5)


### PR DESCRIPTION
## ☀️ Problème

Des variables spécifiques sont utilisées pour définir les Url et Api key utilisés pour LCMS dans les tests e2e.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On supprime les env var au profit des variables déjà existantes qu'il suffit de surcharger pour les tests e2e.

Des contextes CircleCI sont créés pour les jobs Cypress et Playwright.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## 🏊 Pour tester

Tests 💚 

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
