### PR TITLE
[FEATURE] Afficher un tooltip lorsqu'il n'y aucune methode de connection (PIX-23684)

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-orga/sco-students-management.test.ts
@@ -519,8 +519,8 @@ test.describe('SCO import does not auto-reconcile a learner when the user alread
           page.getByRole('paragraph').filter({ hasText: 'Les participants ont bien été importés' }),
         ).toBeVisible();
 
-        await expect(page.getByRole('cell', { name: '–' }).nth(0)).toBeVisible();
-        await expect(page.getByRole('cell', { name: '–' }).nth(1)).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Aucune' }).nth(0)).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Aucune' }).nth(1)).toBeVisible();
       });
     });
   });

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -85,16 +85,15 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
         <p class="sco-organization-participant-list-page__user-account-blocked">{{t
             (get USER_ACCOUNT_BLOCKING_TYPES "blocked")
           }}</p>
-      {{/if}}
-
-      {{#each @student.authenticationMethods as |authenticationMethod|}}
-        <p class="organization-participant__align-element">{{t (get CONNECTION_TYPES authenticationMethod)}}
-          {{#if (not @student.isAssociated)}}
-            <EmptyConnectionMethodTooltip @id={{@student.id}} />
-          {{/if}}
+      {{else if (not @student.isAssociated)}}
+        <p class="sco-organization-participant-list-page__no-user-account">{{t (get CONNECTION_TYPES "none")}}
+          <EmptyConnectionMethodTooltip @id={{@student.id}} />
         </p>
-      {{/each}}
-
+      {{else}}
+        {{#each @student.authenticationMethods as |authenticationMethod|}}
+          <p class="organization-participant__align-element">{{t (get CONNECTION_TYPES authenticationMethod)}}</p>
+        {{/each}}
+      {{/if}}
     </:cell>
   </PixTableColumn>
   <PixTableColumn

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -12,6 +12,7 @@ import CertificabilityCell from '../certificability/cell';
 import Tooltip from '../certificability/tooltip';
 import IconTrigger from '../dropdown/icon-trigger';
 import Item from '../dropdown/item';
+import EmptyConnectionMethodTooltip from '../ui/empty-connection-method-tooltip';
 import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip';
 
 <template>
@@ -85,9 +86,15 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
             (get USER_ACCOUNT_BLOCKING_TYPES "blocked")
           }}</p>
       {{/if}}
+
       {{#each @student.authenticationMethods as |authenticationMethod|}}
-        <p>{{t (get CONNECTION_TYPES authenticationMethod)}}</p>
+        <p class="organization-participant__align-element">{{t (get CONNECTION_TYPES authenticationMethod)}}
+          {{#if (not @student.isAssociated)}}
+            <EmptyConnectionMethodTooltip @id={{@student.id}} />
+          {{/if}}
+        </p>
       {{/each}}
+
     </:cell>
   </PixTableColumn>
   <PixTableColumn

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -85,14 +85,15 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
         <p class="sco-organization-participant-list-page__user-account-blocked">{{t
             (get USER_ACCOUNT_BLOCKING_TYPES "blocked")
           }}</p>
-      {{else if (not @student.isAssociated)}}
-        <p class="sco-organization-participant-list-page__no-user-account">{{t (get CONNECTION_TYPES "none")}}
-          <EmptyConnectionMethodTooltip @id={{@student.id}} />
-        </p>
-      {{else}}
+      {{/if}}
+      {{#if @student.isAssociated}}
         {{#each @student.authenticationMethods as |authenticationMethod|}}
           <p class="organization-participant__align-element">{{t (get CONNECTION_TYPES authenticationMethod)}}</p>
         {{/each}}
+      {{else}}
+        <p class="sco-organization-participant-list-page__no-user-account">{{t (get CONNECTION_TYPES "none")}}
+          <EmptyConnectionMethodTooltip @id={{@student.id}} />
+        </p>
       {{/if}}
     </:cell>
   </PixTableColumn>

--- a/orga/app/components/sco-organization-participant/table-row.gjs
+++ b/orga/app/components/sco-organization-participant/table-row.gjs
@@ -88,10 +88,12 @@ import LastParticipationDateTooltip from '../ui/last-participation-date-tooltip'
       {{/if}}
       {{#if @student.isAssociated}}
         {{#each @student.authenticationMethods as |authenticationMethod|}}
-          <p class="organization-participant__align-element">{{t (get CONNECTION_TYPES authenticationMethod)}}</p>
+          <p>{{t (get CONNECTION_TYPES authenticationMethod)}}</p>
         {{/each}}
       {{else}}
-        <p class="sco-organization-participant-list-page__no-user-account">{{t (get CONNECTION_TYPES "none")}}
+        <p class="organization-participant__align-element sco-organization-participant-list-page__no-user-account">{{t
+            (get CONNECTION_TYPES "none")
+          }}
           <EmptyConnectionMethodTooltip @id={{@student.id}} />
         </p>
       {{/if}}

--- a/orga/app/components/ui/empty-connection-method-tooltip.gjs
+++ b/orga/app/components/ui/empty-connection-method-tooltip.gjs
@@ -1,0 +1,34 @@
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { concat } from '@ember/helper';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+
+export default class EmptyConnectionMethodTooltip extends Component {
+  @service intl;
+
+  <template>
+    <PixTooltip
+      class="empty-connection-method-tooltip"
+      @id={{concat "no-connection-method-tooltip-" @id}}
+      @position="top"
+      @isWide={{true}}
+    >
+      <:triggerElement>
+        <PixIcon
+          @name="info"
+          @plainIcon={{true}}
+          aria-hidden="true"
+          tabindex="0"
+          class="empty-connection-method-tooltip__icon"
+          aria-label={{t "pages.sco-organization-participants.connection-types.no-login-method-tooltip.label"}}
+          aria-describedby={{concat "no-connection-method-tooltip-" @id}}
+        />
+      </:triggerElement>
+      <:tooltip>
+        {{t "pages.sco-organization-participants.connection-types.no-login-method-tooltip.content"}}
+      </:tooltip>
+    </PixTooltip>
+  </template>
+}

--- a/orga/app/helpers/connection-types.js
+++ b/orga/app/helpers/connection-types.js
@@ -1,5 +1,5 @@
 export const CONNECTION_TYPES = {
-  empty: 'pages.sco-organization-participants.connection-types.empty',
+  empty: 'pages.sco-organization-participants.connection-types.none',
   none: 'pages.sco-organization-participants.connection-types.none',
   email: 'pages.sco-organization-participants.connection-types.email',
   identifiant: 'pages.sco-organization-participants.connection-types.identifiant',

--- a/orga/app/helpers/connection-types.js
+++ b/orga/app/helpers/connection-types.js
@@ -1,5 +1,4 @@
 export const CONNECTION_TYPES = {
-  empty: 'pages.sco-organization-participants.connection-types.none',
   none: 'pages.sco-organization-participants.connection-types.none',
   email: 'pages.sco-organization-participants.connection-types.email',
   identifiant: 'pages.sco-organization-participants.connection-types.identifiant',

--- a/orga/app/models/sco-organization-participant.js
+++ b/orga/app/models/sco-organization-participant.js
@@ -31,7 +31,8 @@ export default class ScoOrganizationParticipant extends Model {
   get authenticationMethods() {
     const messages = [];
 
-    if (!this.isAssociated) messages.push('empty');
+    if (!this.isAssociated) return ['none'];
+
     if (this.hasEmail) messages.push('email');
     if (this.hasUsername) messages.push('identifiant');
     if (this.isAuthenticatedFromGar) messages.push('mediacentre');

--- a/orga/app/styles/components/ui/empty-connection-method-tooltip.scss
+++ b/orga/app/styles/components/ui/empty-connection-method-tooltip.scss
@@ -1,0 +1,14 @@
+
+
+.empty-connection-method-tooltip {
+  display: inline-flex;
+  font-weight: var(--pix-font-normal);
+
+  &__icon {
+    fill: var(--pix-neutral-500);
+  }
+
+  [role='tooltip'] {
+    text-align: left;
+  }
+}

--- a/orga/app/styles/components/ui/index.scss
+++ b/orga/app/styles/components/ui/index.scss
@@ -12,7 +12,7 @@
 @use 'form-field';
 @use 'form-section';
 @use 'last-participation-date-tooltip';
+@use 'empty-connection-method-tooltip';
 @use 'action-bar';
 @use 'tooltip-with-icon';
 @use 'page-title';
-

--- a/orga/app/styles/pages/authenticated/organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/list.scss
@@ -12,6 +12,7 @@ $margin-right: 32px;
   &__align-element {
     display: inline-flex;
     gap:var(--pix-spacing-2x);
+    align-items: center;
     justify-content: center;
 
     &--column {

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -1,12 +1,19 @@
 .sco-organization-participant-list-page {
   &__user-account-temporarily-blocked {
     margin-bottom: var(--pix-spacing-2x);
-    color: var(--pix-warning-500);
+    color: var(--pix-error-500);
+    font-weight: var(--pix-font-bold);
   }
 
   &__user-account-blocked {
     margin-bottom: var(--pix-spacing-2x);
+    color: var(--pix-error-500);
+    font-weight: var(--pix-font-bold);
+  }
+
+  &__no-user-account {
     color: var(--pix-warning-500);
+    font-weight: var(--pix-font-bold);
   }
 
   &__authentication-methods {
@@ -21,4 +28,3 @@
     flex-wrap: wrap;
   }
 }
-

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -12,7 +12,7 @@
   }
 
   &__no-user-account {
-    color: var(--pix-warning-500);
+    color: var(--pix-secondary-700);
     font-weight: var(--pix-font-bold);
   }
 

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -1,4 +1,8 @@
 .sco-organization-participant-list-page {
+  .pix-tooltip__trigger-element {
+    display: flex; align-items: center;
+  }
+
   &__user-account-temporarily-blocked {
     margin-bottom: var(--pix-spacing-2x);
     color: var(--pix-error-500);
@@ -14,6 +18,8 @@
   &__no-user-account {
     color: var(--pix-secondary-700);
     font-weight: var(--pix-font-bold);
+
+
   }
 
   &__authentication-methods {

--- a/orga/tests/integration/components/sco-organization-participant/list-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/list-test.gjs
@@ -731,8 +731,12 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       );
     });
 
-    test('it should display dash for authentication method', async function (assert) {
-      assert.ok(within(screen.getAllByRole('row')[1]).getByRole('cell', { name: '\u2013' }));
+    test('it should display None for authentication method', async function (assert) {
+      assert.ok(
+        within(screen.getAllByRole('row')[1]).getByRole('cell', {
+          name: t('pages.sco-organization-participants.connection-types.none'),
+        }),
+      );
     });
 
     test('it should not display actions menu for username', async function (assert) {

--- a/orga/tests/integration/components/sco-organization-participant/table-row-test.gjs
+++ b/orga/tests/integration/components/sco-organization-participant/table-row-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import ScoOrganizationParticipantTableRow from 'pix-orga/components/sco-organization-participant/table-row';
 import { module, test } from 'qunit';
@@ -178,6 +179,48 @@ module('Integration | Component | ScoOrganizationParticipant::TableRow', functio
       assert
         .dom(screen.getByText(t('pages.sco-organization-participants.user-account-blocking-types.blocked')))
         .exists();
+    });
+  });
+
+  module('when student is not associated', function () {
+    test('it display a none label and a tooltip', async function (assert) {
+      // given
+      const noop = sinon.stub();
+      const student = {
+        firstName: 'Jean',
+        lastName: 'Bon',
+        birthdate: '2020/01/01',
+        division: '3A',
+        authenticationMethods: ['none'],
+        participationCount: 0,
+        isCertifiable: false,
+        isAssociated: false,
+      };
+
+      // when
+      const screen = await render(
+        <template>
+          <ScoOrganizationParticipantTableRow
+            @showCheckbox={{noop}}
+            @student={{student}}
+            @isStudentSelected={{noop}}
+            @openAuthenticationMethodModal={{noop}}
+            @onToggleStudent={{noop}}
+            @onClickLearner={{noop}}
+          />
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('pages.sco-organization-participants.connection-types.none'))).exists();
+      await click(
+        screen.getByLabelText(t('pages.sco-organization-participants.connection-types.no-login-method-tooltip.label')),
+      );
+
+      // then
+      assert.ok(
+        screen.getByText(t('pages.sco-organization-participants.connection-types.no-login-method-tooltip.content')),
+      );
     });
   });
 });

--- a/orga/tests/unit/models/sco-organization-participant-test.js
+++ b/orga/tests/unit/models/sco-organization-participant-test.js
@@ -5,14 +5,14 @@ module('Unit | Model | sco-organization-participant', function (hooks) {
   setupTest(hooks);
   module('#authenticationMethods', function () {
     module('when not reconciled', function () {
-      test('it should return empty message', function (assert) {
+      test('it should return "none" message', function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const organizationScoParticipant = { lastName: 'Last', firstName: 'First', birthdate: '2010-10-10' };
         // when
         const model = store.createRecord('sco-organization-participant', organizationScoParticipant);
         // then
-        assert.deepEqual(model.authenticationMethods, ['empty']);
+        assert.deepEqual(model.authenticationMethods, ['none']);
       });
     });
 

--- a/orga/translations/de.json
+++ b/orga/translations/de.json
@@ -1785,9 +1785,12 @@
       },
       "connection-types": {
         "email": "E-Mail-Adresse",
-        "empty": "-",
         "identifiant": "Benutzername",
         "mediacentre": "Mediacentre",
+        "no-login-method-tooltip": {
+          "content": "Der Schüler muss an einer Kampagne teilnehmen, um ein Konto mit Ihrer Organisation zu verknüpfen.",
+          "label": "Informationen zu den Verbindungsmethoden"
+        },
         "none": "Keine",
         "without-mediacentre": "Ohne Mediacentre"
       },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1785,9 +1785,12 @@
       },
       "connection-types": {
         "email": "Email address",
-        "empty": "–",
         "identifiant": "Username",
         "mediacentre": "Mediacentre",
+        "no-login-method-tooltip": {
+          "content": "The student must play a campaign to link an account to your organization.",
+          "label": "Information about connection methods"
+        },
         "none": "None",
         "without-mediacentre": "Without Mediacentre"
       },

--- a/orga/translations/es.json
+++ b/orga/translations/es.json
@@ -1785,9 +1785,12 @@
       },
       "connection-types": {
         "email": "Correo electrónico",
-        "empty": "-",
         "identifiant": "ID",
         "mediacentre": "Mediacentre",
+        "no-login-method-tooltip": {
+          "content": "El alumno debe realizar una campaña para vincular una cuenta a su organización.",
+          "label": "Información sobre los métodos de conexión"
+        },
         "none": "No",
         "without-mediacentre": "Sin Mediacentre"
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1785,9 +1785,12 @@
       },
       "connection-types": {
         "email": "Adresse e-mail",
-        "empty": "–",
         "identifiant": "Identifiant",
         "mediacentre": "Mediacentre",
+        "no-login-method-tooltip": {
+          "content": "L'élève doit jouer une campagne pour lier un compte à votre organisation.",
+          "label": "Information sur les méthodes de connections"
+        },
         "none": "Aucune",
         "without-mediacentre": "Sans Mediacentre"
       },

--- a/orga/translations/it.json
+++ b/orga/translations/it.json
@@ -1785,9 +1785,12 @@
       },
       "connection-types": {
         "email": "Indirizzo e-mail",
-        "empty": "-",
         "identifiant": "Identificatore",
         "mediacentre": "Mediacentre",
+        "no-login-method-tooltip": {
+          "content": "Lo studente deve partecipare a una campagna per collegare un account alla vostra organizzazione.",
+          "label": "Informazioni sui metodi di connessione"
+        },
         "none": "No",
         "without-mediacentre": "Senza Mediacentre"
       },

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -1785,9 +1785,12 @@
       },
       "connection-types": {
         "email": "E-mailadres",
-        "empty": "-",
         "identifiant": "Gebruikersnaam",
         "mediacentre": "Mediacentrum",
+        "no-login-method-tooltip": {
+          "content": "De leerling moet een campagne spelen om een account aan uw organisatie te koppelen.",
+          "label": "Informatie over de verbindingsmethoden"
+        },
         "none": "Geen",
         "without-mediacentre": "Zonder mediacentrum"
       },


### PR DESCRIPTION





## ☀️ Problème

L'affichage d'un tiret dans la liste des prescrit sco lorsqu'il n'y a pas de méthode de connection n'est pas très lisible

## ⛱️ Proposition

Ajotuer un code couleur et remplacé le tiret par "Aucune"

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
- Aller sur le page des prescrit d'une orga sco avec import 
- voir le tooltip
<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
