### PR TITLE
[TECH] Corrige certains tests flaky

### DIFF
--- a/api/db/database-builder/database-buffer.js
+++ b/api/db/database-builder/database-buffer.js
@@ -16,6 +16,7 @@ const databaseBuffer = {
 
   purge() {
     this.objectsToInsert = {};
+    this.nextId = INITIAL_ID;
   },
 };
 

--- a/api/tests/certification/session-management/unit/infrastructure/serializers/session-serializer_test.js
+++ b/api/tests/certification/session-management/unit/infrastructure/serializers/session-serializer_test.js
@@ -121,13 +121,14 @@ describe('Unit | Certification | session-management | Serializer | session-seria
       expect(session.version).to.equal(3);
     });
 
-    EMPTY_BLANK_AND_NULL.forEach((examinerGlobalComment) => {
-      it(`should return no examiner comment if comment is "${examinerGlobalComment}"`, function () {
+    EMPTY_BLANK_AND_NULL.forEach((emptyValue) => {
+      it(`should return no examiner comment if comment is "${emptyValue}"`, function () {
         // given
-        jsonApiSession.data.attributes['examiner-global-comment'] = examinerGlobalComment;
+        const jsonApiSessionWithEmptyExaminerComment = structuredClone(jsonApiSession);
+        jsonApiSessionWithEmptyExaminerComment.data.attributes['examiner-global-comment'] = emptyValue;
 
         // when
-        const result = serializer.deserialize(jsonApiSession);
+        const result = serializer.deserialize(jsonApiSessionWithEmptyExaminerComment);
 
         // then
         expect(result.examinerGlobalComment).to.be.null;

--- a/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipant_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/models/CampaignParticipant_test.js
@@ -289,14 +289,13 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
 
       beforeEach(function () {
         userIdentity = { id: 1 };
-      });
-
-      it('throws a ForbiddenAccess exception when the user is not in the organization learners on managingStudents cases', async function () {
         restrictedCampaign = domainBuilder.buildCampaignToStartParticipation({
           externalIdLabel: null,
           isManagingStudents: true,
         });
+      });
 
+      it('throws a ForbiddenAccess exception when the user is not in the organization learners on managingStudents cases', async function () {
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation: restrictedCampaign,
           userIdentity,
@@ -312,11 +311,6 @@ describe('Unit | Domain | Models | CampaignParticipant', function () {
       });
 
       it('throws a ForbiddenAccess exception when the user is not in the organization learners on feature cases', async function () {
-        restrictedCampaign = domainBuilder.buildCampaignToStartParticipation({
-          externalIdLabel: null,
-          hasLearnersImportFeature: true,
-        });
-
         const campaignParticipant = new CampaignParticipant({
           campaignToStartParticipation: restrictedCampaign,
           userIdentity,

--- a/api/tests/privacy/unit/domain/services/anonymize-services/can-self-anonymize.usecase.test.js
+++ b/api/tests/privacy/unit/domain/services/anonymize-services/can-self-anonymize.usecase.test.js
@@ -29,10 +29,11 @@ describe('Unit | Privacy | Domain | UseCase | Services | Anonymize | can-self-an
   });
 
   context('When feature flag is enabled', function () {
+    beforeEach(async function () {
+      await featureToggles.set('isSelfAccountDeletionEnabled', true);
+    });
     context('When user is eligible', function () {
       it('returns true', async function () {
-        // given
-        await featureToggles.set('isSelfAccountDeletionEnabled', true);
         // when
         const result = await anonymizeServices.canSelfAnonymize({ userId, ...dependencies });
 

--- a/api/tests/setup/common.js
+++ b/api/tests/setup/common.js
@@ -7,6 +7,7 @@ import localizedFormat from 'dayjs/plugin/localizedFormat.js';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
+import { featureToggles } from '../../src/shared/infrastructure/feature-toggles/index.js';
 import * as customChaiHelpers from '../tooling/chai-custom-helpers/index.js';
 import { jobChai } from '../tooling/chai-custom-helpers/jobs/expect-job.js';
 
@@ -20,7 +21,8 @@ chaiUse(jobChai);
 Object.values(customChaiHelpers).forEach(chaiUse);
 
 export const mochaHooks = {
-  afterEach() {
+  async afterEach() {
     sinon.restore();
+    await featureToggles.resetDefaults();
   },
 };

--- a/api/tests/setup/integration.js
+++ b/api/tests/setup/integration.js
@@ -3,7 +3,6 @@ import nock from 'nock';
 import * as moduleRepository from '../../src/devcomp/infrastructure/repositories/module-repository.js';
 import * as tutorialRepository from '../../src/devcomp/infrastructure/repositories/tutorial-repository.js';
 import * as missionRepository from '../../src/school/infrastructure/repositories/mission-repository.js';
-import { featureToggles } from '../../src/shared/infrastructure/feature-toggles/index.js';
 import { JobClient } from '../../src/shared/infrastructure/jobs/JobClient.js';
 import { clearMutex } from '../../src/shared/infrastructure/mutex/RedisMutex.js';
 import { releaseInfrastructure } from '../../src/shared/infrastructure/release-infrastructure.js';
@@ -42,7 +41,6 @@ export const mochaHooks = {
       tutorialRepository.clearCache();
       missionRepository.clearCache();
       moduleRepository.clearCache();
-      await featureToggles.resetDefaults();
       await clearMutex();
       await JobClient.instance.flushJobs();
       await datamartBuilder.clean();

--- a/api/tests/setup/test-random.js
+++ b/api/tests/setup/test-random.js
@@ -5,7 +5,7 @@ import Mocha from 'mocha';
  * problèmes d'isolation des tests.
  *
  * Exemple d'exécution avec une seed aléatoire :
- * npm run test:api:unit -- --require ./tests/test-random.js --bail
+ * npm run test:api:unit -- --require ./tests/setup/test-random.js --bail
  *
  * Exemple d'exécution avec une seed fixe, nombre flottant: 0 < seed < 1 :
  * SEED=0.12243342423 npm run test:api:unit -- --require ./tests/test-random.js --bail

--- a/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
+++ b/api/tests/shared/unit/domain/models/CampaignLearningContent_test.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { buildFramework } from '../../../../../db/database-builder/factory/learning-content/build-framework.js';
 import { CampaignLearningContent } from '../../../../../src/shared/domain/models/CampaignLearningContent.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
+import { buildFramework } from '../../../../tooling/domain-builder/factory/build-framework.js';
 
 describe('Unit | Domain | Models | CampaignLearningContent', function () {
   let framework;


### PR DESCRIPTION
## ☀️ Problème

Certains tests sont flaky.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On utilise la commande `npm run test:api:unit -- --require ./tests/setup/test-random.js --bail` qui lance les tests unitaires de manière aléatoire afin d'identifier les tests flacky.

On identifie certains patterns qui doivent être respectés :
- Dans les tests unitaires, ne pas utiliser database-builder mais domain-builder
- Ne pas muter d'objets utilisés dans les tests mais les cloner avant de modifier leurs propriétés

On a également ajouté le reset des feature toggles pour tous les types de tests.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
