### PR TITLE
[BUGFIX] Corriger les variables des libellés du bandeau d'information d'import en anglais et néerlandais (PIX-24142)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -407,7 +407,7 @@
       "error-link": "(see import page).",
       "in-progress": "An import is in progress",
       "in-progress-link": "(check import status).",
-      "success": "Participants have been imported on {date} by {firstName} {lastName}."
+      "success": "Participants have been imported on {date} by {firstname} {lastname}."
     },
     "index": {
       "action-cards": {

--- a/orga/translations/nl.json
+++ b/orga/translations/nl.json
@@ -407,7 +407,7 @@
       "error-link": "(zie de importpagina).",
       "in-progress": "Bezig met importeren",
       "in-progress-link": "(controleer importstatus).",
-      "success": "De deelnemers zijn geïmporteerd op {date} door {firstName} {lastName}."
+      "success": "De deelnemers zijn geïmporteerd op {date} door {firstname} {lastname}."
     },
     "index": {
       "action-cards": {


### PR DESCRIPTION
## :package: Problème

Sur le bandeau d'information affiché après un import de participants (PixOrga), les traductions `en` et `nl` de la clé `success` utilisaient les variables `{firstName}` / `{lastName}` alors que le code fournit `{firstname}` / `{lastname}`. Résultat : le prénom et le nom n'étaient pas interpolés.

## :wrench: Proposition

Aligner les variables des fichiers `en.json` et `nl.json` sur celles déjà utilisées dans `fr.json` : `{firstname}` et `{lastname}`.

## :rotating_light: Points d'attention

Modification limitée aux fichiers de traduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)