### PR TITLE
[TECH] Ne pas stocker de timestamp pour la révocation de session (PIX-24133)

### DIFF
--- a/api/src/identity-access-management/domain/models/RevokedUserAccess.js
+++ b/api/src/identity-access-management/domain/models/RevokedUserAccess.js
@@ -2,12 +2,12 @@ export class RevokedUserAccess {
   /**
    * @param {{
    *   revokedAllTimeStamp?: number
-   *   revokedSessions?: string[]
+   *   revokedSessionIds?: string[]
    * }} param
    */
-  constructor({ revokedAllTimeStamp, revokedSessions }) {
+  constructor({ revokedAllTimeStamp, revokedSessionIds }) {
     this.revokedAllTimeStamp = revokedAllTimeStamp;
-    this.revokedSessions = revokedSessions;
+    this.revokedSessionIds = revokedSessionIds;
   }
 
   isAccessTokenRevoked(decodedToken) {
@@ -17,7 +17,7 @@ export class RevokedUserAccess {
     }
 
     const sessionId = decodedToken.sid;
-    if (this.revokedSessions?.includes(sessionId)) {
+    if (this.revokedSessionIds?.includes(sessionId)) {
       return true;
     }
 

--- a/api/src/identity-access-management/domain/models/RevokedUserAccess.js
+++ b/api/src/identity-access-management/domain/models/RevokedUserAccess.js
@@ -2,12 +2,12 @@ export class RevokedUserAccess {
   /**
    * @param {{
    *   revokedAllTimeStamp?: number
-   *   revokedSessionTimeStamps?: Record<string, number | undefined>
+   *   revokedSessions?: string[]
    * }} param
    */
-  constructor({ revokedAllTimeStamp, revokedSessionTimeStamps }) {
+  constructor({ revokedAllTimeStamp, revokedSessions }) {
     this.revokedAllTimeStamp = revokedAllTimeStamp;
-    this.revokedSessionTimeStamps = revokedSessionTimeStamps;
+    this.revokedSessions = revokedSessions;
   }
 
   isAccessTokenRevoked(decodedToken) {
@@ -17,7 +17,7 @@ export class RevokedUserAccess {
     }
 
     const sessionId = decodedToken.sid;
-    if (this.revokedSessionTimeStamps?.[sessionId] && issuedAt < this.revokedSessionTimeStamps[sessionId]) {
+    if (this.revokedSessions?.includes(sessionId)) {
       return true;
     }
 

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -76,7 +76,7 @@ async function findByUserId(userId) {
 
   const { all: revokedAllTimeStamp, ...revokedSessionTimeStamps } = revokedTimeStamps;
 
-  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessionTimeStamps });
+  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessions: Object.keys(revokedSessionTimeStamps).sort() });
 }
 
 export const revokedUserAccessRepository = { revokeAll, revokeSession, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -6,7 +6,7 @@ import { featureToggles } from '../../../shared/infrastructure/feature-toggles/i
 import { RevokedUserAccess } from '../../domain/models/RevokedUserAccess.js';
 
 const revokedUserAccessTemporaryStorage = temporaryStorage.withPrefix('revoked-user-access:');
-const revokedUserAccessLifespanMs = config.authentication.revokedUserAccessLifespanMs;
+const { revokedUserAccessLifespanMs } = config.authentication;
 
 const isSessionLogoutEnabled = featureToggles.use('isSessionLogoutEnabled');
 
@@ -40,16 +40,14 @@ async function revokeAll({ userId, revokeUntil }) {
  * @param {Object} params - The params object.
  * @param {string} params.userId - The ID of the user to revoke access for.
  * @param {string} params.sessionId - The ID of the user’s session to revoke.
- * @param {Date} params.revokeUntil - The date until the user's access should be revoked.
  */
-async function revokeSession({ userId, sessionId, revokeUntil }) {
+async function revokeSession({ userId, sessionId }) {
   Joi.assert(userId, Joi.required());
   Joi.assert(sessionId, Joi.required());
-  Joi.assert(revokeUntil, Joi.date().required());
 
   await revokedUserAccessTemporaryStorage.save({
     key: `${userId}:${sessionId}`,
-    value: Math.floor(revokeUntil.getTime() / 1000),
+    value: '',
     expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
   });
 }
@@ -66,17 +64,17 @@ async function findByUserId(userId) {
     return new RevokedUserAccess({ revokedAllTimeStamp });
   }
 
-  const revokeKeys = await revokedUserAccessTemporaryStorage.keys(`${userId}:*`);
+  const revokedKeys = await revokedUserAccessTemporaryStorage.keys(`${userId}:*`);
 
-  const revokedTimeStamps = Object.fromEntries(
-    await Promise.all(
-      revokeKeys.map(async (key) => [key.split(':')[1], await revokedUserAccessTemporaryStorage.get(key)]),
-    ),
-  );
+  const revokedAllKey = `${userId}:all`;
 
-  const { all: revokedAllTimeStamp, ...revokedSessionTimeStamps } = revokedTimeStamps;
+  const revokedAllTimeStamp = revokedKeys.includes(revokedAllKey)
+    ? await revokedUserAccessTemporaryStorage.get(`${userId}:all`)
+    : undefined;
 
-  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessions: Object.keys(revokedSessionTimeStamps).sort() });
+  const revokedSessions = revokedKeys.filter((key) => key !== revokedAllKey).map((key) => key.split(':')[1]);
+
+  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessions });
 }
 
 export const revokedUserAccessRepository = { revokeAll, revokeSession, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -72,9 +72,9 @@ async function findByUserId(userId) {
     ? await revokedUserAccessTemporaryStorage.get(`${userId}:all`)
     : undefined;
 
-  const revokedSessions = revokedKeys.filter((key) => key !== revokedAllKey).map((key) => key.split(':')[1]);
+  const revokedSessionIds = revokedKeys.filter((key) => key !== revokedAllKey).map((key) => key.split(':')[1]);
 
-  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessions });
+  return new RevokedUserAccess({ revokedAllTimeStamp, revokedSessionIds });
 }
 
 export const revokedUserAccessRepository = { revokeAll, revokeSession, findByUserId };

--- a/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
+++ b/api/src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js
@@ -11,6 +11,24 @@ const { revokedUserAccessLifespanMs } = config.authentication;
 const isSessionLogoutEnabled = featureToggles.use('isSessionLogoutEnabled');
 
 /**
+ * Saves the revoke date for a user session.
+ *
+ * @param {Object} params - The params object.
+ * @param {string} params.userId - The ID of the user to revoke access for.
+ * @param {string} params.sessionId - The ID of the user’s session to revoke.
+ */
+async function revokeSession({ userId, sessionId }) {
+  Joi.assert(userId, Joi.required());
+  Joi.assert(sessionId, Joi.required());
+
+  await revokedUserAccessTemporaryStorage.save({
+    key: `${userId}:${sessionId}`,
+    value: '',
+    expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
+  });
+}
+
+/**
  * Saves the revoke date for all the accesses of a user.
  *
  * @param {Object} params - The params object.
@@ -30,24 +48,6 @@ async function revokeAll({ userId, revokeUntil }) {
   await revokedUserAccessTemporaryStorage.save({
     key: `${userId}:all`,
     value: Math.floor(revokeUntil.getTime() / 1000),
-    expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
-  });
-}
-
-/**
- * Saves the revoke date for a user session.
- *
- * @param {Object} params - The params object.
- * @param {string} params.userId - The ID of the user to revoke access for.
- * @param {string} params.sessionId - The ID of the user’s session to revoke.
- */
-async function revokeSession({ userId, sessionId }) {
-  Joi.assert(userId, Joi.required());
-  Joi.assert(sessionId, Joi.required());
-
-  await revokedUserAccessTemporaryStorage.save({
-    key: `${userId}:${sessionId}`,
-    value: '',
     expirationDelaySeconds: revokedUserAccessLifespanMs / 1000,
   });
 }

--- a/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
+++ b/api/src/shared/infrastructure/feature-toggles/feature-toggles-client.js
@@ -218,9 +218,13 @@ export class FeatureTogglesClient {
           this.#currentValues[key] = newValue;
 
           this.#eventTarget.dispatchEvent(new FeatureTogglesEvent('set', key, newValue, oldValue));
-
-          break;
         }
+
+        break;
+      }
+
+      default: {
+        logger.warn({ type: message.type }, 'unknown message type');
       }
     }
   }

--- a/api/src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js
+++ b/api/src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js
@@ -11,11 +11,8 @@ class InMemoryKeyValueStorage extends KeyValueStorage {
     super();
   }
 
-  async save({ key, value, expirationDelaySeconds }) {
-    const storageKey = trim(key) || InMemoryKeyValueStorage.generateKey();
-    if (expirationDelaySeconds) {
-      setTimeout(() => this.#store.delete(storageKey), expirationDelaySeconds * 1000);
-    }
+  async save({ key, value }) {
+    const storageKey = key?.trim() ?? InMemoryKeyValueStorage.generateKey();
     this.#store.set(storageKey, value);
     return storageKey;
   }

--- a/api/src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js
+++ b/api/src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js
@@ -1,14 +1,11 @@
-import lodash from 'lodash';
-
-const { trim, noop } = lodash;
-
 import { KeyValueStorage } from './KeyValueStorage.js';
 
 class InMemoryKeyValueStorage extends KeyValueStorage {
-  #store = new Map();
+  #store;
 
-  constructor() {
+  constructor({ store = new Map() } = {}) {
     super();
+    this.#store = store;
   }
 
   async save({ key, value }) {
@@ -18,7 +15,7 @@ class InMemoryKeyValueStorage extends KeyValueStorage {
   }
 
   async update(key, value) {
-    const storageKey = trim(key);
+    const storageKey = key.trim();
     this.#store.set(storageKey, value);
   }
 
@@ -47,11 +44,11 @@ class InMemoryKeyValueStorage extends KeyValueStorage {
   }
 
   quit() {
-    noop;
+    // noop
   }
 
   async expire() {
-    noop;
+    // noop
   }
 
   async ttl() {

--- a/api/src/shared/infrastructure/key-value-storages/KeyValueStorage.js
+++ b/api/src/shared/infrastructure/key-value-storages/KeyValueStorage.js
@@ -95,7 +95,7 @@ class KeyValueStorage {
       },
 
       ttl(key) {
-        return storage.ttl(key);
+        return storage.ttl(prefix + key);
       },
 
       lpush({ key, value }) {

--- a/api/tests/identity-access-management/acceptance/application/token.route.test.js
+++ b/api/tests/identity-access-management/acceptance/application/token.route.test.js
@@ -669,8 +669,8 @@ describe('Acceptance | Identity Access Management | Route | Token', function () 
       // then
       expect(response.statusCode).to.equal(204);
 
-      const revokeSessionTimestamp = await revokedUserAccessTemporaryStorage.get(`${userId}:${sessionId}`);
-      expect(revokeSessionTimestamp).to.be.a('number');
+      const revokedKeys = await revokedUserAccessTemporaryStorage.keys(`${userId}:*`);
+      expect(revokedKeys).to.deep.equal([`${userId}:${sessionId}`]);
     });
   });
 });

--- a/api/tests/identity-access-management/integration/domain/usecases/revoke-session.usecase.test.js
+++ b/api/tests/identity-access-management/integration/domain/usecases/revoke-session.usecase.test.js
@@ -15,7 +15,7 @@ describe('Integration | Identity Access Management | Domain | UseCase | revoke-s
     await usecases.revokeSession({ userId, sessionId });
 
     // then
-    const revokeTimeStamp = await revokedUserAccessTemporaryStorage.get(`${userId}:${sessionId}`);
-    expect(revokeTimeStamp).to.be.a('number');
+    const revokedKeys = await revokedUserAccessTemporaryStorage.keys(`${userId}:*`);
+    expect(revokedKeys).to.deep.equal([`${userId}:${sessionId}`]);
   });
 });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -59,7 +59,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       // then
       expect(result).to.deep.equal({
         revokedAllTimeStamp,
-        revokedSessionTimeStamps: undefined,
+        revokedSessions: undefined,
       });
       expect(result).to.be.instanceOf(RevokedUserAccess);
     });
@@ -87,10 +87,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         // then
         expect(result).to.deep.equal({
           revokedAllTimeStamp,
-          revokedSessionTimeStamps: {
-            session1: session1RevokedTimestamp,
-            session2: session2RevokedTimestamp,
-          },
+          revokedSessions: ['session1', 'session2'],
         });
         expect(result).to.be.instanceOf(RevokedUserAccess);
       });

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -2,6 +2,7 @@ import { setImmediate } from 'node:timers/promises';
 
 import { expect } from 'chai';
 
+import { config } from '../../../../../config/config.js';
 import { RevokedUserAccess } from '../../../../../src/identity-access-management/domain/models/RevokedUserAccess.js';
 import { revokedUserAccessRepository } from '../../../../../src/identity-access-management/infrastructure/repositories/revoked-user-access.repository.js';
 import { featureToggles } from '../../../../../src/shared/infrastructure/feature-toggles/index.js';
@@ -35,15 +36,16 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
   describe('#revokeSession', function () {
     it('saves revoked access for user session in TemporaryStorage', async function () {
       // given
-      const revokeUntil = new Date();
-      const revokedTimeStamp = Math.floor(revokeUntil.getTime() / 1000);
+      const sessionId = crypto.randomUUID();
 
       // when
-      await revokedUserAccessRepository.revokeSession({ userId: 12345, sessionId: 67890, revokeUntil });
+      await revokedUserAccessRepository.revokeSession({ userId: 12345, sessionId });
 
       // then
-      const result = await revokedUserAccessTemporaryStorage.get('12345:67890');
-      expect(result).to.equal(revokedTimeStamp);
+      const result = await revokedUserAccessTemporaryStorage.get(`12345:${sessionId}`);
+      expect(result).to.equal('');
+      const ttl = await revokedUserAccessTemporaryStorage.ttl(`12345:${sessionId}`);
+      expect(ttl).to.equal(config.authentication.revokedUserAccessLifespanMs / 1000);
     });
   });
 
@@ -75,16 +77,14 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         const revokedAllTimeStamp = Math.floor(new Date('2026-08-27T15:00:50Z').getTime() / 1000);
         await revokedUserAccessTemporaryStorage.save({ key: '12345:all', value: revokedAllTimeStamp });
 
-        const session1RevokedTimestamp = Math.floor(new Date().getTime('2026-08-27T16:00:50Z') / 1000);
-        await revokedUserAccessTemporaryStorage.save({ key: '12345:session1', value: session1RevokedTimestamp });
-
-        const session2RevokedTimestamp = Math.floor(new Date().getTime('2026-08-27T17:00:50Z') / 1000);
-        await revokedUserAccessTemporaryStorage.save({ key: '12345:session2', value: session2RevokedTimestamp });
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:session1', value: '' });
+        await revokedUserAccessTemporaryStorage.save({ key: '12345:session2', value: '' });
 
         // when
         const result = await revokedUserAccessRepository.findByUserId(12345);
 
         // then
+        result.revokedSessions.sort();
         expect(result).to.deep.equal({
           revokedAllTimeStamp,
           revokedSessions: ['session1', 'session2'],

--- a/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
+++ b/api/tests/identity-access-management/integration/infrastructure/repositories/revoked-user-access.repository.test.js
@@ -61,7 +61,7 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
       // then
       expect(result).to.deep.equal({
         revokedAllTimeStamp,
-        revokedSessions: undefined,
+        revokedSessionIds: undefined,
       });
       expect(result).to.be.instanceOf(RevokedUserAccess);
     });
@@ -84,10 +84,10 @@ describe('Integration | Identity Access Management | Infrastructure | Repository
         const result = await revokedUserAccessRepository.findByUserId(12345);
 
         // then
-        result.revokedSessions.sort();
+        result.revokedSessionIds.sort();
         expect(result).to.deep.equal({
           revokedAllTimeStamp,
-          revokedSessions: ['session1', 'session2'],
+          revokedSessionIds: ['session1', 'session2'],
         });
         expect(result).to.be.instanceOf(RevokedUserAccess);
       });

--- a/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
@@ -7,12 +7,12 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     it('builds a revoke user access model', function () {
       //when
       const revokedAllTimeStamp = Math.floor(new Date().getTime() / 1000);
-      const revokedSessionTimeStamps = { 12345: Math.floor(new Date().getTime() / 1000) };
-      const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp, revokedSessionTimeStamps });
+      const revokedSessions = [crypto.randomUUID()];
+      const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp, revokedSessions });
 
       //then
       expect(revokedUserAccess.revokedAllTimeStamp).to.equal(revokedAllTimeStamp);
-      expect(revokedUserAccess.revokedSessionTimeStamps).to.equal(revokedSessionTimeStamps);
+      expect(revokedUserAccess.revokedSessions).to.equal(revokedSessions);
     });
   });
 
@@ -52,11 +52,9 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     context("when access token's session is revoked", function () {
       it('returns true', function () {
         //given
-        const revokedAllTimeStamp = Math.floor(new Date('2024-12-01').getTime() / 1000);
-        const iat = Math.floor(new Date('2024-11-01').getTime() / 1000);
         const sid = crypto.randomUUID();
-        const decodedToken = { iat, sid };
-        const revokedUserAccess = new RevokedUserAccess({ revokedSessionTimeStamps: { [sid]: revokedAllTimeStamp } });
+        const decodedToken = { sid };
+        const revokedUserAccess = new RevokedUserAccess({ revokedSessions: [sid] });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
@@ -69,11 +67,9 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     context("when access token's session is not revoked", function () {
       it('returns false', function () {
         //given
-        const revokedAllTimeStamp = Math.floor(new Date('2024-10-01').getTime() / 1000);
-        const iat = Math.floor(new Date('2024-12-01').getTime() / 1000);
         const sid = crypto.randomUUID();
-        const decodedToken = { iat, sid };
-        const revokedUserAccess = new RevokedUserAccess({ revokedSessionTimeStamps: { [sid]: revokedAllTimeStamp } });
+        const decodedToken = { sid };
+        const revokedUserAccess = new RevokedUserAccess({ revokedSessions: [crypto.randomUUID()] });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);

--- a/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
+++ b/api/tests/identity-access-management/unit/domain/models/RevokedUserAccess.test.js
@@ -7,12 +7,12 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
     it('builds a revoke user access model', function () {
       //when
       const revokedAllTimeStamp = Math.floor(new Date().getTime() / 1000);
-      const revokedSessions = [crypto.randomUUID()];
-      const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp, revokedSessions });
+      const revokedSessionIds = [crypto.randomUUID()];
+      const revokedUserAccess = new RevokedUserAccess({ revokedAllTimeStamp, revokedSessionIds });
 
       //then
       expect(revokedUserAccess.revokedAllTimeStamp).to.equal(revokedAllTimeStamp);
-      expect(revokedUserAccess.revokedSessions).to.equal(revokedSessions);
+      expect(revokedUserAccess.revokedSessionIds).to.equal(revokedSessionIds);
     });
   });
 
@@ -54,7 +54,7 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
         //given
         const sid = crypto.randomUUID();
         const decodedToken = { sid };
-        const revokedUserAccess = new RevokedUserAccess({ revokedSessions: [sid] });
+        const revokedUserAccess = new RevokedUserAccess({ revokedSessionIds: [sid] });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);
@@ -69,7 +69,7 @@ describe('Unit | Identity Access Management | Domain | Model | RevokedUserAccess
         //given
         const sid = crypto.randomUUID();
         const decodedToken = { sid };
-        const revokedUserAccess = new RevokedUserAccess({ revokedSessions: [crypto.randomUUID()] });
+        const revokedUserAccess = new RevokedUserAccess({ revokedSessionIds: [crypto.randomUUID()] });
 
         //when
         const result = revokedUserAccess.isAccessTokenRevoked(decodedToken);

--- a/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import { InMemoryKeyValueStorage } from '../../../../../src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js';
 
@@ -39,13 +38,6 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   });
 
   describe('#save', function () {
-    let clock;
-
-    beforeEach(function () {
-      // InMemoryKeyValueStorage expires its keys with setTimeout
-      clock = sinon.useFakeTimers({ toFake: ['Date', 'setTimeout'] });
-    });
-
     it('should resolve with the generated key', async function () {
       // when
       const key = await inMemoryKeyValueStorage.save({ value: {}, expirationDelaySeconds: 1000 });
@@ -83,22 +75,6 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
       // then
       expect(returnedKey).not.be.equal(keyParameter);
     });
-
-    it('should save key value with a defined ttl in seconds', async function () {
-      // given
-      const TWO_MINUTES_IN_SECONDS = 2 * 60;
-
-      // when
-      const key = await inMemoryKeyValueStorage.save({
-        value: 'foobar',
-        expirationDelaySeconds: TWO_MINUTES_IN_SECONDS,
-      });
-
-      // then
-      expect(await inMemoryKeyValueStorage.get(key)).to.equal('foobar');
-      await clock.tickAsync(TWO_MINUTES_IN_SECONDS * 1000);
-      expect(await inMemoryKeyValueStorage.get(key)).to.be.undefined;
-    });
   });
 
   describe('#get', function () {
@@ -131,27 +107,6 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
       const result = await inMemoryKeyValueStorage.get(key);
       expect(result).to.deep.equal({ url: 'url' });
     });
-
-    it('should not change the time to live', async function () {
-      // given
-      // InMemoryKeyValueStorage expires its keys with setTimeout
-      const clock = sinon.useFakeTimers({ toFake: ['Date', 'setTimeout'] });
-      const keyWithTtl = await inMemoryKeyValueStorage.save({
-        value: {},
-        expirationDelaySeconds: 1,
-      });
-      const keyWithoutTtl = await inMemoryKeyValueStorage.save({ value: {} });
-
-      // when
-      await clock.tickAsync(500);
-      await inMemoryKeyValueStorage.update(keyWithTtl, {});
-      await inMemoryKeyValueStorage.update(keyWithoutTtl, {});
-      await clock.tickAsync(600);
-
-      // then
-      expect(await inMemoryKeyValueStorage.get(keyWithTtl)).to.be.undefined;
-      expect(await inMemoryKeyValueStorage.get(keyWithoutTtl)).not.to.be.undefined;
-    });
   });
 
   describe('#delete', function () {
@@ -172,21 +127,8 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   });
 
   describe('#expire', function () {
-    it('should add an expiration time to the list', async function () {
-      // given
-      // InMemoryKeyValueStorage expires its keys with setTimeout
-      const clock = sinon.useFakeTimers({ toFake: ['Date', 'setTimeout'] });
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
-
-      // when
-      const key = 'key:lpush';
-      await inMemoryKeyValueStorage.lpush(key, 'value');
-      await inMemoryKeyValueStorage.expire({ key, expirationDelaySeconds: 1 });
-      await clock.tickAsync(1200);
-      const list = inMemoryKeyValueStorage.lrange(key);
-
-      // then
-      expect(list).to.be.empty;
+    it('resolves', async function () {
+      await inMemoryKeyValueStorage.expire('key');
     });
   });
 

--- a/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
+++ b/api/tests/shared/unit/infrastructure/key-value-storages/InMemoryKeyValueStorage_test.js
@@ -3,23 +3,23 @@ import { expect } from 'chai';
 import { InMemoryKeyValueStorage } from '../../../../../src/shared/infrastructure/key-value-storages/InMemoryKeyValueStorage.js';
 
 describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', function () {
-  let inMemoryKeyValueStorage;
+  let store, inMemoryKeyValueStorage;
 
   beforeEach(function () {
-    inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
+    store = new Map();
+    inMemoryKeyValueStorage = new InMemoryKeyValueStorage({ store });
   });
 
   describe('#increment', function () {
     it('should call client incr to increment value', async function () {
       // given
       const key = 'valueKey';
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
 
       // when
       await inMemoryKeyValueStorage.increment(key);
 
       // then
-      expect(await inMemoryKeyValueStorage.get(key)).to.equal('1');
+      expect(store.get(key)).to.equal('1');
     });
   });
 
@@ -27,13 +27,12 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
     it('should call client incr to decrement value', async function () {
       // given
       const key = 'valueKey';
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
 
       // when
       await inMemoryKeyValueStorage.decrement(key);
 
       // then
-      expect(await inMemoryKeyValueStorage.get(key)).to.equal('-1');
+      expect(store.get(key)).to.equal('-1');
     });
   });
 
@@ -80,10 +79,9 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   describe('#get', function () {
     it('should retrieve the value if it exists', async function () {
       // given
+      const key = 'testkey';
       const value = { name: 'name' };
-      const expirationDelaySeconds = 1000;
-
-      const key = await inMemoryKeyValueStorage.save({ value, expirationDelaySeconds });
+      store.set(key, value);
 
       // when
       const result = await inMemoryKeyValueStorage.get(key);
@@ -96,33 +94,30 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   describe('#update', function () {
     it('should set a new value', async function () {
       // given
-      const key = await inMemoryKeyValueStorage.save({
-        value: { name: 'name' },
-      });
+      const key = 'testkey';
+      const value = { name: 'name' };
+      store.set(key, value);
 
       // when
       await inMemoryKeyValueStorage.update(key, { url: 'url' });
 
       // then
-      const result = await inMemoryKeyValueStorage.get(key);
-      expect(result).to.deep.equal({ url: 'url' });
+      expect(store.get(key)).to.deep.equal({ url: 'url' });
     });
   });
 
   describe('#delete', function () {
     it('should delete the value if it exists', async function () {
       // given
+      const key = 'testkey';
       const value = { name: 'name' };
-      const expirationDelaySeconds = 1000;
-
-      const key = await inMemoryKeyValueStorage.save({ value, expirationDelaySeconds });
+      store.set(key, value);
 
       // when
       await inMemoryKeyValueStorage.delete(key);
 
       // then
-      const savedKey = await inMemoryKeyValueStorage.get(key);
-      expect(savedKey).to.be.undefined;
+      expect(store.has(key)).to.be.false;
     });
   });
 
@@ -135,61 +130,54 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
   describe('#lpush', function () {
     it('should add value into key list', async function () {
       // given
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
+      const key = 'key:lpush';
+      const value = 'value';
 
       // when
       const length = await inMemoryKeyValueStorage.lpush('key:lpush', 'value');
 
       // then
       expect(length).to.equal(1);
+      expect(store.get(key)).to.deep.equal([value]);
     });
   });
 
   describe('#lrem', function () {
     it('should remove values into key list', async function () {
       // given
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
+      const key = 'key:lrem';
+      store.set(key, ['value1', 'value2', 'value1']);
 
       // when
-      const key = 'key:lrem';
-      await inMemoryKeyValueStorage.lpush(key, 'value1');
-      await inMemoryKeyValueStorage.lpush(key, 'value2');
-      await inMemoryKeyValueStorage.lpush(key, 'value1');
-
       const length = await inMemoryKeyValueStorage.lrem(key, 'value1');
 
       // then
       expect(length).to.equal(2);
+      expect(store.get(key)).to.deep.equal(['value2']);
     });
   });
 
   describe('#lrange', function () {
     it('should return key values list', async function () {
       // given
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
+      const key = 'key:lrange';
+      store.set(key, ['value1', 'value2', 'value3']);
 
       // when
-      const key = 'key:lrange';
-      await inMemoryKeyValueStorage.lpush(key, 'value1');
-      await inMemoryKeyValueStorage.lpush(key, 'value2');
-      await inMemoryKeyValueStorage.lpush(key, 'value3');
-
       const values = await inMemoryKeyValueStorage.lrange(key);
 
       // then
-      expect(values).to.have.lengthOf(3);
-      expect(values).to.deep.equal(['value3', 'value2', 'value1']);
+      expect(values).to.deep.equal(['value1', 'value2', 'value3']);
     });
   });
 
   describe('#keys', function () {
     it('should return matching keys', async function () {
       // given
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
-      inMemoryKeyValueStorage.save({ key: 'prefix:key1', value: true });
-      inMemoryKeyValueStorage.save({ key: 'prefix:key2', value: true });
-      inMemoryKeyValueStorage.save({ key: 'prefix:key3', value: true });
-      inMemoryKeyValueStorage.save({ key: 'otherprefix:key4', value: true });
+      store.set('prefix:key1', true);
+      store.set('prefix:key2', true);
+      store.set('prefix:key3', true);
+      store.set('otherprefix:key4', true);
 
       // when
       const values = inMemoryKeyValueStorage.keys('prefix:*');
@@ -200,14 +188,13 @@ describe('Unit | Infrastructure | key-value-storage | InMemoryKeyValueStorage', 
 
     it('should return matching keys for all keys', async function () {
       // given
-      const inMemoryKeyValueStorage = new InMemoryKeyValueStorage();
-      inMemoryKeyValueStorage.save({ key: 'prefix:key1', value: true });
-      inMemoryKeyValueStorage.save({ key: 'prefix:key2', value: true });
-      inMemoryKeyValueStorage.save({ key: 'prefix:key3', value: true });
-      inMemoryKeyValueStorage.save({ key: 'otherprefix:key4', value: true });
+      store.set('prefix:key1', true);
+      store.set('prefix:key2', true);
+      store.set('prefix:key3', true);
+      store.set('otherprefix:key4', true);
 
       // when
-      const values = inMemoryKeyValueStorage.keys('*');
+      const values = await inMemoryKeyValueStorage.keys('*');
 
       // then
       expect(values).to.deep.equal(['prefix:key1', 'prefix:key2', 'prefix:key3', 'otherprefix:key4']);


### PR DESCRIPTION
## ☀️ Problème

Une session est révoquée définitivement, donc il n’est pas nécessaire de stocker un timestamp de fin de révocation.

## ⛱️ Proposition

Cesser de stocker le timstamp de révocation de session, on stocke une chaîne vide à la place, la présence de la clé est suffisante.

## 🧴 Remarques

N/A

## 🏊 Pour tester

Vérifier qu’il n’y a pas de régression au niveau de la révocation de session avec le feature toggle actif.

Le feature toggle est actif sur la RA.
