### PR TITLE
[FEATURE] Forcer le choix de langue français pour les certifications Pix + (PIX-24134)

### DIFF
--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -216,10 +216,17 @@ export default class CertificationStarter extends Component {
             @options={{this.languageOptions}}
             @hideDefaultOption={{true}}
             @iconName="language"
+            @isDisabled={{@model.certificationCandidate.hasPixPlusSubscription}}
           >
             <:label>{{t "pages.certification-start.language-selector.label"}}</:label>
             <:default as |language|>{{language.label}}</:default>
           </PixSelect>
+
+          {{#if @model.certificationCandidate.hasPixPlusSubscription}}
+            <span class="certification-start-form__pix-plus-explanation">{{t
+                "pages.certification-start.language-selector.pix-plus-explanation"
+              }}</span>
+          {{/if}}
 
           <PixCheckbox
             @class="certification-start-form__lang-confirm-checkbox"

--- a/mon-pix/app/models/certification-candidate.js
+++ b/mon-pix/app/models/certification-candidate.js
@@ -20,4 +20,8 @@ export default class CertificationCandidate extends Model {
   get isEligibleToDoubleCertification() {
     return this.isRegisteredToDoubleCertification && this.doubleCertificationEligibility;
   }
+
+  get hasPixPlusSubscription() {
+    return !(this.subscription === 'CORE');
+  }
 }

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -112,6 +112,12 @@
   border-bottom: 1px solid var(--pix-neutral-100);
 }
 
+.certification-start-form__pix-plus-explanation {
+  color: var(--pix-neutral-800);
+
+  @extend %pix-body-s;
+}
+
 .certification-start-form__code {
   padding-top: var(--pix-spacing-4x);
 

--- a/mon-pix/tests/integration/components/certification-starter-test.gjs
+++ b/mon-pix/tests/integration/components/certification-starter-test.gjs
@@ -106,18 +106,41 @@ module('Integration | Component | certification-starter', function (hooks) {
           );
         });
 
-        test('should be possible to update the selected language', async function (assert) {
-          // given
-          const screen = await renderComponent();
+        module('when candidate subscription is CORE', function () {
+          test('should be possible to update the selected language', async function (assert) {
+            // given
+            setCertificationCandidate(this, { hasStartedTest: false, subscription: 'CORE' });
+            const screen = await renderComponent();
 
-          // when
-          await click(screen.getByRole('button', { name: 'Langue de certification' }));
-          await click(screen.getByText('anglais - EN'));
+            // when
+            await click(screen.getByRole('button', { name: 'Langue de certification' }));
+            await click(screen.getByText('anglais - EN'));
 
-          // then
-          assert.ok(
-            screen.getByRole('button', { name: 'Langue de certification' }).textContent.includes('anglais - EN'),
-          );
+            // then
+
+            assert.ok(
+              screen.getByRole('button', { name: 'Langue de certification' }).textContent.includes('anglais - EN'),
+            );
+          });
+        });
+
+        module('when candidate subscription is not CORE', function () {
+          test('should be not possible to update the french selected language', async function (assert) {
+            // given
+            setCertificationCandidate(this, { hasStartedTest: false, subscription: 'DROIT' });
+            const screen = await renderComponent();
+
+            // then
+            assert.ok(
+              screen.getByRole('button', { name: 'Langue de certification' }).textContent.includes('français - FR'),
+            );
+            assert.ok(
+              screen.getByRole('button', { name: 'Langue de certification' }).hasAttribute('aria-disabled', 'true'),
+            );
+            assert
+              .dom(screen.getByText(t('pages.certification-start.language-selector.pix-plus-explanation')))
+              .exists();
+          });
         });
 
         module('when the language confirmation checkbox is not checked and code filled', function () {

--- a/mon-pix/translations/de.json
+++ b/mon-pix/translations/de.json
@@ -981,7 +981,8 @@
         "options": {
           "english": "Englisch - EN",
           "french": "Französisch - FR"
-        }
+        },
+        "pix-plus-explanation": "Test nur auf Französisch verfügbar."
       },
       "link-to-user-certification": "Meine Zertifizierungen ansehen",
       "non-eligible-subscription": "Du bist nicht für {subscriptionLabel} qualifiziert. Du aknnst dennoch deine Pix-Zertifizierung ablegen.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -981,7 +981,8 @@
         "options": {
           "english": "English - EN",
           "french": "French - FR"
-        }
+        },
+        "pix-plus-explanation": "Test only available in french."
       },
       "link-to-user-certification": "See my certificates",
       "non-eligible-subscription": "You are not eligible to {subscriptionLabel}. However, you can still take your Pix Certification.",

--- a/mon-pix/translations/es.json
+++ b/mon-pix/translations/es.json
@@ -981,7 +981,8 @@
         "options": {
           "english": "inglés - EN",
           "french": "francés - FR"
-        }
+        },
+        "pix-plus-explanation": "Test disponible únicamente en francés."
       },
       "link-to-user-certification": "Ver mis certificaciones",
       "non-eligible-subscription": "No eres elegible para {subscriptionLabel}. Sin embargo, puedes presentarte a la certificación Pix.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -981,7 +981,8 @@
         "options": {
           "english": "anglais - EN",
           "french": "français - FR"
-        }
+        },
+        "pix-plus-explanation": "Test disponible uniquement en français."
       },
       "link-to-user-certification": "Voir mes certifications",
       "non-eligible-subscription": "Vous n'êtes pas éligible à {subscriptionLabel}. Vous pouvez néanmoins passer votre certification Pix.",

--- a/mon-pix/translations/it.json
+++ b/mon-pix/translations/it.json
@@ -981,7 +981,8 @@
         "options": {
           "english": "inglese - EN",
           "french": "francese - FR"
-        }
+        },
+        "pix-plus-explanation": "Test disponibile solo in francese."
       },
       "link-to-user-certification": "Vedi le mie certificazioni",
       "non-eligible-subscription": "Non si ha diritto a {subscriptionLabel}. È tuttavia possibile ottenere la certificazione Pix.",

--- a/mon-pix/translations/nl.json
+++ b/mon-pix/translations/nl.json
@@ -981,7 +981,8 @@
         "options": {
           "english": "Engels - EN",
           "french": "Frans - FR"
-        }
+        },
+        "pix-plus-explanation": "Test alleen beschikbaar in het Frans."
       },
       "link-to-user-certification": "Bekijk mijn certificaten",
       "non-eligible-subscription": "Je komt niet in aanmerking voor {subscriptionLabel}. Je kunt echter wel je Pix-certificering behalen.",


### PR DESCRIPTION
## ☀️ Problème

Les Pix + ne sont disponible qu'en français. Nous avions à l'origine imposé qu'elles ne soient accessibles que sur pix.fr. Si un candidat tentait de se réconcilier à une Pix+ depuis pix.org, un message lui disait d'aller sur pix.fr. L'utilisateur devait alors se reconnecter et remplir à nouveau le formulaire de reconciliation.

## ⛱️ Proposition

Depuis que nous avons ajouté une sélection explicite de la langue avant l'entrée en certification, ainsi que l'enregistrement de ce choix sur le certification course (implémenté suite à des bugs de locale en certif), on peut éviter ces étapes à l'utilisateur.
Dorénavant, lors de l'entrée sur une certification Pix + depuis pix.org, la selection de la langue sera bloquée sur français.  

<img width="1123" height="982" alt="Capture d’écran du 2026-09-03 18-05-01" src="https://github.com/user-attachments/assets/7f53f3e4-7df5-4cfd-8ff8-d8955627c6b8" />

## 🧴 Remarques

Lors de l'entrée en certif depuis pix.fr, la langue française est toujours imposée.

Est ce qu'on autorise l'anglais pour CLEA ou c'est comme pour les Pix+ ?

## 🏊 Pour tester

Passer une certif cœur : la sélection de langue est disponible
Passer une certif Pix + : la selection de langue est bloqué, le français est imposé.

+ test E2E