### PR TITLE
[BUGFIX] Ajoutez une traduction manquante dans Pix App (PIX-23903)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1018,7 +1018,7 @@
         "skip-go-to-next": "Skip and go to the next question",
         "validate": "Validate",
         "validate-go-to-next": "Validate and go to the next question",
-        "wait-for-invigilator": "Les actions sont mises en pause en attendant le surveillant"
+        "wait-for-invigilator": "Actions are paused while waiting for the invigilator"
       },
       "already-answered": "You have already answered this question",
       "answer-input": {


### PR DESCRIPTION
## ☀️ Problème

Une traduction été manquante dans mon-pix

## ⛱️ Proposition

Ajout de la traduction

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
Déclencher une live alert pendant le passage d'une certification en anglais
