### PR TITLE
[TECH] :broom: suppression de certaines utilisations de `lodash` chez Certif

### DIFF
--- a/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
+++ b/api/src/certification/configuration/infrastructure/repositories/attachable-target-profiles-repository.js
@@ -1,6 +1,5 @@
 // @ts-check
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
-import { isBlank } from '../../../../shared/infrastructure/utils/lodash-utils.js';
 import { AttachableTargetProfile } from '../../domain/models/AttachableTargetProfile.js';
 
 /**
@@ -25,7 +24,7 @@ export async function find({ searchTerm } = {}) {
 }
 
 function _searchByCriteria({ builder, searchTerm }) {
-  if (!isBlank(searchTerm)) {
+  if (searchTerm !== undefined && searchTerm.trim().length !== 0) {
     const filteredBuilder = _searchByTargetProfileName({ builder, searchTerm });
     const isNumberOnly = /^\d+$/.test(searchTerm);
     if (isNumberOnly) {

--- a/api/src/certification/session-management/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js
+++ b/api/src/certification/session-management/domain/read-models/ComplementaryCertificationCourseResultForJuryCertificationWithExternal.js
@@ -1,7 +1,3 @@
-import lodash from 'lodash';
-
-const { minBy } = lodash;
-
 import { ChallengesReferential } from '../../../shared/domain/models/ChallengesReferential.js';
 import { juryOptions } from '../../../shared/domain/models/ComplementaryCertificationCourseResult.js';
 
@@ -82,7 +78,7 @@ export class ComplementaryCertificationCourseResultForJuryCertificationWithExter
     if (!this.pixSection.acquired) return 'Rejetée';
     if (!this.externalSection.isEvaluated) return 'En attente volet jury';
     if (!this.externalSection.acquired) return 'Rejetée';
-    return minBy([this.pixSection, this.externalSection], ({ level }) => level).label;
+    return [this.pixSection, this.externalSection].reduce((a, b) => (a.level <= b.level ? a : b), {}).label;
   }
 }
 

--- a/api/src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js
+++ b/api/src/certification/session-management/infrastructure/serializers/jury-certification-summary-serializer.js
@@ -1,8 +1,4 @@
-import lodash from 'lodash';
-
 const { Serializer } = jsonapiSerializer;
-
-const { get } = lodash;
 
 import jsonapiSerializer from 'jsonapi-serializer';
 
@@ -12,7 +8,7 @@ export function serialize(juryCertificationSummary, meta, { translate }) {
       // eslint-disable-next-line no-unused-vars
       const { certificationIssueReports, ...result } = juryCertificationSummary;
       result.certificationObtained = juryCertificationSummary.getCertificationLabel(translate);
-      result.examinerComment = get(juryCertificationSummary, 'certificationIssueReports[0].description');
+      result.examinerComment = extractExaminerComment(juryCertificationSummary);
       result.numberOfCertificationIssueReports = juryCertificationSummary.certificationIssueReports.length;
       result.reachedResultKey = juryCertificationSummary.reachedResultKey;
       result.numberOfCertificationIssueReportsWithRequiredAction =
@@ -39,4 +35,10 @@ export function serialize(juryCertificationSummary, meta, { translate }) {
     ],
     meta,
   }).serialize(juryCertificationSummary);
+}
+
+function extractExaminerComment(juryCertificationSummary) {
+  if (juryCertificationSummary.certificationIssueReports.length > 0) {
+    return juryCertificationSummary.certificationIssueReports[0].description;
+  }
 }

--- a/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certifiable-badge-acquisition-repository.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CertifiableBadgeAcquisition } from '../../domain/models/CertifiableBadgeAcquisition.js';
 
@@ -62,22 +60,29 @@ export async function findHighestCertifiable({ userId, limitDate = new Date() })
         ),
     });
 
-  const highestCertifiableBadgeAcquisitionByComplementaryCertificationId = _(certifiableBadgeAcquisitions)
-    .groupBy('complementaryCertificationId')
-    .values()
-    .map((certifiableBadgeAcquisitionByComplementaryCertifications) =>
-      maxByComplementaryCertificationBadgeLevel(certifiableBadgeAcquisitionByComplementaryCertifications),
-    )
-    .flatten()
-    .value();
-
-  return _toDomain(highestCertifiableBadgeAcquisitionByComplementaryCertificationId);
+  const highestCertifiableBadgeAcquisitionByComplementaryCertificationId = {};
+  for (const certifiableBadgeAcquisition of certifiableBadgeAcquisitions) {
+    const complementaryCertificationId = certifiableBadgeAcquisition.complementaryCertificationId;
+    const existingEntryForBadge =
+      highestCertifiableBadgeAcquisitionByComplementaryCertificationId[complementaryCertificationId];
+    if (
+      badgeLevelIsNotGreaterThan(
+        existingEntryForBadge,
+        certifiableBadgeAcquisition.complementaryCertificactionBadgeLevel,
+      )
+    ) {
+      continue;
+    }
+    highestCertifiableBadgeAcquisitionByComplementaryCertificationId[complementaryCertificationId] =
+      certifiableBadgeAcquisition;
+  }
+  return _toDomain(Object.values(highestCertifiableBadgeAcquisitionByComplementaryCertificationId));
 }
 
-function maxByComplementaryCertificationBadgeLevel(certifiableBadgeAcquisitionByComplementaryCertifications) {
-  return certifiableBadgeAcquisitionByComplementaryCertifications.reduce(function (a, b) {
-    return a.complementaryCertificactionBadgeLevel >= b.complementaryCertificactionBadgeLevel ? a : b;
-  }, {});
+function badgeLevelIsNotGreaterThan(existingEntryForBadge, otherBadgeLevel) {
+  return (
+    existingEntryForBadge !== undefined && existingEntryForBadge.complementaryCertificationBadgeLevel >= otherBadgeLevel
+  );
 }
 
 function _toDomain(certifiableBadgeAcquisitionsDto) {

--- a/api/src/shared/infrastructure/utils/lodash-utils.js
+++ b/api/src/shared/infrastructure/utils/lodash-utils.js
@@ -2,11 +2,6 @@ import pkg from 'lodash';
 
 const { runInContext } = pkg;
 const _ = runInContext();
-
-const isBlank = (string) => {
-  return string == null || (_.isString(string) && string.trim().length === 0);
-};
-
 _.mixin({
   /*
    * Returns the second element of an array.
@@ -65,7 +60,6 @@ _.mixin({
       }
     }
   },
-  isBlank,
   isArrayOfString: function (x) {
     return _.isArray(x) && _.every(x, _.isString);
   },
@@ -77,4 +71,4 @@ _.mixin({
   },
 });
 
-export { _, isBlank };
+export { _ };

--- a/api/tests/shared/unit/infrastructure/utils/lodash-utils_test.js
+++ b/api/tests/shared/unit/infrastructure/utils/lodash-utils_test.js
@@ -96,22 +96,4 @@ describe('Unit | Shared | infrastructure | Utils | lodash-utils', function () {
       expect(_.ensureString(true)).to.equal('true');
     });
   });
-
-  describe('#isBlank', function () {
-    it('should return true if string is undefined', function () {
-      expect(_.isBlank()).to.be.true;
-    });
-
-    [null, '', ' ', '   ', '\t', '\r\n', '\n'].forEach(function (string) {
-      it(`should return true if string is "${string}"`, function () {
-        expect(_.isBlank(string)).to.be.true;
-      });
-    });
-
-    ['a', ' a', 'a ', ' a ', '\ta\ta'].forEach(function (string) {
-      it(`should return false if string is "${string}"`, function () {
-        expect(_.isBlank(string)).to.be.false;
-      });
-    });
-  });
 });


### PR DESCRIPTION
## ☀️ Problème

Nous utilisons une bibliothèque externe pour faire des choses que nous pourrions faire en javascript natif.
Une bibliothèque externe est source d'insécurité pour notre logiciel.

## ⛱️ Proposition

Réduire l'utilisation de `lodash` dans le context de certification.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
