### PR TITLE
[TECH] :art: Met en place la règle de linter autour des noms de fonctions pour le sous domaine `certification/shared`

### DIFF
--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig([
     files: [
       'src/certification/configuration/**/*.{js,mjs,ts}',
       'src/certification/enrolment/**/*.{js,mjs,ts}',
+      'src/certification/shared/**/*.{js,mjs,ts}',
       'src/certification/results/**/*.{js,mjs,ts}',
       'src/certification/evaluation/**/*.{js,mjs,ts}',
     ],

--- a/api/src/certification/shared/application/pre-handlers/authorization.js
+++ b/api/src/certification/shared/application/pre-handlers/authorization.js
@@ -2,7 +2,7 @@ import { NotFoundError } from '../../../../shared/application/errors/http-errors
 import * as sessionRepository from '../../../session-management/infrastructure/repositories/session-management-repository.js';
 import * as certificationCourseRepository from '../../infrastructure/repositories/certification-course-repository.js';
 
-const verifySessionAuthorization = (request, h, dependencies = { sessionRepository }) => {
+export function verifySessionAuthorization(request, h, dependencies = { sessionRepository }) {
   const userId = request.auth.credentials.userId;
   const sessionId = request.params.sessionId;
 
@@ -11,13 +11,13 @@ const verifySessionAuthorization = (request, h, dependencies = { sessionReposito
     sessionId,
     sessionRepository: dependencies.sessionRepository,
   });
-};
+}
 
-const verifyCertificationSessionAuthorization = async (
+export async function verifyCertificationSessionAuthorization(
   request,
   h,
   dependencies = { sessionRepository, certificationCourseRepository },
-) => {
+) {
   const userId = request.auth.credentials.userId;
   const certificationCourseId = request.params.certificationCourseId;
 
@@ -28,11 +28,9 @@ const verifyCertificationSessionAuthorization = async (
     sessionId,
     sessionRepository: dependencies.sessionRepository,
   });
-};
+}
 
-const authorization = { verifySessionAuthorization, verifyCertificationSessionAuthorization };
-
-export { authorization, verifyCertificationSessionAuthorization, verifySessionAuthorization };
+export const authorization = { verifySessionAuthorization, verifyCertificationSessionAuthorization };
 
 async function _isAuthorizedToAccessSession({ userId, sessionId, sessionRepository }) {
   const hasMembershipAccess = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession({

--- a/api/src/certification/shared/domain/services/certification-badges-service.js
+++ b/api/src/certification/shared/domain/services/certification-badges-service.js
@@ -9,21 +9,21 @@ import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-ut
 /**
  * @returns {Promise<Array<CertifiableBadgeAcquisition>>}
  */
-const findStillValidBadgeAcquisitions = async function ({
+export async function findStillValidBadgeAcquisitions({
   userId,
   limitDate = new Date(),
   dependencies = { certifiableBadgeAcquisitionRepository, knowledgeElementRepository, badgeForCalculationRepository },
 }) {
   return _findBadgeAcquisitions({ userId, limitDate, shouldGetOutdated: false, dependencies });
-};
+}
 
-const findLatestBadgeAcquisitions = async function ({
+export async function findLatestBadgeAcquisitions({
   userId,
   limitDate = new Date(),
   dependencies = { certifiableBadgeAcquisitionRepository, knowledgeElementRepository, badgeForCalculationRepository },
 }) {
   return _findBadgeAcquisitions({ userId, limitDate, shouldGetOutdated: true, dependencies });
-};
+}
 
 /**
  * @param {object} params
@@ -34,7 +34,7 @@ const findLatestBadgeAcquisitions = async function ({
  *
  * @returns {Array<CertifiableBadgeAcquisition>} acquired complementary certification badges by a user
  */
-const _findBadgeAcquisitions = async function ({
+async function _findBadgeAcquisitions({
   userId,
   limitDate = new Date(),
   shouldGetOutdated = false,
@@ -70,6 +70,4 @@ const _findBadgeAcquisitions = async function ({
   );
 
   return badgeAcquisitions.filter(Boolean);
-};
-
-export { findLatestBadgeAcquisitions, findStillValidBadgeAcquisitions };
+}

--- a/api/src/certification/shared/domain/validators/session-validator.js
+++ b/api/src/certification/shared/domain/validators/session-validator.js
@@ -60,14 +60,14 @@ const sessionFiltersValidationSchema = Joi.object({
   version: Joi.number().valid(AlgorithmEngineVersion.V2, AlgorithmEngineVersion.V3).optional(),
 });
 
-const validateForMassSessionImport = function (session) {
+export function validateForMassSessionImport(session) {
   const { error } = sessionValidationForMassImportJoiSchema.validate(session, validationConfiguration);
   if (error) {
     return error.details.map(({ message }) => message);
   }
-};
+}
 
-const validateAndNormalizeFilters = function (filters) {
+export function validateAndNormalizeFilters(filters) {
   const { value, error } = sessionFiltersValidationSchema.validate(filters, { abortEarly: true });
 
   if (error) {
@@ -75,6 +75,4 @@ const validateAndNormalizeFilters = function (filters) {
   }
 
   return value;
-};
-
-export { validateAndNormalizeFilters, validateForMassSessionImport };
+}

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-live-alert-repository.js
@@ -4,29 +4,29 @@ import {
   CertificationChallengeLiveAlertStatus,
 } from '../../domain/models/CertificationChallengeLiveAlert.js';
 
-const save = async function ({ certificationChallengeLiveAlert }) {
+export async function save({ certificationChallengeLiveAlert }) {
   const knexConn = DomainTransaction.getConnection();
   return knexConn('certification-challenge-live-alerts')
-    .insert({ ..._toDTO(certificationChallengeLiveAlert), updatedAt: knexConn.fn.now() })
+    .insert({ ...certificationChallengeLiveAlert, updatedAt: knexConn.fn.now() })
     .onConflict(['id'])
     .merge();
-};
+}
 
-const getByAssessmentId = async ({ assessmentId }) => {
+export async function getByAssessmentId({ assessmentId }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationChallengeLiveAlertsDto = await knexConn('certification-challenge-live-alerts').where({
     assessmentId,
   });
 
   return certificationChallengeLiveAlertsDto.map(_toDomain);
-};
+}
 
 /**
  * @param {object} params
  * @param {number} params.assessmentId
  * @returns {Array<string>} array of challengeId with validated live alert raised for that assessment
  */
-const getLiveAlertValidatedChallengeIdsByAssessmentId = async ({ assessmentId }) => {
+export async function getLiveAlertValidatedChallengeIdsByAssessmentId({ assessmentId }) {
   const knexConn = DomainTransaction.getConnection();
   const liveAlertValidatedChallengeIds = await knexConn('certification-challenge-live-alerts')
     .select('challengeId')
@@ -36,9 +36,9 @@ const getLiveAlertValidatedChallengeIdsByAssessmentId = async ({ assessmentId })
     });
 
   return liveAlertValidatedChallengeIds.map((ccla) => ccla.challengeId);
-};
+}
 
-const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {
+export async function getOngoingBySessionIdAndUserId({ sessionId, userId }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationChallengeLiveAlertDto = await knexConn('certification-courses')
     .leftJoin('assessments', 'certification-courses.id', 'assessments.certificationCourseId')
@@ -55,9 +55,9 @@ const getOngoingBySessionIdAndUserId = async ({ sessionId, userId }) => {
     .first();
 
   return _toDomain(certificationChallengeLiveAlertDto);
-};
+}
 
-const getOngoingByChallengeIdAndAssessmentId = async ({ challengeId, assessmentId }) => {
+export async function getOngoingByChallengeIdAndAssessmentId({ challengeId, assessmentId }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationChallengeLiveAlertDto = await knexConn('certification-challenge-live-alerts')
     .where({
@@ -68,9 +68,9 @@ const getOngoingByChallengeIdAndAssessmentId = async ({ challengeId, assessmentI
     .first();
 
   return _toDomain(certificationChallengeLiveAlertDto);
-};
+}
 
-const getOngoingOrValidatedByChallengeIdAndAssessmentId = async ({ challengeId, assessmentId }) => {
+export async function getOngoingOrValidatedByChallengeIdAndAssessmentId({ challengeId, assessmentId }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationChallengeLiveAlertDto = await knexConn('certification-challenge-live-alerts')
     .where({
@@ -86,21 +86,11 @@ const getOngoingOrValidatedByChallengeIdAndAssessmentId = async ({ challengeId, 
     .first();
 
   return _toDomain(certificationChallengeLiveAlertDto);
-};
+}
 
-const _toDomain = (certificationChallengeLiveAlertDto) => {
+function _toDomain(certificationChallengeLiveAlertDto) {
   if (!certificationChallengeLiveAlertDto) {
     return null;
   }
   return new CertificationChallengeLiveAlert(certificationChallengeLiveAlertDto);
-};
-
-const _toDTO = (certificationChallengeLiveAlertDto) => certificationChallengeLiveAlertDto;
-export {
-  getByAssessmentId,
-  getLiveAlertValidatedChallengeIdsByAssessmentId,
-  getOngoingByChallengeIdAndAssessmentId,
-  getOngoingBySessionIdAndUserId,
-  getOngoingOrValidatedByChallengeIdAndAssessmentId,
-  save,
-};
+}

--- a/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-challenge-repository.js
@@ -7,7 +7,7 @@ const logContext = {
   type: 'repository',
 };
 
-const save = async function ({ certificationChallenge }) {
+export async function save({ certificationChallenge }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationChallengeToSave = new CertificationChallenge({
     challengeId: certificationChallenge.challengeId,
@@ -24,9 +24,9 @@ const save = async function ({ certificationChallenge }) {
     .returning('*');
 
   return new CertificationChallenge(savedCertificationChallenge);
-};
+}
 
-const getNextChallengeByCourseId = async function (courseId, ignoredChallengeIds) {
+export async function getNextChallengeByCourseId(courseId, ignoredChallengeIds) {
   const knexConn = DomainTransaction.getConnection();
   const certificationChallenge = await knexConn('certification-challenges')
     .where({ courseId })
@@ -42,6 +42,4 @@ const getNextChallengeByCourseId = async function (courseId, ignoredChallengeIds
   logger.trace(logContext, 'found challenge');
 
   return new CertificationChallenge(certificationChallenge);
-};
-
-export { getNextChallengeByCourseId, save };
+}

--- a/api/src/certification/shared/infrastructure/repositories/certification-companion-alert-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-companion-alert-repository.js
@@ -14,15 +14,15 @@ export async function create({ assessmentId, status }, { knex = DomainTransactio
   await knex(TABLE_NAME).insert({ assessmentId, status });
 }
 
-export const getAllByAssessmentId = async ({ assessmentId }) => {
+export async function getAllByAssessmentId({ assessmentId }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationCompanionLiveAlertsDto = await knexConn(TABLE_NAME).select('id', 'assessmentId', 'status').where({
     assessmentId,
   });
 
   return certificationCompanionLiveAlertsDto.map(_toDomain);
-};
+}
 
-const _toDomain = (certificationCompanionLiveAlertDto) => {
+function _toDomain(certificationCompanionLiveAlertDto) {
   return new CertificationCompanionLiveAlert(certificationCompanionLiveAlertDto);
-};
+}

--- a/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-course-repository.js
@@ -25,17 +25,17 @@ export async function save({ certificationCourse }) {
   return get({ id: certificationCourseId });
 }
 
-const _findCertificationCourse = async function (id, knexConn) {
+async function _findCertificationCourse(id, knexConn) {
   return knexConn('certification-courses').where({ id }).first();
-};
+}
 
-const _findAssessment = async function (certificationCourseId, knexConn) {
+async function _findAssessment(certificationCourseId, knexConn) {
   return knexConn('assessments').where({ certificationCourseId }).first();
-};
+}
 
-const _findAllChallenges = async function (certificationCourseId, knexConn) {
+async function _findAllChallenges(certificationCourseId, knexConn) {
   return knexConn('certification-challenges').where({ courseId: certificationCourseId });
-};
+}
 
 export async function get({ id }) {
   const knexConn = DomainTransaction.getConnection();

--- a/api/src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-issue-report-repository.js
@@ -2,7 +2,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
 
-const save = async function ({ certificationIssueReport }) {
+export async function save({ certificationIssueReport }) {
   const knexConn = DomainTransaction.getConnection();
 
   //eslint-disable-next-line no-unused-vars
@@ -16,9 +16,9 @@ const save = async function ({ certificationIssueReport }) {
     .returning('*');
 
   return new CertificationIssueReport(data);
-};
+}
 
-const get = async function ({ id }) {
+export async function get({ id }) {
   const knexConn = DomainTransaction.getConnection();
 
   const certificationIssueReport = await knexConn('certification-issue-reports').where({ id }).first();
@@ -26,20 +26,18 @@ const get = async function ({ id }) {
     throw new NotFoundError(`Certification issue report ${id} does not exist`);
   }
   return new CertificationIssueReport(certificationIssueReport);
-};
+}
 
-const findByCertificationCourseId = async function ({ certificationCourseId }) {
+export async function findByCertificationCourseId({ certificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
 
   const certificationIssueReports = await knexConn('certification-issue-reports').where({ certificationCourseId });
   return certificationIssueReports.map(
     (certificationIssueReport) => new CertificationIssueReport(certificationIssueReport),
   );
-};
+}
 
-const remove = async function ({ id }) {
+export async function remove({ id }) {
   const knexConn = DomainTransaction.getConnection();
   return knexConn('certification-issue-reports').where({ id }).del();
-};
-
-export { findByCertificationCourseId, get, remove, save };
+}

--- a/api/src/certification/shared/infrastructure/repositories/certification-report-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/certification-report-repository.js
@@ -3,7 +3,7 @@ import { Assessment } from '../../../../shared/domain/models/Assessment.js';
 import { CertificationIssueReport } from '../../domain/models/CertificationIssueReport.js';
 import { CertificationReport } from '../../domain/models/CertificationReport.js';
 
-export const findBySessionId = async ({ sessionId }) => {
+export async function findBySessionId({ sessionId }) {
   const knexConn = DomainTransaction.getConnection();
   const certificationReportsData = await knexConn
     .select({
@@ -54,7 +54,7 @@ export const findBySessionId = async ({ sessionId }) => {
   }
 
   return Array.from(certificationReportsWithIssuesDataByCertif.values(), toDomain);
-};
+}
 
 function toDomain(certificationReportWithIssuesData) {
   const certificationIssueReports = [];

--- a/api/src/certification/shared/infrastructure/repositories/competence-mark-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/competence-mark-repository.js
@@ -1,7 +1,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { CompetenceMark } from '../../domain/models/CompetenceMark.js';
 
-const save = async function (competenceMark) {
+export async function save(competenceMark) {
   await competenceMark.validate();
   const knexConn = DomainTransaction.getConnection();
   const [savedCompetenceMark] = await knexConn('competence-marks')
@@ -11,18 +11,16 @@ const save = async function (competenceMark) {
     .returning('*');
 
   return new CompetenceMark(savedCompetenceMark);
-};
+}
 
 /**
  * @param {object} params
  * @param {CompetenceMark[]} params.competenceMarks
  * @returns {Promise<void>}
  */
-const saveMany = async function ({ competenceMarks }) {
+export async function saveMany({ competenceMarks }) {
   await Promise.all(competenceMarks.map((competenceMark) => competenceMark.validate()));
 
   const knexConn = DomainTransaction.getConnection();
   await knexConn('competence-marks').insert(competenceMarks).returning('*');
-};
-
-export { save, saveMany };
+}

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-badge-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-badge-repository.js
@@ -2,7 +2,7 @@ import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.j
 import { NotFoundError } from '../../../../shared/domain/errors.js';
 import { ComplementaryCertificationBadge } from '../../domain/models/ComplementaryCertificationBadge.js';
 
-export const getAllWithSameTargetProfile = async (complementaryCertificationBadgeId) => {
+export async function getAllWithSameTargetProfile(complementaryCertificationBadgeId) {
   const knexConn = DomainTransaction.getConnection();
   const complementaryCertificationBadges = await knexConn('complementary-certification-badges')
     .select('complementary-certification-badges.*')
@@ -22,7 +22,7 @@ export const getAllWithSameTargetProfile = async (complementaryCertificationBadg
   }
 
   return complementaryCertificationBadges.map(_toDomain);
-};
+}
 
 function _toDomain(complementaryCertificationBadgeDTO) {
   return new ComplementaryCertificationBadge(complementaryCertificationBadgeDTO);

--- a/api/src/certification/shared/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -1,7 +1,7 @@
 import { DomainTransaction } from '../../../../shared/domain/DomainTransaction.js';
 import { ComplementaryCertificationCourseResult } from '../../domain/models/ComplementaryCertificationCourseResult.js';
 
-const getPixSourceResultByComplementaryCertificationCourseId = async function ({ complementaryCertificationCourseId }) {
+export async function getPixSourceResultByComplementaryCertificationCourseId({ complementaryCertificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   const result = await knexConn
     .select('*')
@@ -12,11 +12,9 @@ const getPixSourceResultByComplementaryCertificationCourseId = async function ({
   if (!result) return null;
 
   return ComplementaryCertificationCourseResult.from(result);
-};
+}
 
-const getAllowedJuryLevelIdsByComplementaryCertificationBadgeId = async function ({
-  complementaryCertificationBadgeId,
-}) {
+export async function getAllowedJuryLevelIdsByComplementaryCertificationBadgeId({ complementaryCertificationBadgeId }) {
   const knexConn = DomainTransaction.getConnection();
   return knexConn
     .pluck('complementary-certification-badges.id')
@@ -32,16 +30,16 @@ const getAllowedJuryLevelIdsByComplementaryCertificationBadgeId = async function
         .first(),
     )
     .orderBy('complementary-certification-badges.level', 'asc');
-};
+}
 
-const removeExternalJuryResult = async function ({ complementaryCertificationCourseId }) {
+export async function removeExternalJuryResult({ complementaryCertificationCourseId }) {
   const knexConn = DomainTransaction.getConnection();
   await knexConn('complementary-certification-course-results')
     .where({ complementaryCertificationCourseId, source: ComplementaryCertificationCourseResult.sources.EXTERNAL })
     .delete();
-};
+}
 
-const save = async function ({
+export async function save({
   complementaryCertificationCourseId,
   complementaryCertificationBadgeId,
   acquired,
@@ -52,11 +50,4 @@ const save = async function ({
     .insert({ complementaryCertificationBadgeId, acquired, complementaryCertificationCourseId, source })
     .onConflict(['complementaryCertificationCourseId', 'source'])
     .merge();
-};
-
-export {
-  getAllowedJuryLevelIdsByComplementaryCertificationBadgeId,
-  getPixSourceResultByComplementaryCertificationCourseId,
-  removeExternalJuryResult,
-  save,
-};
+}

--- a/api/src/certification/shared/infrastructure/repositories/issue-report-category-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/issue-report-category-repository.js
@@ -6,7 +6,7 @@ function _toDomain(issueReportCategoryModel) {
   return new CertificationIssueReportCategory({ id: issueReportCategoryModel.id });
 }
 
-const get = async function ({ name }) {
+export async function get({ name }) {
   const knexConn = DomainTransaction.getConnection();
   const issueReportCategory = await knexConn('issue-report-categories').where({ name }).first();
 
@@ -14,6 +14,4 @@ const get = async function ({ name }) {
     throw new NotFoundError('The issue report category name does not exist');
   }
   return _toDomain(issueReportCategory);
-};
-
-export { get };
+}

--- a/api/src/certification/shared/infrastructure/repositories/target-profile-history-repository.js
+++ b/api/src/certification/shared/infrastructure/repositories/target-profile-history-repository.js
@@ -3,7 +3,7 @@ import { TargetProfileHistoryForAdmin } from '../../../../shared/domain/models/T
 import { PromiseUtils } from '../../../../shared/infrastructure/utils/promise-utils.js';
 import { ComplementaryCertificationBadgeForAdmin } from '../../domain/models/ComplementaryCertificationBadgeForAdmin.js';
 
-const getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId = async function ({
+export async function getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId({
   complementaryCertificationId,
 }) {
   const knexConn = DomainTransaction.getConnection();
@@ -25,11 +25,9 @@ const getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId = 
     const badges = await _getTargetProfileComplementaryCertificationBadges({ targetProfile });
     return _toDomain({ targetProfile, badges });
   });
-};
+}
 
-const getDetachedTargetProfilesHistoryByComplementaryCertificationId = async function ({
-  complementaryCertificationId,
-}) {
+export async function getDetachedTargetProfilesHistoryByComplementaryCertificationId({ complementaryCertificationId }) {
   const knexConn = DomainTransaction.getConnection();
   const detachedTargetProfiles = await knexConn('complementary-certification-badges')
     .select({
@@ -54,12 +52,7 @@ const getDetachedTargetProfilesHistoryByComplementaryCertificationId = async fun
     const badges = await _getTargetProfileComplementaryCertificationBadges({ targetProfile });
     return _toDomain({ targetProfile, badges });
   });
-};
-
-export {
-  getCurrentTargetProfilesHistoryWithBadgesByComplementaryCertificationId,
-  getDetachedTargetProfilesHistoryByComplementaryCertificationId,
-};
+}
 
 async function _getTargetProfileComplementaryCertificationBadges({ targetProfile }) {
   const knexConn = DomainTransaction.getConnection();
@@ -79,6 +72,6 @@ async function _getTargetProfileComplementaryCertificationBadges({ targetProfile
   return badgesDTO.map((badge) => new ComplementaryCertificationBadgeForAdmin({ ...badge }));
 }
 
-const _toDomain = ({ targetProfile, badges }) => {
+function _toDomain({ targetProfile, badges }) {
   return new TargetProfileHistoryForAdmin({ ...targetProfile, badges });
-};
+}

--- a/api/src/certification/shared/infrastructure/serializers/jsonapi/certification-report-serializer.js
+++ b/api/src/certification/shared/infrastructure/serializers/jsonapi/certification-report-serializer.js
@@ -4,7 +4,7 @@ const { Serializer, Deserializer } = jsonapiSerializer;
 
 import { CertificationReport } from '../../../domain/models/CertificationReport.js';
 
-const serialize = function (certificationReports) {
+function serialize(certificationReports) {
   return new Serializer('certification-report', {
     attributes: [
       'certificationCourseId',
@@ -20,12 +20,12 @@ const serialize = function (certificationReports) {
       attributes: ['category', 'description', 'subcategory', 'questionNumber'],
     },
   }).serialize(certificationReports);
-};
+}
 
-const deserialize = async function (jsonApiData) {
+async function deserialize(jsonApiData) {
   const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
   const deserializedReport = await deserializer.deserialize(jsonApiData);
   return new CertificationReport(deserializedReport);
-};
+}
 
 export const certificationReportSerializer = { deserialize, serialize };


### PR DESCRIPTION
## ☀️ Problème

Il y a plein de façon de déclarer des fonctions dans JavaScript et Pix les utilisent toutes. Ça rends le code peu lisible.

## ⛱️ Proposition

Appliquer une règle de linter sur la façon de nommer les fonctions.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
