### PR TITLE
[BUGFIX] Réparer Smart Random simulator

### DIFF
--- a/api/src/evaluation/application/smart-random-simulator/index.js
+++ b/api/src/evaluation/application/smart-random-simulator/index.js
@@ -71,9 +71,7 @@ const getNextChallengeRoute = {
                 skill: skillValidationObject.required(),
                 timer: Joi.number().integer().allow(null),
                 focused: Joi.boolean().optional().allow(null),
-                locales: Joi.array()
-                  .items(Joi.string().valid(...getChallengeLocales()))
-                  .required(),
+                locales: Joi.array().items(Joi.string()).required(),
               })
               .min(1)
               .required(),


### PR DESCRIPTION
## ☀️ Problème

La validation des locales est trop stricte pour le simulateur.

## ⛱️ Proposition

Assouplir les règles Joi pour accepter n'importe quelle `string` pour la locale.

## 🏊 Pour tester

Le simulateur marche.