### PR TITLE
[FEATURE] Ajouter l'ID de la catégorie à la modification d'organisations en masse (PIX-23565)

### DIFF
--- a/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
+++ b/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
@@ -15,6 +15,47 @@ export default class UpdateOrganizationsInBatch extends Component {
   @service errorResponseHandler;
 
   @action
+  async handleBatchUpdateError(errorResponse) {
+    const error = errorResponse.errors[0];
+
+    switch (error.code) {
+      case 'ORGANIZATION_NOT_FOUND':
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.organization-not-found',
+            error.meta,
+          ),
+        });
+
+      case 'DPO_EMAIL_INVALID':
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.data-protection-email-invalid',
+            error.meta,
+          ),
+        });
+
+      case 'STRUCTURE_CATEGORY_NOT_FOUND':
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.category-not-found',
+            { categoryId: error.meta.categoryId },
+          ),
+        });
+
+      case 'ORGANIZATION_BATCH_UPDATE_ERROR':
+        return this.pixToast.sendErrorNotification({
+          message: this.intl.t(
+            'components.administration.update-organizations-in-batch.notifications.errors.organization-batch-update-error',
+            error.meta,
+          ),
+        });
+
+      default:
+        this.errorResponseHandler.notify(errorResponse);
+    }
+  }
+  @action
   async updateOrganizationsInBatch(files) {
     let response;
 
@@ -37,41 +78,10 @@ export default class UpdateOrganizationsInBatch extends Component {
         });
         return;
       } else {
-        const json = await response.json();
-        const error = json.errors[0];
+        const errorResponse = await response.json();
 
-        if (error.code === 'ORGANIZATION_NOT_FOUND') {
-          return this.pixToast.sendErrorNotification({
-            message: this.intl.t(
-              'components.administration.update-organizations-in-batch.notifications.errors.organization-not-found',
-              error.meta,
-            ),
-          });
-        } else if (error.code === 'DPO_EMAIL_INVALID') {
-          return this.pixToast.sendErrorNotification({
-            message: this.intl.t(
-              'components.administration.update-organizations-in-batch.notifications.errors.data-protection-email-invalid',
-              error.meta,
-            ),
-          });
-        } else if (error.code === 'ORGANIZATION_BATCH_UPDATE_ERROR') {
-          return this.pixToast.sendErrorNotification({
-            message: this.intl.t(
-              'components.administration.update-organizations-in-batch.notifications.errors.organization-batch-update-error',
-              error.meta,
-            ),
-          });
-        } else if (error.code === 'STRUCTURE_CATEGORY_NOT_FOUND') {
-          return this.pixToast.sendErrorNotification({
-            message: this.intl.t(
-              'components.administration.update-organizations-in-batch.notifications.errors.category-not-found',
-              { categoryId: error.meta.categoryId },
-            ),
-          });
-        }
+        await this.handleBatchUpdateError(errorResponse);
       }
-
-      this.errorResponseHandler.notify(await response.json());
     } catch {
       this.pixToast.sendErrorNotification({ message: this.intl.t('common.notifications.generic-error') });
     } finally {

--- a/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
+++ b/admin/app/components/administration/deployment/update-organizations-in-batch.gjs
@@ -61,6 +61,13 @@ export default class UpdateOrganizationsInBatch extends Component {
               error.meta,
             ),
           });
+        } else if (error.code === 'STRUCTURE_CATEGORY_NOT_FOUND') {
+          return this.pixToast.sendErrorNotification({
+            message: this.intl.t(
+              'components.administration.update-organizations-in-batch.notifications.errors.category-not-found',
+              { categoryId: error.meta.categoryId },
+            ),
+          });
         }
       }
 

--- a/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
+++ b/admin/tests/integration/components/administration/deployment/update-organizations-in-batch-test.gjs
@@ -112,6 +112,41 @@ module('Integration | Component |  administration/update-organizations-in-batch'
       );
     });
 
+    test('it displays an error when category id not found', async function (assert) {
+      // given
+      window.fetch.resolves(
+        fetchResponse({
+          body: {
+            errors: [
+              {
+                code: 'STRUCTURE_CATEGORY_NOT_FOUND',
+                meta: { categoryId: '42' },
+              },
+            ],
+          },
+          status: 422,
+        }),
+      );
+
+      // when
+      const screen = await render(
+        <template><UpdateOrganizationsInBatch /><PixToastContainer @closeButtonAriaLabel="Close" /></template>,
+      );
+      const input = await screen.findByLabelText(
+        t('components.administration.update-organizations-in-batch.upload-button'),
+      );
+      await triggerEvent(input, 'change', { files: [file] });
+
+      // then
+      assert.ok(
+        await screen.findByText(
+          t('components.administration.update-organizations-in-batch.notifications.errors.category-not-found', {
+            categoryId: '42',
+          }),
+        ),
+      );
+    });
+
     test('it displays an error when an unexpected issue happend during import', async function (assert) {
       // given
       window.fetch.resolves(

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -340,6 +340,7 @@
         "description": "Note: Only columns with a value will be modified.",
         "notifications": {
           "errors": {
+            "category-not-found": "Not found category for ID \"{categoryId}\".",
             "data-protection-email-invalid": "DPO email format invalid \"{value}\" for the organization \"{organizationId}\".",
             "organization-batch-update-error": "An error occurred for organization \"{organizationId}\".",
             "organization-not-found": "Organization id not found: \"{organizationId}\"."

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -347,6 +347,7 @@
         "description": "Note: Seules les colonnes ayant une valeur seront modifiées.",
         "notifications": {
           "errors": {
+            "category-not-found": "Identifiant non trouvé pour la catégorie \"{categoryId}\".",
             "data-protection-email-invalid": "Le format de l'email du DPO est incorrect \"{value}\" pour l'organisation \"{organizationId}\".",
             "organization-batch-update-error": "Une erreur s'est produite sur l'organisation \"{organizationId}\".",
             "organization-not-found": "Identifiant non trouvé pour l'organisation \"{organizationId}\"."

--- a/api/db/database-builder/factory/build-organization.js
+++ b/api/db/database-builder/factory/build-organization.js
@@ -106,9 +106,9 @@ const buildOrganizationInNetwork = function ({
  * @param {number} [options.certificationCenterId] - optional certification center id to link to the organization
  * @returns {{ organization: object, structure: object }}
  */
-const buildOrganizationWithStructure = function ({ organizationData, certificationCenterId } = {}) {
+const buildOrganizationWithStructure = function ({ organizationData, certificationCenterId, categoryId } = {}) {
   const organization = buildOrganization(organizationData);
-  const structure = buildStructure();
+  const structure = buildStructure({ categoryId });
   buildFactStructure({ structureId: structure.id, organizationId: organization.id, certificationCenterId });
   return { organization, structure };
 };

--- a/api/src/organizational-entities/domain/constants.js
+++ b/api/src/organizational-entities/domain/constants.js
@@ -51,6 +51,11 @@ export const ORGANIZATIONS_UPDATE_HEADER = {
       name: 'Organization Learner Type ID',
       property: 'organizationLearnerTypeId',
     }),
+    new CsvColumn({
+      name: 'Category ID',
+      property: 'categoryId',
+      isInteger: true,
+    }),
   ],
 };
 

--- a/api/src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js
+++ b/api/src/organizational-entities/domain/dtos/OrganizationBatchUpdateDTO.js
@@ -14,6 +14,7 @@ export class OrganizationBatchUpdateDTO {
    * @param {string|undefined} data.administrationTeamId
    * @param {string|undefined} data.countryCode
    * @param {string|undefined} data.organizationLearnerTypeId
+   * @param {number|null} data.categoryId
    */
   constructor(data) {
     this.id = data.id;
@@ -29,5 +30,6 @@ export class OrganizationBatchUpdateDTO {
     this.administrationTeamId = data.administrationTeamId ?? '';
     this.countryCode = data.countryCode ?? '';
     this.organizationLearnerTypeId = data.organizationLearnerTypeId ?? '';
+    this.categoryId = data.categoryId ?? '';
   }
 }

--- a/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
+++ b/api/src/organizational-entities/domain/models/OrganizationForAdmin.js
@@ -232,6 +232,7 @@ class OrganizationForAdmin {
       this.organizationLearnerType.id = organizationBatchUpdateDto.organizationLearnerTypeId;
       this.organizationLearnerType.name = undefined;
     }
+    if (organizationBatchUpdateDto.categoryId) this.categoryId = organizationBatchUpdateDto.categoryId;
   }
 
   updateParentOrganizationId(parentOrganizationId) {

--- a/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
+++ b/api/src/organizational-entities/domain/usecases/update-organizations-in-batch.usecase.js
@@ -14,6 +14,7 @@ import {
   OrganizationBatchUpdateError,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
+  StructureCategoryNotFound,
 } from '../errors.js';
 
 /**
@@ -23,6 +24,7 @@ import {
  * @param {OrganizationForAdminRepository} params.organizationForAdminRepository
  * @param {AdministrationTeamRepository} params.administrationTeamRepository
  * @param {CountryRepository} params.countryRepository
+ * @param {StructureCategoryRepository} params.structureCategoryRepository
  * @return {Promise<void>}
  */
 export const updateOrganizationsInBatch = withTransaction(
@@ -32,6 +34,7 @@ export const updateOrganizationsInBatch = withTransaction(
     administrationTeamRepository,
     countryRepository,
     organizationLearnerTypeRepository,
+    structureCategoryRepository,
   }) => {
     const dtos = await _getCsvData(filePath);
     if (dtos.length === 0) return;
@@ -40,12 +43,14 @@ export const updateOrganizationsInBatch = withTransaction(
     const administrationTeamIds = new Set();
     const countryCodes = new Set();
     const organizationLearnerTypeIds = new Set();
+    const structureCategoryIds = new Set();
 
     for (const dto of dtos) {
       organizationIds.add(dto.id);
       if (dto.administrationTeamId) administrationTeamIds.add(dto.administrationTeamId);
       if (dto.countryCode) countryCodes.add(dto.countryCode);
       if (dto.organizationLearnerTypeId) organizationLearnerTypeIds.add(dto.organizationLearnerTypeId);
+      if (dto.categoryId) structureCategoryIds.add(dto.categoryId);
     }
 
     const existingOrganizationIds = await _toExistingSet(Array.from(new Set([...organizationIds])), (ids) =>
@@ -64,11 +69,16 @@ export const updateOrganizationsInBatch = withTransaction(
       organizationLearnerTypeRepository.findExistingIds({ ids }),
     );
 
+    const existingStructureCategoryIds = await _toExistingSet(Array.from(structureCategoryIds), (ids) =>
+      structureCategoryRepository.findExistingIds({ ids }),
+    );
+
     _validateAllDtos(dtos, {
       existingOrganizationIds,
       existingAdministrationTeamIds,
       existingCountryCodes,
       existingOrganizationLearnerTypeIds,
+      existingStructureCategoryIds,
     });
 
     for (const dto of dtos) {
@@ -85,7 +95,13 @@ async function _toExistingSet(values, finder) {
 
 function _validateAllDtos(
   dtos,
-  { existingOrganizationIds, existingAdministrationTeamIds, existingCountryCodes, existingOrganizationLearnerTypeIds },
+  {
+    existingOrganizationIds,
+    existingAdministrationTeamIds,
+    existingCountryCodes,
+    existingOrganizationLearnerTypeIds,
+    existingStructureCategoryIds,
+  },
 ) {
   for (const dto of dtos) {
     if (!existingOrganizationIds.has(String(dto.id))) {
@@ -128,6 +144,13 @@ function _validateAllDtos(
       throw new OrganizationLearnerTypeNotFound({
         message: `Organization learner type not found for id ${dto.organizationLearnerTypeId}`,
         meta: { organizationLearnerTypeId: dto.organizationLearnerTypeId },
+      });
+    }
+
+    if (dto.categoryId && !existingStructureCategoryIds.has(String(dto.categoryId))) {
+      throw new StructureCategoryNotFound({
+        message: `Structure category not found for id ${dto.categoryId}`,
+        meta: { categoryId: dto.categoryId },
       });
     }
   }

--- a/api/src/organizational-entities/infrastructure/repositories/structure-category-repository.js
+++ b/api/src/organizational-entities/infrastructure/repositories/structure-category-repository.js
@@ -28,6 +28,17 @@ const findById = async function (id) {
   return _toDomain(structureCategory);
 };
 
+/**
+ * @type {function}
+ * @param {Array<string>} ids
+ * @return {Promise<Array<number>>}
+ */
+const findExistingIds = async function ({ ids = {} }) {
+  const knexConn = DomainTransaction.getConnection();
+  const structureCategories = await knexConn('structure_categories').select('id').whereIn('id', ids);
+  return structureCategories.map((category) => category.id);
+};
+
 const _toDomain = function (structureCategoryDTO) {
   return new StructureCategory({
     id: structureCategoryDTO.id,
@@ -35,4 +46,4 @@ const _toDomain = function (structureCategoryDTO) {
   });
 };
 
-export { findAll, findById };
+export { findAll, findById, findExistingIds };

--- a/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
+++ b/api/tests/organizational-entities/acceptance/application/organization/organization.admin.route.test.js
@@ -1462,16 +1462,21 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
           originalName: 'LALALAND',
         });
         databaseBuilder.factory.buildAdministrationTeam({ id: 1234 });
-        firstOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'first organization',
-          type: 'PRO',
-          countryCode: 99100,
-        });
-        otherOrganization = databaseBuilder.factory.buildOrganization({
-          name: 'other organization',
-          type: 'PRO',
-          countryCode: 99100,
-        });
+        databaseBuilder.factory.buildStructureCategory({ id: 50 });
+        firstOrganization = databaseBuilder.factory.buildOrganizationWithStructure({
+          organizationData: {
+            name: 'first organization',
+            type: 'PRO',
+            countryCode: 99100,
+          },
+        }).organization;
+        otherOrganization = databaseBuilder.factory.buildOrganizationWithStructure({
+          organizationData: {
+            name: 'other organization',
+            type: 'PRO',
+            countryCode: 99100,
+          },
+        }).organization;
 
         await databaseBuilder.commit();
       });
@@ -1479,8 +1484,8 @@ describe('Acceptance | Organizational Entities | Application | Route | Admin | O
       it('responds with a 204 - no content', async function () {
         // given
         const input = `${ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';')}
-      ${firstOrganization.id};MSFT;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500;
-      ${otherOrganization.id};APPL;;;;;;Cali;;1234;99500;`;
+      ${firstOrganization.id};MSFT;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;99500;;50
+      ${otherOrganization.id};APPL;;;;;;Cali;;1234;99500;;`;
 
         const options = {
           method: 'POST',

--- a/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
+++ b/api/tests/organizational-entities/integration/domain/usecases/update-organizations-in-batch.usecase.test.js
@@ -7,6 +7,7 @@ import {
   DpoEmailInvalid,
   OrganizationLearnerTypeNotFound,
   OrganizationNotFound,
+  StructureCategoryNotFound,
 } from '../../../../../src/organizational-entities/domain/errors.js';
 import { usecases } from '../../../../../src/organizational-entities/domain/usecases/index.js';
 import { ORGANIZATION_FEATURE } from '../../../../../src/shared/constants.js';
@@ -53,26 +54,36 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       databaseBuilder.factory.buildOrganizationLearnerType({ id: 12 });
       databaseBuilder.factory.buildOrganizationLearnerType({ id: 34 });
 
+      databaseBuilder.factory.buildStructureCategory({ label: 'Initial - Category', id: 50 });
+      databaseBuilder.factory.buildStructureCategory({ label: 'New - Category', id: 100 });
+
       databaseBuilder.factory.buildCertificationCpfCountry({
         code: '99100',
         commonName: 'France',
         originalName: 'France',
       });
 
-      organization1 = databaseBuilder.factory.buildOrganization({
-        externalId: 111,
-        identityProviderForCampaigns: null,
-        documentationUrl: null,
-        administrationTeamId: null,
-        countryCode: 99200,
-        name: 'Org 1 Before',
-      });
-      organization2 = databaseBuilder.factory.buildOrganization({
-        externalId: 222,
-        name: 'Org 2 Before',
-        administrationTeamId: null,
-        countryCode: 99200,
-      });
+      organization1 = databaseBuilder.factory.buildOrganizationWithStructure({
+        organizationData: {
+          externalId: 111,
+          identityProviderForCampaigns: null,
+          documentationUrl: null,
+          administrationTeamId: null,
+          countryCode: 99200,
+          name: 'Org 1 Before',
+        },
+        categoryId: 50,
+      }).organization;
+
+      organization2 = databaseBuilder.factory.buildOrganizationWithStructure({
+        organizationData: {
+          externalId: 222,
+          name: 'Org 2 Before',
+          administrationTeamId: null,
+          countryCode: 99200,
+        },
+        categoryId: 50,
+      }).organization;
 
       await databaseBuilder.commit();
     });
@@ -81,8 +92,8 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization1.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100;12
-      ${organization2.id};New Name;;;;;;Cali;;5678;99100;34`;
+      ${organization1.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;1234;99100;12;100
+      ${organization2.id};New Name;;;;;;Cali;;5678;99100;34;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -97,6 +108,13 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       expect(updatedOrganization1.countryCode).to.equal(99100);
       expect(updatedOrganization1.organizationLearnerTypeId).to.equal(12);
 
+      const updatedOrganization1Category = await knex('fct_structures')
+        .select({ id: 'structures.category_id' })
+        .join('structures', 'structures.id', 'fct_structures.structure_id')
+        .where({ organization_id: organization1.id })
+        .first();
+      expect(updatedOrganization1Category.id).to.equal(100);
+
       const dpo1 = await knex('data-protection-officers').where({ organizationId: organization1.id }).first();
       expect(dpo1.firstName).to.equal('Adam');
       expect(dpo1.lastName).to.equal('Troisjour');
@@ -107,6 +125,13 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       expect(updatedOrganization2.administrationTeamId).to.equal(5678);
       expect(updatedOrganization2.countryCode).to.equal(99100);
       expect(updatedOrganization2.organizationLearnerTypeId).to.equal(34);
+
+      const updatedOrganization2Category = await knex('fct_structures')
+        .select({ id: 'structures.category_id' })
+        .join('structures', 'structures.id', 'fct_structures.structure_id')
+        .where({ organization_id: organization2.id })
+        .first();
+      expect(updatedOrganization2Category.id).to.equal(50);
     });
   });
 
@@ -121,7 +146,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // given
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      999999;;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
+      999999;;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -139,7 +164,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;`;
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;1234;;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -157,7 +182,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;99999;`;
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;99999;;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -176,7 +201,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;`;
+        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -196,7 +221,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;;;`;
+        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo@email.com;;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -218,7 +243,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
         const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
         const fileData = `${headers}
-        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo;;;`;
+        ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;foo;;;;`;
         filePath = await createTempFile('test.csv', fileData);
 
         // when
@@ -241,7 +266,7 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
 
       const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
       const fileData = `${headers}
-      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;5678`;
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;5678;`;
       filePath = await createTempFile('test.csv', fileData);
 
       // when
@@ -252,6 +277,29 @@ describe('Integration | Organizational Entities | Domain | UseCase | update-orga
       // then
       expect(error).to.be.instanceOf(OrganizationLearnerTypeNotFound);
       expect(error.meta.organizationLearnerTypeId).to.equal('5678');
+    });
+
+    it('throws a StructureCategoryNotFound error when category id does not exist', async function () {
+      // given
+      const category = databaseBuilder.factory.buildStructureCategory({ id: 50 });
+      const organization = databaseBuilder.factory.buildOrganizationWithStructure({
+        categoryId: category.id,
+      }).organization;
+      await databaseBuilder.commit();
+
+      const headers = ORGANIZATIONS_UPDATE_HEADER.columns.map(({ name }) => name).join(';');
+      const fileData = `${headers}
+      ${organization.id};;12;OIDC_EXAMPLE_NET;https://doc.url;;Troisjour;Adam;;;;;999`;
+      filePath = await createTempFile('test.csv', fileData);
+
+      // when
+      const error = await catchErr(usecases.updateOrganizationsInBatch)({
+        filePath,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(StructureCategoryNotFound);
+      expect(error.meta.categoryId).to.equal(999);
     });
   });
 });

--- a/api/tests/organizational-entities/integration/infrastructure/repositories/structure-category-repository_test.js
+++ b/api/tests/organizational-entities/integration/infrastructure/repositories/structure-category-repository_test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   findAll,
   findById,
+  findExistingIds,
 } from '../../../../../src/organizational-entities/infrastructure/repositories/structure-category-repository.js';
 import { databaseBuilder } from '../../../../tooling/databases.js';
 import { domainBuilder } from '../../../../tooling/domain-builder/domain-builder.js';
@@ -54,6 +55,38 @@ describe('Integration | Repository | structure-category-repository', function ()
 
       // then
       expect(result).to.be.null;
+    });
+  });
+
+  describe('#findExistingIds', function () {
+    it('should return the ids of the structure categories matching the given ids', async function () {
+      // given
+      const firstStructureCategory = databaseBuilder.factory.buildStructureCategory({
+        label: 'Category 1',
+        id: 123,
+      });
+      const secondStructureCategory = databaseBuilder.factory.buildStructureCategory({
+        label: 'Category 2',
+        id: 456,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await findExistingIds({ ids: [firstStructureCategory.id, secondStructureCategory.id] });
+
+      // then
+      expect(result).to.deep.equal([firstStructureCategory.id, secondStructureCategory.id]);
+    });
+
+    it('should return an empty array if no structure categories matches the given ids', async function () {
+      // given
+      const unknownIds = [123, 456];
+
+      // when
+      const result = await findExistingIds({ ids: unknownIds });
+
+      // then
+      expect(result).to.deep.equal([]);
     });
   });
 });

--- a/api/tests/organizational-entities/unit/domain/dtos/OrganizationBatchUpdateDTO.test.js
+++ b/api/tests/organizational-entities/unit/domain/dtos/OrganizationBatchUpdateDTO.test.js
@@ -12,6 +12,7 @@ describe('Unit | Organizational Entities | Domain | DTO | OrganizationBatchUpdat
         dataProtectionOfficerEmail: 'adam.troisjour@example.net',
         administrationTeamId: '1234',
         countryCode: '99100',
+        categoryId: 50,
       };
 
       // when
@@ -33,6 +34,7 @@ describe('Unit | Organizational Entities | Domain | DTO | OrganizationBatchUpdat
         administrationTeamId: '1234',
         countryCode: '99100',
         organizationLearnerTypeId: '',
+        categoryId: 50,
       });
     });
   });

--- a/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
+++ b/api/tests/organizational-entities/unit/domain/models/OrganizationForAdmin_test.js
@@ -1213,6 +1213,28 @@ describe('Unit | Organizational Entities | Domain | Model | OrganizationForAdmin
       expect(organizationToUpdate.organizationLearnerType.id).to.equal(5678);
       expect(organizationToUpdate.organizationLearnerType.name).to.equal(undefined);
     });
+
+    it('updates the category id', function () {
+      // given
+      const organizationToUpdate = domainBuilder.buildOrganizationForAdmin();
+
+      // when
+      organizationToUpdate.updateFromOrganizationBatchUpdateDto(new OrganizationBatchUpdateDTO({ categoryId: 50 }));
+
+      // then
+      expect(organizationToUpdate.categoryId).to.equal(50);
+    });
+
+    it('does not update the category id if not provided', function () {
+      // given
+      const organizationToUpdate = domainBuilder.buildOrganizationForAdmin({ categoryId: 50 });
+
+      // when
+      organizationToUpdate.updateFromOrganizationBatchUpdateDto(new OrganizationBatchUpdateDTO({ categoryId: '' }));
+
+      // then
+      expect(organizationToUpdate.categoryId).to.equal(50);
+    });
   });
 
   context('#setCountryName', function () {


### PR DESCRIPTION
## ☀️ Problème
 On ne peut pas modifier la catégorie d'une organisation lors de la modification en masse.

## ⛱️ Proposition

Ajouter une colonne Category ID dans le CSV de modification en masse d'organisations et enregistrer cette modification.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
 Sur Pix Admin, connecté en tant que Super Admin:
- aller sur l'onglet Administration -> Déploiement
- télécharger le template de Modification des organisations en masse
- choisir plusieurs orgas à modifier et remplir les informations, notamment la nouvelle colonne _Category ID_ (IDs existants en base des RA: 8003, 8004, 8005)
- importer le fichier et constater le message de succès
- aller sur la page des orgas et constater les modifications de catégories

Cas d'erreur
- tester avec un ID de catégorie inexistant
- constater l'erreur
- constater qu'aucune orga du fichier n'a été modifiée