### PR TITLE
[BUGFIX] Corrections sur le blocage de langue de certif pour les pix-plus

### DIFF
--- a/high-level-tests/e2e-playwright/pages/pix-app/CertificationAccessCodePage.ts
+++ b/high-level-tests/e2e-playwright/pages/pix-app/CertificationAccessCodePage.ts
@@ -8,9 +8,6 @@ export class CertificationAccessCodePage {
     const languageDropdown = this.page.getByRole('button', { name: 'Langue de certification' });
 
     if (await languageDropdown.isVisible()) {
-      await languageDropdown.click();
-      await this.page.getByRole('option', { name: 'français - FR' }).click();
-
       const languageConfirmationCheckbox = this.page.getByRole('checkbox', {
         name: /Je confirme être à l'aise dans la langue sélectionnée/,
       });

--- a/mon-pix/app/components/certification-starter.gjs
+++ b/mon-pix/app/components/certification-starter.gjs
@@ -43,6 +43,13 @@ export default class CertificationStarter extends Component {
     : VALID_CERTIFICATION_LOCALES.FRENCH_FRANCE;
   @tracked hasCandidateConfirmedLanguage = !this._isOrgDomain;
 
+  get _certificationLocale() {
+    if (this._isOrgDomain && this.args.model.certificationCandidate.hasPixPlusSubscription) {
+      return VALID_CERTIFICATION_LOCALES.FRENCH_FRANCE;
+    }
+    return this.selectedLanguage;
+  }
+
   get accessCode() {
     return this.inputAccessCode.toUpperCase();
   }
@@ -134,7 +141,7 @@ export default class CertificationStarter extends Component {
     const newCertificationCourse = this.store.createRecord('certification-course', {
       accessCode: this.accessCode,
       sessionId: this.args.model.certificationCandidate.sessionId,
-      locale: this.selectedLanguage,
+      locale: this._certificationLocale,
     });
     try {
       await newCertificationCourse.save();

--- a/mon-pix/tests/integration/components/certification-starter-test.gjs
+++ b/mon-pix/tests/integration/components/certification-starter-test.gjs
@@ -351,6 +351,43 @@ module('Integration | Component | certification-starter', function (hooks) {
         assert.ok(certificationCourse.save.calledOnce);
       });
 
+      test('should submit with fr-fr locale when candidate has a Pix+ subscription on org domain', async function (assert) {
+        // given
+        const certificationCourse = {
+          id: '456',
+          save: sinon.stub(),
+          deleteRecord: sinon.stub(),
+        };
+
+        const createRecordStub = sinon.stub().returns(certificationCourse);
+
+        class StoreServiceStub extends Service {
+          createRecord = createRecordStub;
+        }
+
+        this.owner.register('service:store', StoreServiceStub);
+
+        stubFranceDomain(this.owner, false);
+
+        model = {
+          certificationCandidate: { hasStartedTest: false, sessionId: 123, hasPixPlusSubscription: true },
+        };
+        const screen = await renderComponent();
+        await fillAccessCode(screen, 'ABC123');
+        await confirmLanguageSelection(screen);
+
+        // when
+        await submitForm();
+
+        // then
+        sinon.assert.calledWithExactly(createRecordStub, 'certification-course', {
+          accessCode: 'ABC123',
+          sessionId: 123,
+          locale: 'fr-fr',
+        });
+        assert.ok(true);
+      });
+
       module('when the creation of certification course is in error', function (hooks) {
         hooks.beforeEach(function () {
           class RouterServiceStub extends Service {


### PR DESCRIPTION
## ☀️ Problème

La PR #17398 force la locale fr sur les pix +, or il faudrait forcer la 'fr-FR'. De plus la PR a cassé les tests e2e car elle désactive la dropdown  de choix de langue en cas de passage d'un pix +, or le test essaie de cliquer sur cette dropdown.

## ⛱️ Proposition

En cas de passage Pix plus, forcer la locale 'fr-FR'
Ne pas essayer de cliquer si la dropdown est désactiver

## 🧴 Remarques

Dans les tests, il n'est pas indispensable de cliquer sur ce menu dans tous les cas, car sauf erreur de ma part, "Français" est le choix par défaut, cependant, on teste donc pourquoi pas vérifier qu'il marche :woman_shrugging: 

## 🏊 Pour tester

Passer une certif pix plus sur le domain org. Vérifier qu'on se voit proposer 32 questions + vérifier en BDD que la locale est bien fr-FR
sur une certif coeur, pas d'impact.
Lancer les tests e2e (j'ai pas pu les lancer en local)
