### PR TITLE
[BUGFIX] Réduire au maximum l’exposition du jeton de réinitialisation de mot de passe (temporaryKey) dans les URL (PIX-24167)

### DIFF
--- a/api/src/identity-access-management/domain/emails/create-reset-password-demand.email.js
+++ b/api/src/identity-access-management/domain/emails/create-reset-password-demand.email.js
@@ -30,7 +30,7 @@ export function createResetPasswordDemandEmail({ email, temporaryKey, locale = F
       homeName: getPixWebsiteDomain(locale),
       homeUrl: getPixWebsiteUrl(locale),
       helpdeskUrl: getSupportUrl(locale),
-      resetUrl: getPixAppUrl(locale, { pathname: `/changer-mot-de-passe/${temporaryKey}` }),
+      resetUrl: getPixAppUrl(locale, { pathname: '/changer-mot-de-passe', hash: temporaryKey }),
       clickOnTheButton: i18n.__('reset-password-demand-email.params.clickOnTheButton'),
       contactUs: i18n.__('reset-password-demand-email.params.contactUs'),
       doNotAnswer: i18n.__('reset-password-demand-email.params.doNotAnswer'),

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -141,7 +141,7 @@ Router.map(function () {
   this.route('logout', { path: '/deconnexion' });
   this.route('not-connected', { path: '/nonconnecte' });
 
-  this.route('reset-password', { path: '/changer-mot-de-passe/:temporary_key' });
+  this.route('reset-password', { path: '/changer-mot-de-passe' });
   this.route('password-reset-demand', { path: '/mot-de-passe-oublie' });
   this.route('update-expired-password', { path: '/mise-a-jour-mot-de-passe-expire' });
 

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -2,14 +2,17 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
+import Location from 'mon-pix/utils/location';
 
 export default class ResetPasswordRoute extends Route {
   @service requestManager;
   @service errors;
   @service router;
 
-  async model(params) {
-    const passwordResetTemporaryKey = params.temporary_key;
+  async model() {
+    const { hash } = new URL(Location.getHref());
+    const passwordResetTemporaryKey = hash.slice(1);
+
     try {
       await this.requestManager.request({
         url: `${ENV.APP.API_HOST}/api/check-password-reset-demand`,

--- a/mon-pix/tests/acceptance/authentication/reset-password-form-test.js
+++ b/mon-pix/tests/acceptance/authentication/reset-password-form-test.js
@@ -30,10 +30,10 @@ module('Acceptance | Reset Password Form', function (hooks) {
     });
 
     // when
-    await visit('/changer-mot-de-passe/temporaryKey');
+    await visit('/changer-mot-de-passe#temporaryKey');
 
     // then
-    assert.strictEqual(currentURL(), '/changer-mot-de-passe/temporaryKey');
+    assert.strictEqual(currentURL(), '/changer-mot-de-passe#temporaryKey');
   });
 
   test('stays on /changer-mot-de-passe when password is successfully reset', async function (assert) {
@@ -51,7 +51,7 @@ module('Acceptance | Reset Password Form', function (hooks) {
       email: 'brandone.martins@pix.com',
     });
 
-    const screen = await visit('/changer-mot-de-passe/brandone-reset-key');
+    const screen = await visit('/changer-mot-de-passe#brandone-reset-key');
     const passwordInput = screen.getByLabelText(
       t('components.authentication.password-reset-form.fields.password.label'),
     );
@@ -61,7 +61,7 @@ module('Acceptance | Reset Password Form', function (hooks) {
     await clickByLabel(t('components.authentication.password-reset-form.actions.submit'));
 
     // then
-    assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
+    assert.strictEqual(currentURL(), '/changer-mot-de-passe#brandone-reset-key');
   });
 
   test('allows connected user to visit reset-password page', async function (assert) {
@@ -82,9 +82,9 @@ module('Acceptance | Reset Password Form', function (hooks) {
     await authenticate(user);
 
     // when
-    await visit('/changer-mot-de-passe/brandone-reset-key');
+    await visit('/changer-mot-de-passe#brandone-reset-key');
 
     // then
-    assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
+    assert.strictEqual(currentURL(), '/changer-mot-de-passe#brandone-reset-key');
   });
 });

--- a/mon-pix/tests/unit/routes/reset-password-test.js
+++ b/mon-pix/tests/unit/routes/reset-password-test.js
@@ -32,12 +32,8 @@ module('Unit | Route | reset-password', function (hooks) {
           sinon.stub(requestManagerService, 'request');
         });
 
-        test('it adds an error with its translation in error service', async function (assert) {
+        test('it adds an error and redirects to password-reset-demand', async function (assert) {
           // given
-          const params = {
-            temporary_key: 'pwd-reset-demand-token',
-          };
-
           requestManagerService.request.rejects({
             errors: [
               {
@@ -47,12 +43,13 @@ module('Unit | Route | reset-password', function (hooks) {
           });
 
           // when
-          await route.model(params);
+          await route.model();
 
           // then
           assert.strictEqual(errorService.errors.length, 1);
-          const errorTranslationKey = 'pages.reset-password.error.expired-demand';
-          assert.strictEqual(errorService.errors[0], errorTranslationKey);
+          assert.strictEqual(errorService.errors[0], 'pages.reset-password.error.expired-demand');
+
+          sinon.assert.calledWith(route.router.replaceWith, 'password-reset-demand');
         });
       });
     });


### PR DESCRIPTION
## ☀️ Problème

Cette PR est la suite de #17203 qui avait déjà bien réduit l’exposition d’informations sensibles passées dans les URL.

Mais il reste encore le jeton de réinitialisation de mot de passe (temporaryKey) qui est présent dans un chemin d’URL et qui va être donc présent dans toutes les requêtes côté serveur.

## ⛱️ Proposition

Utiliser un fragment d’URL (hash), qui n’est jamais envoyé aux serveurs, pour transmettre le jeton de réinitialisation de mot de passe (temporaryKey) au frontal Pix App.

Il reste 1 seul endroit où le jeton de réinitialisation de mot de passe (temporaryKey) reste loggé : c’est dans l’historique du navigateur. Utiliser un fragment d’URL (hash) est la manière qui fait/laisse le moins de traces, mais qui laissera toujours des traces dans le navigateur de l’utilisateur. C’est connu, mais non-améliorable. C’est pourquoi le jeton doit : 
* avoir une expiration, qui plus est courte
* être fonctionnellement révoqué une fois qu’il a été utilisé

## 🧴 Remarques

ℹ️ On fait le choix de ne pas chercher pas à gérer l’ancienne route `/changer-mot-de-passe/:temporary_key` car : 
* une demande de réinitialisation de mot de passe a une durée de validité de 1h, ce qui fait une plage très petite plage problématique de 1h après la mise en production
* l’ancienne route `/changer-mot-de-passe/:temporary_key` va rediriger l’utilisateur sur la page de connexion de Pix App, et le réflexe de l’utilisateur va être de refaire une nouvelle demande et il obtiendra à ce moment un nouveau lien, avec la nouvelle solution avec fragment (hash), qui fonctionnera cette fois.

## 🏊 Pour tester

La RA de Pix API peut envoyer des emails (la variable d’environnement `MAILING_ENABLED` a été mise à `true`).

1. Effectuer une demande de réinitialisation de mot de passe en suivant le lien _« Mot de passe oublié ? »_
2. Constater que l’URL reçu dans le courriel est de la forme `https://app-pr17421.review.pix.fr/changer-mot-de-passe#YYY` et non de la forme  `https://app-pr17421.review.pix.fr/changer-mot-de-passe/YYY`
3. Constater qu’il n’y a aucune erreur pendant toute la procédure et qu’on peut bien se connecter au compte avec le nouveau mot de passe défini
4. Constater dans les logs serveur que le jeton de réinitialisation de mot de passe (temporaryKey) n’est pas présent dans les logs serveur (soit sur la RA de Pix App comme dans la copie d’écran ci-dessous, soit par exemple en local sur une instance locale de nginx si vous en avez une)

<img width="1479" height="567" alt="pix_app_logs" src="https://github.com/user-attachments/assets/3fc4a5bc-a8aa-4cc8-8997-4eed8ed8f3b7" />
