### PR TITLE
[TECH] :recycle: Corrige des tests aléatoire dans le contexte du scoring de certification v2 (PIX-24158)

### DIFF
--- a/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
+++ b/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js
@@ -883,65 +883,15 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
   });
 
   context('#calculateCertificationAssessmentScore', function () {
-    let certificationAssessment, certificationAssessmentData, expectedCertifiedCompetences;
-    let competenceWithMarks_1_1, competenceWithMarks_2_2, competenceWithMarks_3_3, competenceWithMarks_4_4;
-    let areaRepository, candidateRepository;
-
-    beforeEach(function () {
-      areaRepository = {
-        list: sinon.stub(),
-      };
-      candidateRepository = {
-        findByAssessmentId: sinon.stub().throws('bad arguments'),
-      };
-      areaRepository.list.resolves(['1', '2', '3', '4', '5', '6'].map((code) => ({ id: `area${code}`, code })));
-      certificationAssessmentData = {
-        id: 1,
-        userId: 11,
-        certificationCourseId: 111,
-        createdAt: '2020-02-01T00:00:00Z',
-        state: Assessment.states.COMPLETED,
-        version: 2,
-      };
-      competenceWithMarks_1_1 = domainBuilder.buildCompetenceMark({
-        level: UNCERTIFIED_LEVEL,
-        score: 0,
-        area_code: '1',
-        competence_code: '1.1',
-        competenceId: 'competence_1',
-      });
-      competenceWithMarks_2_2 = domainBuilder.buildCompetenceMark({
-        level: UNCERTIFIED_LEVEL,
-        score: 0,
-        area_code: '2',
-        competence_code: '2.2',
-        competenceId: 'competence_2',
-      });
-      competenceWithMarks_3_3 = domainBuilder.buildCompetenceMark({
-        level: UNCERTIFIED_LEVEL,
-        score: 0,
-        area_code: '3',
-        competence_code: '3.3',
-        competenceId: 'competence_3',
-      });
-      competenceWithMarks_4_4 = domainBuilder.buildCompetenceMark({
-        level: UNCERTIFIED_LEVEL,
-        score: 0,
-        area_code: '4',
-        competence_code: '4.4',
-        competenceId: 'competence_4',
-      });
-      expectedCertifiedCompetences = [
-        competenceWithMarks_1_1,
-        competenceWithMarks_2_2,
-        competenceWithMarks_3_3,
-        competenceWithMarks_4_4,
-      ];
-    });
-
     context('When the candidate is not found', function () {
       it('should throw a CertificationCandidateNotFoundError', async function () {
         // given
+        const areaRepository = {
+          list: sinon.stub(),
+        };
+        const candidateRepository = {
+          findByAssessmentId: sinon.stub().throws('bad arguments'),
+        };
         const certificationAssessment = { id: 1 };
         candidateRepository.findByAssessmentId.withArgs({ assessmentId: certificationAssessment.id }).resolves(null);
 
@@ -962,6 +912,13 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
     context('When at least one challenge have more than one answer ', function () {
       it('should throw', async function () {
         // given
+        const areaRepository = {
+          list: sinon.stub(),
+        };
+        const candidateRepository = {
+          findByAssessmentId: sinon.stub().throws('bad arguments'),
+        };
+        areaRepository.list.resolves(['1', '2', '3', '4', '5', '6'].map((code) => ({ id: `area${code}`, code })));
         const certificationAnswersByDate = _.map(
           [
             { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
@@ -1017,514 +974,107 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
       });
     });
 
-    context('When there are less answers than challenges', function () {
-      it('should throw', async function () {
-        // given
-        const certificationAnswersByDate = _.map(
-          [
-            { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
-            { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
-            { challengeId: 'challenge_C_for_competence_1', result: 'ok' },
-            { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
-            { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
-            { challengeId: 'challenge_F_for_competence_2', result: 'ok' },
-            { challengeId: 'challenge_G_for_competence_3', result: 'ok' },
-            { challengeId: 'challenge_H_for_competence_3', result: 'ok' },
-            { challengeId: 'challenge_I_for_competence_3', result: 'ok' },
-            { challengeId: 'challenge_J_for_competence_4', result: 'ok' },
-            { challengeId: 'challenge_K_for_competence_4', result: 'ok' },
-          ],
-          domainBuilder.buildAnswer,
-        );
-
-        const certificationAssessment = {
-          certificationAnswersByDate,
-          certificationChallenges: challenges,
-        };
-        const candidate = domainBuilder.certification.evaluation.buildCandidate();
-
-        const placementProfileService = {
-          getPlacementProfile: sinon.stub(),
-        };
-        placementProfileService.getPlacementProfile
-          .withArgs({
-            userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
-          })
-          .resolves({ userCompetences });
-        candidateRepository.findByAssessmentId
-          .withArgs({
-            assessmentId: certificationAssessment.id,
-          })
-          .resolves(candidate);
-
-        // when
-        const error = await catchErr(calculateCertificationAssessmentScore)({
-          candidate,
-          certificationAssessment,
-          areaRepository,
-          placementProfileService,
-          scoringService,
-          candidateRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(CertificationComputeError);
-        expect(error.message).to.equal(
-          "L’utilisateur n’a pas répondu à toutes les questions, alors qu'aucune raison d'abandon n'a été fournie.",
-        );
-      });
-    });
-
-    context('When there is no challenge for a competence ', function () {
-      it('should throw', async function () {
-        // given
-        const certificationAnswersByDate = _.map(
-          [
-            { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
-            { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
-            { challengeId: 'challenge_C_for_competence_1', result: 'ok' },
-            { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
-            { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
-            { challengeId: 'challenge_F_for_competence_2', result: 'ok' },
-            { challengeId: 'challenge_G_for_competence_3', result: 'ok' },
-            { challengeId: 'challenge_H_for_competence_3', result: 'ok' },
-            { challengeId: 'challenge_I_for_competence_3', result: 'ok' },
-            { challengeId: 'challenge_J_for_competence_4', result: 'ok' },
-            { challengeId: 'challenge_K_for_competence_4', result: 'ok' },
-          ],
-          domainBuilder.buildAnswer,
-        );
-
-        const challenges = _.map(
-          [
-            {
-              challengeId: 'challenge_A_for_competence_1',
-              competenceId: 'competence_1',
-              associatedSkillName: '@skillChallengeA_1',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_C_for_competence_1',
-              competenceId: 'competence_1',
-              associatedSkillName: '@skillChallengeC_1',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_B_for_competence_1',
-              competenceId: 'competence_1',
-              associatedSkillName: '@skillChallengeB_1',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_D_for_competence_2',
-              competenceId: 'competence_2',
-              associatedSkillName: '@skillChallengeD_2',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_E_for_competence_2',
-              competenceId: 'competence_2',
-              associatedSkillName: '@skillChallengeE_2',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_F_for_competence_2',
-              competenceId: 'competence_2',
-              associatedSkillName: '@skillChallengeF_2',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_G_for_competence_3',
-              competenceId: 'competence_3',
-              associatedSkillName: '@skillChallengeG_3',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_H_for_competence_3',
-              competenceId: 'competence_3',
-              associatedSkillName: '@skillChallengeH_3',
-              type: 'QCM',
-            },
-            {
-              challengeId: 'challenge_I_for_competence_3',
-              competenceId: 'competence_3',
-              associatedSkillName: '@skillChallengeI_3',
-              type: 'QCM',
-            },
-          ],
-          domainBuilder.buildCertificationChallengeWithType,
-        );
-
-        const certificationAssessment = {
-          certificationAnswersByDate,
-          certificationChallenges: challenges,
-        };
-        const candidate = domainBuilder.certification.evaluation.buildCandidate();
-
-        const placementProfileService = {
-          getPlacementProfile: sinon.stub(),
-        };
-        placementProfileService.getPlacementProfile
-          .withArgs({
-            userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
-          })
-          .resolves({ userCompetences });
-        candidateRepository.findByAssessmentId
-          .withArgs({
-            assessmentId: certificationAssessment.id,
-          })
-          .resolves(candidate);
-
-        // when
-        const error = await catchErr(calculateCertificationAssessmentScore)({
-          candidate,
-          certificationAssessment,
-          areaRepository,
-          placementProfileService,
-          scoringService,
-          candidateRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(CertificationComputeError);
-        expect(error.message).to.equal('Pas assez de challenges posés pour la compétence 4.4');
-      });
-    });
-
-    context('Compute certification result for jury', function () {
-      let placementProfileService;
+    context('with a big before each', function () {
+      let certificationAssessment, certificationAssessmentData, expectedCertifiedCompetences;
+      let competenceWithMarks_1_1, competenceWithMarks_2_2, competenceWithMarks_3_3, competenceWithMarks_4_4;
+      let areaRepository, candidateRepository;
 
       beforeEach(function () {
-        certificationAssessment = domainBuilder.buildCertificationAssessment({
-          ...certificationAssessmentData,
-          certificationAnswersByDate: wrongAnswersForAllChallenges(),
-          certificationChallenges: challenges,
-        });
-        const candidate = domainBuilder.certification.evaluation.buildCandidate();
-
-        placementProfileService = {
-          getPlacementProfile: sinon.stub(),
-        };
-        placementProfileService.getPlacementProfile
-          .withArgs({
-            userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
-          })
-          .resolves({ userCompetences });
-        candidateRepository.findByAssessmentId
-          .withArgs({
-            assessmentId: certificationAssessment.id,
-          })
-          .resolves(candidate);
-      });
-
-      it('should get user profile', async function () {
-        // when
-        await calculateCertificationAssessmentScore({
-          certificationAssessment,
-          areaRepository,
-          placementProfileService,
-          scoringService,
-          candidateRepository,
-        });
-
-        // then
-        sinon.assert.calledOnce(placementProfileService.getPlacementProfile);
-      });
-
-      context('when assessment is just started', function () {
-        let startedCertificationAssessment;
-
-        beforeEach(function () {
-          startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
-            ...certificationAssessment,
-            state: Assessment.states.STARTED,
-          });
-        });
-
-        it('should return list of competences with all certifiedLevel at -1', async function () {
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment: startedCertificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when reproducibility rate is < 50%', function () {
-        it('should return list of competences with all certifiedLevel at -1', async function () {
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when reproducibility rate is between 80% and 100%', function () {
-        beforeEach(function () {
-          certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
-        });
-
-        it('should return list of competences with all certifiedLevel equal to estimatedLevel', async function () {
-          // given
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_1_1,
-              level: 1,
-              score: pixForCompetence1,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_2_2,
-              level: 2,
-              score: pixForCompetence2,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_3_3,
-              level: 3,
-              score: pixForCompetence3,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_4_4,
-              level: 4,
-              score: pixForCompetence4,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-
-        it('should return list of competences with certifiedLevel = estimatedLevel except for failed competence', async function () {
-          // given
-          certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_1_1,
-              level: 1,
-              score: pixForCompetence1,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_2_2,
-              level: 2,
-              score: pixForCompetence2,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_3_3,
-              level: 3,
-              score: pixForCompetence3,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_4_4,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when reproducibility rate is between 50% and 80%', function () {
-        it('should return list of competences with certifiedLevel less or equal to estimatedLevel', async function () {
-          // given
-          certificationAssessment.certificationAnswersByDate = await answersWithReproducibilityRateLessThan80();
-          const malusForFalseAnswer = 8;
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_1_1,
-              level: 0,
-              score: pixForCompetence1 - malusForFalseAnswer,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_2_2,
-              level: 2,
-              score: pixForCompetence2,
-            }),
-            competenceWithMarks_3_3,
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_4_4,
-              level: 3,
-              score: pixForCompetence4 - malusForFalseAnswer,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-
-        it('should return the percentage of correct answers', async function () {
-          // given
-          const certificationAssessmentWithNeutralizedChallenge = structuredClone(certificationAssessment);
-          certificationAssessmentWithNeutralizedChallenge.certificationAnswersByDate =
-            answersWithReproducibilityRateLessThan80();
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
-
-          // when
-          const { percentageCorrectAnswers } = await calculateCertificationAssessmentScore({
-            certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(percentageCorrectAnswers).to.deep.equal(64);
-        });
-
-        context('when one competence is evaluated with 3 challenges', function () {
-          let placementProfileService;
-
-          context('with one OK, one KO and one QROCM-dep OK', function () {
-            it('should return level obtained equal to level positioned minus one', async function () {
-              certificationAssessment.certificationAnswersByDate = await answersWithReproducibilityRateLessThan80();
-              // Given
-              const positionedLevel = 2;
-              const positionedScore = 20;
-
-              const answers = _.map(
-                [
-                  { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
-                  { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
-                  { challengeId: 'challenge_C_for_competence_1', result: 'ko' },
-                ],
-                domainBuilder.buildAnswer,
-              );
-
-              const challenges = _.map(
-                [
-                  {
-                    challengeId: 'challenge_A_for_competence_1',
-                    competenceId: 'competence_1',
-                    associatedSkillName: '@skillChallengeA_1',
-                  },
-                  {
-                    challengeId: 'challenge_B_for_competence_1',
-                    competenceId: 'competence_1',
-                    associatedSkillName: '@skillChallengeB_1',
-                  },
-                  {
-                    challengeId: 'challenge_C_for_competence_1',
-                    competenceId: 'competence_1',
-                    associatedSkillName: '@skillChallengeC_1',
-                  },
-                ],
-                domainBuilder.buildCertificationChallengeWithType,
-              );
-
-              const userCompetences = [_buildUserCompetence(competence_1, positionedScore, positionedLevel)];
-
-              certificationAssessment.certificationAnswersByDate = answers;
-              certificationAssessment.certificationChallenges = challenges;
-              placementProfileService = {
-                getPlacementProfile: sinon.stub(),
-              };
-              const candidate = domainBuilder.certification.evaluation.buildCandidate();
-              candidateRepository.findByAssessmentId
-                .withArgs({
-                  assessmentId: certificationAssessment.id,
-                })
-                .resolves(candidate);
-              placementProfileService.getPlacementProfile
-                .withArgs({
-                  userId: certificationAssessment.userId,
-                  limitDate: candidate.reconciledAt,
-                })
-                .resolves({ userCompetences });
-
-              // When
-              const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-                certificationAssessment,
-                areaRepository,
-                placementProfileService,
-                scoringService,
-                candidateRepository,
-              });
-
-              // Then
-              expect(certificationAssessmentScore.competenceMarks[0].level).to.deep.equal(positionedLevel - 1);
-              expect(certificationAssessmentScore.competenceMarks[0].score).to.deep.equal(positionedScore - 8);
-            });
-          });
-        });
-      });
-    });
-
-    context('Calculate certification result when assessment is completed (stop on error)', function () {
-      let placementProfileService;
-
-      beforeEach(function () {
-        certificationAssessment = domainBuilder.buildCertificationAssessment({
-          ...certificationAssessmentData,
-          certificationAnswersByDate: wrongAnswersForAllChallenges(),
-          certificationChallenges: challenges,
-        });
-        const candidate = domainBuilder.certification.evaluation.buildCandidate();
-        placementProfileService = {
-          getPlacementProfile: sinon.stub(),
+        areaRepository = {
+          list: sinon.stub(),
         };
         candidateRepository = {
-          findByAssessmentId: sinon
-            .stub()
+          findByAssessmentId: sinon.stub().throws('bad arguments'),
+        };
+        areaRepository.list.resolves(['1', '2', '3', '4', '5', '6'].map((code) => ({ id: `area${code}`, code })));
+        certificationAssessmentData = {
+          id: 1,
+          userId: 11,
+          certificationCourseId: 111,
+          createdAt: '2020-02-01T00:00:00Z',
+          state: Assessment.states.COMPLETED,
+          version: 2,
+        };
+        competenceWithMarks_1_1 = domainBuilder.buildCompetenceMark({
+          level: UNCERTIFIED_LEVEL,
+          score: 0,
+          area_code: '1',
+          competence_code: '1.1',
+          competenceId: 'competence_1',
+        });
+        competenceWithMarks_2_2 = domainBuilder.buildCompetenceMark({
+          level: UNCERTIFIED_LEVEL,
+          score: 0,
+          area_code: '2',
+          competence_code: '2.2',
+          competenceId: 'competence_2',
+        });
+        competenceWithMarks_3_3 = domainBuilder.buildCompetenceMark({
+          level: UNCERTIFIED_LEVEL,
+          score: 0,
+          area_code: '3',
+          competence_code: '3.3',
+          competenceId: 'competence_3',
+        });
+        competenceWithMarks_4_4 = domainBuilder.buildCompetenceMark({
+          level: UNCERTIFIED_LEVEL,
+          score: 0,
+          area_code: '4',
+          competence_code: '4.4',
+          competenceId: 'competence_4',
+        });
+        expectedCertifiedCompetences = [
+          competenceWithMarks_1_1,
+          competenceWithMarks_2_2,
+          competenceWithMarks_3_3,
+          competenceWithMarks_4_4,
+        ];
+      });
+
+      context('When there are less answers than challenges', function () {
+        it('should throw', async function () {
+          // given
+          const certificationAnswersByDate = _.map(
+            [
+              { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+              { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+              { challengeId: 'challenge_C_for_competence_1', result: 'ok' },
+              { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
+              { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
+              { challengeId: 'challenge_F_for_competence_2', result: 'ok' },
+              { challengeId: 'challenge_G_for_competence_3', result: 'ok' },
+              { challengeId: 'challenge_H_for_competence_3', result: 'ok' },
+              { challengeId: 'challenge_I_for_competence_3', result: 'ok' },
+              { challengeId: 'challenge_J_for_competence_4', result: 'ok' },
+              { challengeId: 'challenge_K_for_competence_4', result: 'ok' },
+            ],
+            domainBuilder.buildAnswer,
+          );
+
+          const certificationAssessment = {
+            certificationAnswersByDate,
+            certificationChallenges: challenges,
+          };
+          const candidate = domainBuilder.certification.evaluation.buildCandidate();
+
+          const placementProfileService = {
+            getPlacementProfile: sinon.stub(),
+          };
+          placementProfileService.getPlacementProfile
+            .withArgs({
+              userId: certificationAssessment.userId,
+              limitDate: candidate.reconciledAt,
+            })
+            .resolves({ userCompetences });
+          candidateRepository.findByAssessmentId
             .withArgs({
               assessmentId: certificationAssessment.id,
             })
-            .resolves(candidate),
-        };
-        placementProfileService.getPlacementProfile
-          .withArgs({
-            userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
-          })
-          .resolves({ userCompetences });
-      });
+            .resolves(candidate);
 
-      context('when reproducibility rate is < 50%', function () {
-        it('should return list of competences with all certifiedLevel at -1', async function () {
           // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+          const error = await catchErr(calculateCertificationAssessmentScore)({
+            candidate,
             certificationAssessment,
             areaRepository,
             placementProfileService,
@@ -1533,374 +1083,117 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           });
 
           // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when reproducibility rate is between 80% and 100%', function () {
-        beforeEach(function () {
-          certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
-        });
-
-        it('should return list of competences with all certifiedLevel equal to estimatedLevel', async function () {
-          // given
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_1_1,
-              level: 1,
-              score: pixForCompetence1,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_2_2,
-              level: 2,
-              score: pixForCompetence2,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_3_3,
-              level: 3,
-              score: pixForCompetence3,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_4_4,
-              level: 4,
-              score: pixForCompetence4,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-
-        it('should return list of competences with certifiedLevel = estimatedLevel except for failed competence', async function () {
-          // given
-          certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_1_1,
-              level: 1,
-              score: pixForCompetence1,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_2_2,
-              level: 2,
-              score: pixForCompetence2,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_3_3,
-              level: 3,
-              score: pixForCompetence3,
-            }),
-            competenceWithMarks_4_4,
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when reproducibility rate is between 50% and 80%', function () {
-        beforeEach(function () {
-          certificationAssessment.certificationAnswersByDate = answersWithReproducibilityRateLessThan80();
-        });
-
-        it('should return list of competences with certifiedLevel less or equal to estimatedLevel', async function () {
-          // given
-          const malusForFalseAnswer = 8;
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_1_1,
-              level: 0,
-              score: pixForCompetence1 - malusForFalseAnswer,
-            }),
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_2_2,
-              level: 2,
-              score: pixForCompetence2,
-            }),
-            competenceWithMarks_3_3,
-            domainBuilder.buildCompetenceMark({
-              ...competenceWithMarks_4_4,
-              level: 3,
-              score: pixForCompetence4 - malusForFalseAnswer,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when only one challenge is asked for a competence', function () {
-        let placementProfileService, candidateRepository;
-
-        it('certifies a level below the estimated one if reproducibility rate is < 70%', async function () {
-          // given
-          const userCompetences = [
-            _buildUserCompetence(competence_5, 50, 5),
-            _buildUserCompetence(competence_6, 36, 3),
-          ];
-          certificationAssessment.certificationChallenges = _.map(
-            [
-              {
-                challengeId: 'challenge_A_for_competence_5',
-                competenceId: 'competence_5',
-                associatedSkillName: '@skillChallengeA_5',
-              },
-              {
-                challengeId: 'challenge_A_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeA_6',
-              },
-              {
-                challengeId: 'challenge_B_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeB_6',
-              },
-              {
-                challengeId: 'challenge_C_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeC_6',
-              },
-            ],
-            domainBuilder.buildCertificationChallengeWithType,
+          expect(error).to.be.instanceOf(CertificationComputeError);
+          expect(error.message).to.equal(
+            "L’utilisateur n’a pas répondu à toutes les questions, alors qu'aucune raison d'abandon n'a été fournie.",
           );
+        });
+      });
 
-          placementProfileService = {
-            getPlacementProfile: sinon.stub(),
-          };
-          const candidate = domainBuilder.certification.evaluation.buildCandidate();
-          candidateRepository = {
-            findByAssessmentId: sinon
-              .stub()
-              .withArgs({
-                assessmentId: certificationAssessment.id,
-              })
-              .resolves(candidate),
-          };
-          placementProfileService.getPlacementProfile
-            .withArgs({
-              userId: certificationAssessment.userId,
-              limitDate: candidate.reconciledAt,
-            })
-            .resolves({ userCompetences });
-          certificationAssessment.certificationAnswersByDate = _.map(
+      context('When there is no challenge for a competence ', function () {
+        it('should throw', async function () {
+          // given
+          const certificationAnswersByDate = _.map(
             [
-              { challengeId: 'challenge_A_for_competence_5', result: 'ok' },
-              { challengeId: 'challenge_A_for_competence_6', result: 'ko' },
-              { challengeId: 'challenge_B_for_competence_6', result: 'ok' },
-              { challengeId: 'challenge_C_for_competence_6', result: 'ko' },
+              { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+              { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+              { challengeId: 'challenge_C_for_competence_1', result: 'ok' },
+              { challengeId: 'challenge_D_for_competence_2', result: 'ok' },
+              { challengeId: 'challenge_E_for_competence_2', result: 'ok' },
+              { challengeId: 'challenge_F_for_competence_2', result: 'ok' },
+              { challengeId: 'challenge_G_for_competence_3', result: 'ok' },
+              { challengeId: 'challenge_H_for_competence_3', result: 'ok' },
+              { challengeId: 'challenge_I_for_competence_3', result: 'ok' },
+              { challengeId: 'challenge_J_for_competence_4', result: 'ok' },
+              { challengeId: 'challenge_K_for_competence_4', result: 'ok' },
             ],
             domainBuilder.buildAnswer,
           );
 
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              competence_code: '5.5',
-              area_code: '5',
-              competenceId: 'competence_5',
-              level: 4,
-              score: 40,
-            }),
-            domainBuilder.buildCompetenceMark({
-              competence_code: '6.6',
-              area_code: '6',
-              competenceId: 'competence_6',
-              level: UNCERTIFIED_LEVEL,
-              score: 0,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when challenges contains one QROCM-dep challenge to validate two skills', function () {
-        let placementProfileService, candidateRepository;
-
-        beforeEach(function () {
-          const userCompetences = [
-            _buildUserCompetence(competence_5, 50, 5),
-            _buildUserCompetence(competence_6, 36, 3),
-          ];
-
-          certificationAssessment.certificationChallenges = _.map(
-            [
-              {
-                challengeId: 'challenge_A_for_competence_5',
-                competenceId: 'competence_5',
-                associatedSkillName: '@skillChallengeA_5',
-                type: 'QCM',
-              },
-              {
-                challengeId: 'challenge_B_for_competence_5',
-                competenceId: 'competence_5',
-                associatedSkillName: '@skillChallengeB_5',
-                type: 'QROCM-dep',
-              },
-              {
-                challengeId: 'challenge_A_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeA_6',
-                type: 'QCM',
-              },
-              {
-                challengeId: 'challenge_B_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeB_6',
-                type: 'QCM',
-              },
-              {
-                challengeId: 'challenge_C_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeC_6',
-                type: 'QCM',
-              },
-            ],
-            domainBuilder.buildCertificationChallengeWithType,
-          );
-
-          const candidate = domainBuilder.certification.evaluation.buildCandidate();
-          candidateRepository = {
-            findByAssessmentId: sinon
-              .stub()
-              .withArgs({
-                assessmentId: certificationAssessment.id,
-              })
-              .resolves(candidate),
-          };
-
-          placementProfileService = {
-            getPlacementProfile: sinon.stub(),
-          };
-          placementProfileService.getPlacementProfile
-            .withArgs({
-              userId: certificationAssessment.userId,
-              limitDate: candidate.reconciledAt,
-            })
-            .resolves({ userCompetences });
-        });
-
-        it('should compute the result as if QROCM-dep was two OK challenges', async function () {
-          // given
-          certificationAssessment.certificationAnswersByDate = _.map(
-            [
-              { challengeId: 'challenge_A_for_competence_5', result: 'ok' },
-              { challengeId: 'challenge_B_for_competence_5', result: 'ok' },
-              { challengeId: 'challenge_A_for_competence_6', result: 'ko' },
-              { challengeId: 'challenge_B_for_competence_6', result: 'ok' },
-              { challengeId: 'challenge_C_for_competence_6', result: 'ko' },
-            ],
-            domainBuilder.buildAnswer,
-          );
-
-          const expectedCertifiedCompetences = [
-            domainBuilder.buildCompetenceMark({
-              competence_code: '5.5',
-              area_code: '5',
-              competenceId: 'competence_5',
-              level: 5,
-              score: 40,
-            }),
-            domainBuilder.buildCompetenceMark({
-              competence_code: '6.6',
-              area_code: '6',
-              competenceId: 'competence_6',
-              level: UNCERTIFIED_LEVEL,
-              score: 0,
-            }),
-          ];
-
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
-          });
-
-          // then
-          expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
-        });
-      });
-
-      context('when there are challenges for non-certifiable competences', function () {
-        let challenges;
-
-        beforeEach(function () {
-          challenges = _.map(
+          const challenges = _.map(
             [
               {
                 challengeId: 'challenge_A_for_competence_1',
                 competenceId: 'competence_1',
                 associatedSkillName: '@skillChallengeA_1',
+                type: 'QCM',
               },
               {
-                challengeId: 'challenge_M_for_competence_5',
-                competenceId: 'competence_5',
-                associatedSkillName: '@skillChallengeM_5',
+                challengeId: 'challenge_C_for_competence_1',
+                competenceId: 'competence_1',
+                associatedSkillName: '@skillChallengeC_1',
+                type: 'QCM',
               },
               {
-                challengeId: 'challenge_N_for_competence_6',
-                competenceId: 'competence_6',
-                associatedSkillName: '@skillChallengeN_6',
+                challengeId: 'challenge_B_for_competence_1',
+                competenceId: 'competence_1',
+                associatedSkillName: '@skillChallengeB_1',
+                type: 'QCM',
+              },
+              {
+                challengeId: 'challenge_D_for_competence_2',
+                competenceId: 'competence_2',
+                associatedSkillName: '@skillChallengeD_2',
+                type: 'QCM',
+              },
+              {
+                challengeId: 'challenge_E_for_competence_2',
+                competenceId: 'competence_2',
+                associatedSkillName: '@skillChallengeE_2',
+                type: 'QCM',
+              },
+              {
+                challengeId: 'challenge_F_for_competence_2',
+                competenceId: 'competence_2',
+                associatedSkillName: '@skillChallengeF_2',
+                type: 'QCM',
+              },
+              {
+                challengeId: 'challenge_G_for_competence_3',
+                competenceId: 'competence_3',
+                associatedSkillName: '@skillChallengeG_3',
+                type: 'QCM',
+              },
+              {
+                challengeId: 'challenge_H_for_competence_3',
+                competenceId: 'competence_3',
+                associatedSkillName: '@skillChallengeH_3',
+                type: 'QCM',
+              },
+              {
+                challengeId: 'challenge_I_for_competence_3',
+                competenceId: 'competence_3',
+                associatedSkillName: '@skillChallengeI_3',
+                type: 'QCM',
               },
             ],
             domainBuilder.buildCertificationChallengeWithType,
           );
-          certificationAssessment.certificationChallenges = challenges;
 
-          certificationAssessment.certificationAnswersByDate = _.map(
-            [
-              { challengeId: 'challenge_A_for_competence_1', result: 'ko' },
+          const certificationAssessment = {
+            certificationAnswersByDate,
+            certificationChallenges: challenges,
+          };
+          const candidate = domainBuilder.certification.evaluation.buildCandidate();
 
-              { challengeId: 'challenge_M_for_competence_5', result: 'ok' },
-              { challengeId: 'challenge_N_for_competence_6', result: 'ok' },
-            ],
-            domainBuilder.buildAnswer,
-          );
-        });
+          const placementProfileService = {
+            getPlacementProfile: sinon.stub(),
+          };
+          placementProfileService.getPlacementProfile
+            .withArgs({
+              userId: certificationAssessment.userId,
+              limitDate: candidate.reconciledAt,
+            })
+            .resolves({ userCompetences });
+          candidateRepository.findByAssessmentId
+            .withArgs({
+              assessmentId: certificationAssessment.id,
+            })
+            .resolves(candidate);
 
-        it('should not include the extra challenges when computing reproducibility', async function () {
           // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+          const error = await catchErr(calculateCertificationAssessmentScore)({
+            candidate,
             certificationAssessment,
             areaRepository,
             placementProfileService,
@@ -1909,55 +1202,42 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           });
 
           // then
-          expect(certificationAssessmentScore.percentageCorrectAnswers).to.equal(0);
+          expect(error).to.be.instanceOf(CertificationComputeError);
+          expect(error.message).to.equal('Pas assez de challenges posés pour la compétence 4.4');
         });
       });
-    });
 
-    context('non neutralization rate trustability', function () {
-      let placementProfileService, candidateRepository;
+      context('Compute certification result for jury', function () {
+        let placementProfileService;
 
-      beforeEach(function () {
-        certificationAssessment = domainBuilder.buildCertificationAssessment({
-          ...certificationAssessmentData,
-          certificationAnswersByDate: wrongAnswersForAllChallenges(),
-          certificationChallenges: challenges,
-        });
-        certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
-        const candidate = domainBuilder.certification.evaluation.buildCandidate();
-        placementProfileService = {
-          getPlacementProfile: sinon.stub(),
-        };
-        candidateRepository = {
-          findByAssessmentId: sinon
-            .stub()
+        beforeEach(function () {
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: challenges,
+          });
+          const candidate = domainBuilder.certification.evaluation.buildCandidate();
+
+          placementProfileService = {
+            getPlacementProfile: sinon.stub(),
+          };
+          placementProfileService.getPlacementProfile
+            .withArgs({
+              userId: certificationAssessment.userId,
+              limitDate: candidate.reconciledAt,
+            })
+            .resolves({ userCompetences });
+          candidateRepository.findByAssessmentId
             .withArgs({
               assessmentId: certificationAssessment.id,
             })
-            .resolves(candidate),
-        };
-        placementProfileService.getPlacementProfile
-          .withArgs({
-            userId: certificationAssessment.userId,
-            limitDate: candidate.reconciledAt,
-          })
-          .resolves({ userCompetences });
-      });
+            .resolves(candidate);
+        });
 
-      context('when certification has enough non neutralized challenges to be trusted', function () {
-        it('should return a CertificationAssessmentScore which hasEnoughNonNeutralizedChallengesToBeTrusted is true', async function () {
-          // given
-          const certificationAssessmentWithNeutralizedChallenge = certificationAssessment;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[3].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[4].isNeutralized = false;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[5].isNeutralized = false;
-
+        it('should get user profile', async function () {
           // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
+          await calculateCertificationAssessmentScore({
+            certificationAssessment,
             areaRepository,
             placementProfileService,
             scoringService,
@@ -1965,33 +1245,768 @@ describe('Certification | Evaluation | Unit | Domain | Services | Scoring V2', f
           });
 
           // then
-          expect(certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted).to.be.true;
+          sinon.assert.calledOnce(placementProfileService.getPlacementProfile);
+        });
+
+        context('when assessment is just started', function () {
+          let startedCertificationAssessment;
+
+          beforeEach(function () {
+            startedCertificationAssessment = domainBuilder.buildCertificationAssessment({
+              ...certificationAssessment,
+              state: Assessment.states.STARTED,
+            });
+          });
+
+          it('should return list of competences with all certifiedLevel at -1', async function () {
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment: startedCertificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when reproducibility rate is < 50%', function () {
+          it('should return list of competences with all certifiedLevel at -1', async function () {
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when reproducibility rate is between 80% and 100%', function () {
+          beforeEach(function () {
+            certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
+          });
+
+          it('should return list of competences with all certifiedLevel equal to estimatedLevel', async function () {
+            // given
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_1_1,
+                level: 1,
+                score: pixForCompetence1,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_2_2,
+                level: 2,
+                score: pixForCompetence2,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_3_3,
+                level: 3,
+                score: pixForCompetence3,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_4_4,
+                level: 4,
+                score: pixForCompetence4,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+
+          it('should return list of competences with certifiedLevel = estimatedLevel except for failed competence', async function () {
+            // given
+            certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_1_1,
+                level: 1,
+                score: pixForCompetence1,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_2_2,
+                level: 2,
+                score: pixForCompetence2,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_3_3,
+                level: 3,
+                score: pixForCompetence3,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_4_4,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when reproducibility rate is between 50% and 80%', function () {
+          it('should return list of competences with certifiedLevel less or equal to estimatedLevel', async function () {
+            // given
+            certificationAssessment.certificationAnswersByDate = await answersWithReproducibilityRateLessThan80();
+            const malusForFalseAnswer = 8;
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_1_1,
+                level: 0,
+                score: pixForCompetence1 - malusForFalseAnswer,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_2_2,
+                level: 2,
+                score: pixForCompetence2,
+              }),
+              competenceWithMarks_3_3,
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_4_4,
+                level: 3,
+                score: pixForCompetence4 - malusForFalseAnswer,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+
+          it('should return the percentage of correct answers', async function () {
+            // given
+            const certificationAssessmentWithNeutralizedChallenge = structuredClone(certificationAssessment);
+            certificationAssessmentWithNeutralizedChallenge.certificationAnswersByDate =
+              answersWithReproducibilityRateLessThan80();
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
+
+            // when
+            const { percentageCorrectAnswers } = await calculateCertificationAssessmentScore({
+              certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(percentageCorrectAnswers).to.deep.equal(64);
+          });
+
+          context('when one competence is evaluated with 3 challenges', function () {
+            let placementProfileService;
+
+            context('with one OK, one KO and one QROCM-dep OK', function () {
+              it('should return level obtained equal to level positioned minus one', async function () {
+                certificationAssessment.certificationAnswersByDate = await answersWithReproducibilityRateLessThan80();
+                // Given
+                const positionedLevel = 2;
+                const positionedScore = 20;
+
+                const answers = _.map(
+                  [
+                    { challengeId: 'challenge_A_for_competence_1', result: 'ok' },
+                    { challengeId: 'challenge_B_for_competence_1', result: 'ok' },
+                    { challengeId: 'challenge_C_for_competence_1', result: 'ko' },
+                  ],
+                  domainBuilder.buildAnswer,
+                );
+
+                const challenges = _.map(
+                  [
+                    {
+                      challengeId: 'challenge_A_for_competence_1',
+                      competenceId: 'competence_1',
+                      associatedSkillName: '@skillChallengeA_1',
+                    },
+                    {
+                      challengeId: 'challenge_B_for_competence_1',
+                      competenceId: 'competence_1',
+                      associatedSkillName: '@skillChallengeB_1',
+                    },
+                    {
+                      challengeId: 'challenge_C_for_competence_1',
+                      competenceId: 'competence_1',
+                      associatedSkillName: '@skillChallengeC_1',
+                    },
+                  ],
+                  domainBuilder.buildCertificationChallengeWithType,
+                );
+
+                const userCompetences = [_buildUserCompetence(competence_1, positionedScore, positionedLevel)];
+
+                certificationAssessment.certificationAnswersByDate = answers;
+                certificationAssessment.certificationChallenges = challenges;
+                placementProfileService = {
+                  getPlacementProfile: sinon.stub(),
+                };
+                const candidate = domainBuilder.certification.evaluation.buildCandidate();
+                candidateRepository.findByAssessmentId
+                  .withArgs({
+                    assessmentId: certificationAssessment.id,
+                  })
+                  .resolves(candidate);
+                placementProfileService.getPlacementProfile
+                  .withArgs({
+                    userId: certificationAssessment.userId,
+                    limitDate: candidate.reconciledAt,
+                  })
+                  .resolves({ userCompetences });
+
+                // When
+                const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+                  certificationAssessment,
+                  areaRepository,
+                  placementProfileService,
+                  scoringService,
+                  candidateRepository,
+                });
+
+                // Then
+                expect(certificationAssessmentScore.competenceMarks[0].level).to.deep.equal(positionedLevel - 1);
+                expect(certificationAssessmentScore.competenceMarks[0].score).to.deep.equal(positionedScore - 8);
+              });
+            });
+          });
         });
       });
 
-      context('when certification has not enough non neutralized challenges to be trusted', function () {
-        it('should return a CertificationAssessmentScore which hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function () {
-          // given
+      context('Calculate certification result when assessment is completed (stop on error)', function () {
+        let placementProfileService;
 
-          const certificationAssessmentWithNeutralizedChallenge = certificationAssessment;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[3].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[4].isNeutralized = true;
-          certificationAssessmentWithNeutralizedChallenge.certificationChallenges[5].isNeutralized = true;
+        beforeEach(function () {
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: challenges,
+          });
+          const candidate = domainBuilder.certification.evaluation.buildCandidate();
+          placementProfileService = {
+            getPlacementProfile: sinon.stub(),
+          };
+          candidateRepository = {
+            findByAssessmentId: sinon
+              .stub()
+              .withArgs({
+                assessmentId: certificationAssessment.id,
+              })
+              .resolves(candidate),
+          };
+          placementProfileService.getPlacementProfile
+            .withArgs({
+              userId: certificationAssessment.userId,
+              limitDate: candidate.reconciledAt,
+            })
+            .resolves({ userCompetences });
+        });
 
-          // when
-          const certificationAssessmentScore = await calculateCertificationAssessmentScore({
-            certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
-            areaRepository,
-            placementProfileService,
-            scoringService,
-            candidateRepository,
+        context('when reproducibility rate is < 50%', function () {
+          it('should return list of competences with all certifiedLevel at -1', async function () {
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when reproducibility rate is between 80% and 100%', function () {
+          beforeEach(function () {
+            certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
           });
 
-          // then
-          expect(certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted).to.be.false;
+          it('should return list of competences with all certifiedLevel equal to estimatedLevel', async function () {
+            // given
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_1_1,
+                level: 1,
+                score: pixForCompetence1,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_2_2,
+                level: 2,
+                score: pixForCompetence2,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_3_3,
+                level: 3,
+                score: pixForCompetence3,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_4_4,
+                level: 4,
+                score: pixForCompetence4,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+
+          it('should return list of competences with certifiedLevel = estimatedLevel except for failed competence', async function () {
+            // given
+            certificationAssessment.certificationAnswersByDate = answersToHaveOnlyTheLastCompetenceFailed();
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_1_1,
+                level: 1,
+                score: pixForCompetence1,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_2_2,
+                level: 2,
+                score: pixForCompetence2,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_3_3,
+                level: 3,
+                score: pixForCompetence3,
+              }),
+              competenceWithMarks_4_4,
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when reproducibility rate is between 50% and 80%', function () {
+          beforeEach(function () {
+            certificationAssessment.certificationAnswersByDate = answersWithReproducibilityRateLessThan80();
+          });
+
+          it('should return list of competences with certifiedLevel less or equal to estimatedLevel', async function () {
+            // given
+            const malusForFalseAnswer = 8;
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_1_1,
+                level: 0,
+                score: pixForCompetence1 - malusForFalseAnswer,
+              }),
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_2_2,
+                level: 2,
+                score: pixForCompetence2,
+              }),
+              competenceWithMarks_3_3,
+              domainBuilder.buildCompetenceMark({
+                ...competenceWithMarks_4_4,
+                level: 3,
+                score: pixForCompetence4 - malusForFalseAnswer,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when only one challenge is asked for a competence', function () {
+          let placementProfileService, candidateRepository;
+
+          it('certifies a level below the estimated one if reproducibility rate is < 70%', async function () {
+            // given
+            const userCompetences = [
+              _buildUserCompetence(competence_5, 50, 5),
+              _buildUserCompetence(competence_6, 36, 3),
+            ];
+            certificationAssessment.certificationChallenges = _.map(
+              [
+                {
+                  challengeId: 'challenge_A_for_competence_5',
+                  competenceId: 'competence_5',
+                  associatedSkillName: '@skillChallengeA_5',
+                },
+                {
+                  challengeId: 'challenge_A_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeA_6',
+                },
+                {
+                  challengeId: 'challenge_B_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeB_6',
+                },
+                {
+                  challengeId: 'challenge_C_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeC_6',
+                },
+              ],
+              domainBuilder.buildCertificationChallengeWithType,
+            );
+
+            placementProfileService = {
+              getPlacementProfile: sinon.stub(),
+            };
+            const candidate = domainBuilder.certification.evaluation.buildCandidate();
+            candidateRepository = {
+              findByAssessmentId: sinon
+                .stub()
+                .withArgs({
+                  assessmentId: certificationAssessment.id,
+                })
+                .resolves(candidate),
+            };
+            placementProfileService.getPlacementProfile
+              .withArgs({
+                userId: certificationAssessment.userId,
+                limitDate: candidate.reconciledAt,
+              })
+              .resolves({ userCompetences });
+            certificationAssessment.certificationAnswersByDate = _.map(
+              [
+                { challengeId: 'challenge_A_for_competence_5', result: 'ok' },
+                { challengeId: 'challenge_A_for_competence_6', result: 'ko' },
+                { challengeId: 'challenge_B_for_competence_6', result: 'ok' },
+                { challengeId: 'challenge_C_for_competence_6', result: 'ko' },
+              ],
+              domainBuilder.buildAnswer,
+            );
+
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                competence_code: '5.5',
+                area_code: '5',
+                competenceId: 'competence_5',
+                level: 4,
+                score: 40,
+              }),
+              domainBuilder.buildCompetenceMark({
+                competence_code: '6.6',
+                area_code: '6',
+                competenceId: 'competence_6',
+                level: UNCERTIFIED_LEVEL,
+                score: 0,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when challenges contains one QROCM-dep challenge to validate two skills', function () {
+          let placementProfileService, candidateRepository;
+
+          beforeEach(function () {
+            const userCompetences = [
+              _buildUserCompetence(competence_5, 50, 5),
+              _buildUserCompetence(competence_6, 36, 3),
+            ];
+
+            certificationAssessment.certificationChallenges = _.map(
+              [
+                {
+                  challengeId: 'challenge_A_for_competence_5',
+                  competenceId: 'competence_5',
+                  associatedSkillName: '@skillChallengeA_5',
+                  type: 'QCM',
+                },
+                {
+                  challengeId: 'challenge_B_for_competence_5',
+                  competenceId: 'competence_5',
+                  associatedSkillName: '@skillChallengeB_5',
+                  type: 'QROCM-dep',
+                },
+                {
+                  challengeId: 'challenge_A_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeA_6',
+                  type: 'QCM',
+                },
+                {
+                  challengeId: 'challenge_B_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeB_6',
+                  type: 'QCM',
+                },
+                {
+                  challengeId: 'challenge_C_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeC_6',
+                  type: 'QCM',
+                },
+              ],
+              domainBuilder.buildCertificationChallengeWithType,
+            );
+
+            const candidate = domainBuilder.certification.evaluation.buildCandidate();
+            candidateRepository = {
+              findByAssessmentId: sinon
+                .stub()
+                .withArgs({
+                  assessmentId: certificationAssessment.id,
+                })
+                .resolves(candidate),
+            };
+
+            placementProfileService = {
+              getPlacementProfile: sinon.stub(),
+            };
+            placementProfileService.getPlacementProfile
+              .withArgs({
+                userId: certificationAssessment.userId,
+                limitDate: candidate.reconciledAt,
+              })
+              .resolves({ userCompetences });
+          });
+
+          it('should compute the result as if QROCM-dep was two OK challenges', async function () {
+            // given
+            certificationAssessment.certificationAnswersByDate = _.map(
+              [
+                { challengeId: 'challenge_A_for_competence_5', result: 'ok' },
+                { challengeId: 'challenge_B_for_competence_5', result: 'ok' },
+                { challengeId: 'challenge_A_for_competence_6', result: 'ko' },
+                { challengeId: 'challenge_B_for_competence_6', result: 'ok' },
+                { challengeId: 'challenge_C_for_competence_6', result: 'ko' },
+              ],
+              domainBuilder.buildAnswer,
+            );
+
+            const expectedCertifiedCompetences = [
+              domainBuilder.buildCompetenceMark({
+                competence_code: '5.5',
+                area_code: '5',
+                competenceId: 'competence_5',
+                level: 5,
+                score: 40,
+              }),
+              domainBuilder.buildCompetenceMark({
+                competence_code: '6.6',
+                area_code: '6',
+                competenceId: 'competence_6',
+                level: UNCERTIFIED_LEVEL,
+                score: 0,
+              }),
+            ];
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.competenceMarks).to.deep.equal(expectedCertifiedCompetences);
+          });
+        });
+
+        context('when there are challenges for non-certifiable competences', function () {
+          let challenges;
+
+          beforeEach(function () {
+            challenges = _.map(
+              [
+                {
+                  challengeId: 'challenge_A_for_competence_1',
+                  competenceId: 'competence_1',
+                  associatedSkillName: '@skillChallengeA_1',
+                },
+                {
+                  challengeId: 'challenge_M_for_competence_5',
+                  competenceId: 'competence_5',
+                  associatedSkillName: '@skillChallengeM_5',
+                },
+                {
+                  challengeId: 'challenge_N_for_competence_6',
+                  competenceId: 'competence_6',
+                  associatedSkillName: '@skillChallengeN_6',
+                },
+              ],
+              domainBuilder.buildCertificationChallengeWithType,
+            );
+            certificationAssessment.certificationChallenges = challenges;
+
+            certificationAssessment.certificationAnswersByDate = _.map(
+              [
+                { challengeId: 'challenge_A_for_competence_1', result: 'ko' },
+
+                { challengeId: 'challenge_M_for_competence_5', result: 'ok' },
+                { challengeId: 'challenge_N_for_competence_6', result: 'ok' },
+              ],
+              domainBuilder.buildAnswer,
+            );
+          });
+
+          it('should not include the extra challenges when computing reproducibility', async function () {
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.percentageCorrectAnswers).to.equal(0);
+          });
+        });
+      });
+
+      context('non neutralization rate trustability', function () {
+        let placementProfileService, candidateRepository;
+
+        beforeEach(function () {
+          certificationAssessment = domainBuilder.buildCertificationAssessment({
+            ...certificationAssessmentData,
+            certificationAnswersByDate: wrongAnswersForAllChallenges(),
+            certificationChallenges: challenges,
+          });
+          certificationAssessment.certificationAnswersByDate = correctAnswersForAllChallenges();
+          const candidate = domainBuilder.certification.evaluation.buildCandidate();
+          placementProfileService = {
+            getPlacementProfile: sinon.stub(),
+          };
+          candidateRepository = {
+            findByAssessmentId: sinon
+              .stub()
+              .withArgs({
+                assessmentId: certificationAssessment.id,
+              })
+              .resolves(candidate),
+          };
+          placementProfileService.getPlacementProfile
+            .withArgs({
+              userId: certificationAssessment.userId,
+              limitDate: candidate.reconciledAt,
+            })
+            .resolves({ userCompetences });
+        });
+
+        context('when certification has enough non neutralized challenges to be trusted', function () {
+          it('should return a CertificationAssessmentScore which hasEnoughNonNeutralizedChallengesToBeTrusted is true', async function () {
+            // given
+            const certificationAssessmentWithNeutralizedChallenge = certificationAssessment;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[3].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[4].isNeutralized = false;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[5].isNeutralized = false;
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted).to.be.true;
+          });
+        });
+
+        context('when certification has not enough non neutralized challenges to be trusted', function () {
+          it('should return a CertificationAssessmentScore which hasEnoughNonNeutralizedChallengesToBeTrusted is false', async function () {
+            // given
+
+            const certificationAssessmentWithNeutralizedChallenge = certificationAssessment;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[0].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[1].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[2].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[3].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[4].isNeutralized = true;
+            certificationAssessmentWithNeutralizedChallenge.certificationChallenges[5].isNeutralized = true;
+
+            // when
+            const certificationAssessmentScore = await calculateCertificationAssessmentScore({
+              certificationAssessment: certificationAssessmentWithNeutralizedChallenge,
+              areaRepository,
+              placementProfileService,
+              scoringService,
+              candidateRepository,
+            });
+
+            // then
+            expect(certificationAssessmentScore.hasEnoughNonNeutralizedChallengesToBeTrusted).to.be.false;
+          });
         });
       });
     });


### PR DESCRIPTION
## ☀️ Problème


[Message Slack](https://1024pix.slack.com/archives/CHGPQ7W9W/p1788441834353119) 

Problème détecté le 3 septembre

On a trouvé un flacky avec la commande `SEED=0.7949177792222298 npm run test:api:unit -- --require ./tests/setup/test-random.js --bail`

```
1) Certification | Evaluation | Unit | Domain | Services | Scoring V2
       #calculateCertificationAssessmentScore
         Compute certification result for jury
           when reproducibility rate is between 50% and 80%
             should return list of competences with certifiedLevel less or equal to estimatedLevel:

      AssertionError: expected [ CompetenceMark{ …(7) }, …(3) ] to deeply equal [ CompetenceMark{ …(7) }, …(3) ]
      + expected - actual

           "assessmentResultId": [undefined]
           "competenceId": "competence_1"
           "competence_code": "1.1"
           "id": [undefined]
      -    "level": -1
      -    "score": 0
      +    "level": 0
      +    "score": 2
         }
         {
           "area_code": "2"
           "assessmentResultId": [undefined]

      at Context.<anonymous> (file:///Users/gul/Developer/1024pix/pix/api/tests/certification/evaluation/unit/domain/services/scoring/scoring-v2_test.js:1393:72)
```

@HEYGUL 

## ⛱️ Proposition


Il y a de très gros `beforeEach` qui font sans doute trop de chose, et des tests de cas d'erreur qui laisse le système dans un mauvais état.

Extraction des deux tests d'erreurs qui laisse le système en mauvais état : pour ne pas modifié l'état défini dans le beaforeEach

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
