### PR TITLE
[FEATURE] migration pour remettre des contraintes "not nullable" supprimés par inadvertance (PIX-24132)

### DIFF
--- a/api/db/migrations/20260908134704_restore-not-nullable-for-attestations-key-and-template-name.js
+++ b/api/db/migrations/20260908134704_restore-not-nullable-for-attestations-key-and-template-name.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'attestations';
+const KEY_COLUMN_NAME = 'key';
+const TEMPLATE_NAME_COLUMN_NAME = 'templateName';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(KEY_COLUMN_NAME).notNullable().alter({ alterType: false });
+    table.string(TEMPLATE_NAME_COLUMN_NAME).notNullable().alter({ alterType: false });
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(KEY_COLUMN_NAME).nullable().alter({ alterType: false });
+    table.string(TEMPLATE_NAME_COLUMN_NAME).nullable().alter({ alterType: false });
+  });
+}

--- a/api/db/migrations/20260908140000_restore-not-nullable-for-quests-success-requirements.js
+++ b/api/db/migrations/20260908140000_restore-not-nullable-for-quests-success-requirements.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'quests';
+const COLUMN_NAME = 'successRequirements';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).notNullable().alter({ alterType: false });
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).nullable().alter({ alterType: false });
+  });
+}

--- a/api/db/migrations/20260908150000_restore-not-nullable-for-organizations-profile-rewards-organization-id.js
+++ b/api/db/migrations/20260908150000_restore-not-nullable-for-organizations-profile-rewards-organization-id.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'organizations-profile-rewards';
+const COLUMN_NAME = 'organizationId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).notNullable().alter({ alterType: false });
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).nullable().alter({ alterType: false });
+  });
+}


### PR DESCRIPTION
## ☀️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Dans la migration `api/db/migrations/20241227103334_add-comments-on-quests-tables.js`, on a utilisé des `.alter` sans l'option `alterNullable: false`, sur des colonnes créées précédemment avec une contrainte "not nullable", qui a été écrasée.

## ⛱️ Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Migrations pour rétablir les contraintes non-nullables des colonnes qui devraient l'être.
Ces colonnes ne contiennent pas de valeur null en DB de prod.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Bonne pratique :
utiliser les options `{ alterNullable: false, alterType: false }` pour les .alter dans les migrations

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
CI au vert