### PR TITLE
[TECH] Ajoute une règle pour interdire l'usage des builders de base de données dans les tests unitaires.

### DIFF
--- a/api/.dependency-cruiser.mjs
+++ b/api/.dependency-cruiser.mjs
@@ -24,6 +24,18 @@ export default {
       from: { path: '^tests/.*integration/(.*)' },
       to: { path: ['@hapi/hapi', '^server\\.js$'] },
     },
+    {
+      name: 'do-not-import-databuilder-in-unit-tests',
+      severity: 'error',
+      from: {
+        path: '^tests/.*unit/(.*)',
+        pathNot: [
+          'tests/tooling/unit/database-builder/database-buffer_test.js',
+          'tests/tooling/unit/database-builder/database-helpers_test.js',
+        ],
+      },
+      to: { path: ['(.*)database-builder/(.*)'] },
+    },
   ],
   options: {
     doNotFollow: { path: 'node_modules' },


### PR DESCRIPTION
## ☀️ Problème

On a rencontré certains tests unitaires flackys du au fait qu'ils utilisaient la base de données alors qu'aucune base de données n'est disponibles en tests unitaires.
Ces tests utilisaient les builders importés depuis `database-builder` et ont été corrigés depuis **mais** il n'y a aucune règle de lint qui empêche le soucis de se reproduire.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On ajoute une règle dans la section `forbidden` de la configuration de `dependency-cruiser`.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧴 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

En local, ajouter un import de `database-builder` dans un test unitaire.
Exécuter `npm run lint:context-deps`.
Constater qu'une erreur est levée, indiquant que l'import est interdit.

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
