### PR TITLE
[TECH] Supprime tous les usages de `RSVP` dans les applications front.

### DIFF
--- a/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/new.js
+++ b/admin/app/routes/authenticated/certification-frameworks/certification-framework/versions/new.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class FrameworkNewRoute extends Route {
   @service store;
@@ -20,10 +19,10 @@ export default class FrameworkNewRoute extends Route {
       'authenticated.certification-frameworks.certification-framework.versions',
     );
 
-    return RSVP.hash({
+    return {
       frameworks,
       scope: certificationFramework.scope,
       activeVersion,
-    });
+    };
   }
 }

--- a/admin/app/routes/authenticated/organizations/get/invitations.js
+++ b/admin/app/routes/authenticated/organizations/get/invitations.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class InvitationsRoute extends Route {
   @service store;
@@ -14,10 +13,10 @@ export default class InvitationsRoute extends Route {
   }
 
   async model() {
-    const organization = this.modelFor('authenticated.organizations.get');
-    return RSVP.hash({
-      organization: organization,
-      organizationInvitations: organization.organizationInvitations,
-    });
+    const organization = await this.modelFor('authenticated.organizations.get');
+    return {
+      organization,
+      organizationInvitations: await organization.organizationInvitations,
+    };
   }
 }

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class ListRoute extends Route {
   @service store;
@@ -38,10 +37,10 @@ export default class ListRoute extends Route {
       organizations = [];
       administrationTeams = [];
     }
-    return RSVP.hash({
+    return {
       organizations,
       administrationTeams,
-    });
+    };
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/routes/authenticated/organizations/new.js
+++ b/admin/app/routes/authenticated/organizations/new.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class NewRoute extends Route {
   @service router;
@@ -24,12 +23,12 @@ export default class NewRoute extends Route {
     if (parentOrganizationId) {
       parentOrganization = await this.store.findRecord('organization', parentOrganizationId);
     }
-    return RSVP.hash({
+    return {
       administrationTeams,
       countries,
       parentOrganization,
       organizationLearnerTypes,
-    });
+    };
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/routes/authenticated/sessions/certification/informations.js
+++ b/admin/app/routes/authenticated/sessions/certification/informations.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class CertificationInformationsRoute extends Route {
   @service store;
@@ -10,11 +9,11 @@ export default class CertificationInformationsRoute extends Route {
     const certification = await this.modelFor('authenticated.sessions.certification').reload();
     const session = await this.store.findRecord('session', certification.sessionId);
     const certificationIssueReports = await certification.certificationIssueReports;
-    return RSVP.hash({
+    return {
       session,
       certification,
       certificationIssueReports,
-    });
+    };
   }
 
   setupController(controller, model) {

--- a/admin/app/routes/authenticated/sessions/session/certifications.js
+++ b/admin/app/routes/authenticated/sessions/session/certifications.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 
 export default class CertificationsRoute extends Route {
   queryParams = {
@@ -8,7 +7,7 @@ export default class CertificationsRoute extends Route {
   };
 
   async model({ pageSize, pageNumber }) {
-    const session = this.modelFor('authenticated.sessions.session');
+    const session = await this.modelFor('authenticated.sessions.session');
     const juryCertificationSummaries = await session.juryCertificationSummaries;
 
     const adapterOptions = {
@@ -20,6 +19,9 @@ export default class CertificationsRoute extends Route {
     } else {
       juryCertificationSummaries.reload({ adapterOptions });
     }
-    return RSVP.hash({ session, juryCertificationSummaries });
+    return {
+      session,
+      juryCertificationSummaries,
+    };
   }
 }

--- a/admin/app/routes/authenticated/target-profiles/target-profile/badges/badge.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/badges/badge.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class BadgeRoute extends Route {
   @service store;
@@ -11,11 +10,11 @@ export default class BadgeRoute extends Route {
   }
 
   async model(params) {
-    const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
+    const targetProfile = await this.modelFor('authenticated.target-profiles.target-profile');
     const badges = await targetProfile.badges;
-    return RSVP.hash({
-      targetProfile: targetProfile,
+    return {
+      targetProfile,
       badge: badges.find((badge) => badge.id === params.badge_id),
-    });
+    };
   }
 }

--- a/admin/app/routes/authenticated/trainings/training/target-profiles.js
+++ b/admin/app/routes/authenticated/trainings/training/target-profiles.js
@@ -1,14 +1,13 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 
 export default class TrainingDetailsTargetProfilesRoute extends Route {
   async model() {
     const training = this.modelFor('authenticated.trainings.training');
     await training.targetProfileSummaries.reload();
     const targetProfileSummaries = await training.targetProfileSummaries;
-    return RSVP.hash({
+    return {
       training,
       targetProfileSummaries,
-    });
+    };
   }
 }

--- a/admin/app/routes/authenticated/users/get/authentication-methods.js
+++ b/admin/app/routes/authenticated/users/get/authentication-methods.js
@@ -1,13 +1,12 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 
 export default class UserAuthenticationMethodsRoute extends Route {
   async model() {
     const userProfile = this.modelFor('authenticated.users.get');
-    const authenticationMethods = userProfile.authenticationMethods;
-    return RSVP.hash({
+    const authenticationMethods = await userProfile.authenticationMethods;
+    return {
       userProfile,
       authenticationMethods,
-    });
+    };
   }
 }

--- a/admin/eslint.config.mjs
+++ b/admin/eslint.config.mjs
@@ -55,7 +55,7 @@ export default [
     },
     rules: {
       'no-irregular-whitespace': 'off',
-      'no-restricted-imports': ['error', { paths: ['lodash'] }],
+      'no-restricted-imports': ['error', { paths: ['lodash', 'rsvp'] }],
       'qunit/require-expect': ['error', 'except-simple'],
     },
   },

--- a/admin/tests/integration/components/login-form-test.gjs
+++ b/admin/tests/integration/components/login-form-test.gjs
@@ -4,7 +4,6 @@ import { t } from 'ember-intl/test-support';
 import LoginForm from 'pix-admin/components/login-form';
 import ENV from 'pix-admin/config/environment';
 import { module, test } from 'qunit';
-import { reject } from 'rsvp';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -154,7 +153,7 @@ module('Integration | Component | login-form', function (hooks) {
           ],
         },
       };
-      sessionStub.authenticate = () => reject(errorResponse);
+      sessionStub.authenticate = () => Promise.reject(errorResponse);
 
       const screen = await render(<template><LoginForm /></template>);
 
@@ -181,7 +180,7 @@ module('Integration | Component | login-form', function (hooks) {
           ],
         },
       };
-      sessionStub.authenticate = () => reject(errorResponse);
+      sessionStub.authenticate = () => Promise.reject(errorResponse);
 
       const screen = await render(<template><LoginForm /></template>);
 
@@ -207,7 +206,7 @@ module('Integration | Component | login-form', function (hooks) {
           ],
         },
       };
-      sessionStub.authenticate = () => reject(errorResponse);
+      sessionStub.authenticate = () => Promise.reject(errorResponse);
 
       const screen = await render(<template><LoginForm /></template>);
 
@@ -226,7 +225,7 @@ module('Integration | Component | login-form', function (hooks) {
         status: Number(ApiErrorMessages.LOGIN_NO_PERMISSION.CODE),
         responseJSON: { errors: [{ status: ApiErrorMessages.LOGIN_NO_PERMISSION.CODE }] },
       };
-      sessionStub.authenticate = () => reject(errorResponse);
+      sessionStub.authenticate = () => Promise.reject(errorResponse);
 
       const screen = await render(<template><LoginForm /></template>);
 
@@ -252,7 +251,7 @@ module('Integration | Component | login-form', function (hooks) {
           ],
         },
       };
-      sessionStub.authenticate = () => reject(errorResponse);
+      sessionStub.authenticate = () => Promise.reject(errorResponse);
 
       const screen = await render(<template><LoginForm /></template>);
 
@@ -271,7 +270,7 @@ module('Integration | Component | login-form', function (hooks) {
         status: 418,
         responseJSON: { errors: [{ status: 418 }] },
       };
-      sessionStub.authenticate = () => reject(errorResponse);
+      sessionStub.authenticate = () => Promise.reject(errorResponse);
 
       const screen = await render(<template><LoginForm /></template>);
 

--- a/admin/tests/unit/services/current-user-test.js
+++ b/admin/tests/unit/services/current-user-test.js
@@ -2,7 +2,6 @@ import Object from '@ember/object';
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { reject, resolve } from 'rsvp';
 
 module('Unit | Service | current-user', function (hooks) {
   setupTest(hooks);
@@ -13,7 +12,7 @@ module('Unit | Service | current-user', function (hooks) {
       const connectedUserId = 1;
       const connectedUser = Object.create({ id: connectedUserId });
       const storeStub = Service.create({
-        queryRecord: () => resolve(connectedUser),
+        queryRecord: async () => connectedUser,
       });
       const sessionStub = Service.create({
         isAuthenticated: true,
@@ -53,12 +52,12 @@ module('Unit | Service | current-user', function (hooks) {
       // Given
       const connectedUserId = 1;
       const storeStub = Service.create({
-        queryRecord: () => reject({ errors: [{ code: 401 }] }),
+        queryRecord: () => Promise.reject({ errors: [{ code: 401 }] }),
       });
       const sessionStub = Service.create({
         isAuthenticated: true,
         data: { authenticated: { user_id: connectedUserId } },
-        invalidate: () => resolve('invalidate'),
+        invalidate: async () => 'invalidate',
       });
       const currentUser = this.owner.lookup('service:currentUser');
       currentUser.set('store', storeStub);

--- a/admin/tests/unit/services/feature-toggles-test.js
+++ b/admin/tests/unit/services/feature-toggles-test.js
@@ -2,7 +2,6 @@ import Object from '@ember/object';
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Service | feature toggles', function (hooks) {
   setupTest(hooks);
@@ -14,7 +13,7 @@ module('Unit | Service | feature toggles', function (hooks) {
         aFakeFeatureToggle: false,
       });
       const storeStub = Service.create({
-        queryRecord: () => resolve(featureToggles),
+        queryRecord: async () => featureToggles,
       });
       const featureToggleService = this.owner.lookup('service:featureToggles');
       featureToggleService.set('store', storeStub);

--- a/certif/eslint.config.mjs
+++ b/certif/eslint.config.mjs
@@ -56,7 +56,7 @@ export default [
     },
     rules: {
       'no-irregular-whitespace': 'off',
-      'no-restricted-imports': ['error', { paths: ['lodash'] }],
+      'no-restricted-imports': ['error', { paths: ['lodash', 'rsvp'] }],
     },
   },
   {

--- a/certif/tests/integration/components/auth/toggable-login-form-test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form-test.js
@@ -4,7 +4,6 @@ import { triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
@@ -80,11 +79,10 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
   module('When there is a valid invitation and user is not member of certification center yet', function (hooks) {
     let adapter;
     hooks.beforeEach(function () {
-      SessionStub.prototype.authenticate = function (authenticator, email, password) {
+      SessionStub.prototype.authenticate = async function (authenticator, email, password) {
         this.authenticator = authenticator;
         this.email = email;
         this.password = password;
-        return resolve();
       };
 
       adapter = this.owner.lookup('adapter:certification-center-invitation');
@@ -149,11 +147,10 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
             adapter.accept = sinon.stub();
             adapter.accept.rejects({ errors: [{ code: 412, status: '412' }] });
 
-            SessionStub.prototype.authenticate = function (authenticator, email, password) {
+            SessionStub.prototype.authenticate = async function (authenticator, email, password) {
               this.authenticator = authenticator;
               this.email = email;
               this.password = password;
-              return resolve();
             };
 
             const sessionServiceObserver = this.owner.lookup('service:session');

--- a/certif/tests/integration/components/login-test.gjs
+++ b/certif/tests/integration/components/login-test.gjs
@@ -5,7 +5,6 @@ import { t } from 'ember-intl/test-support';
 import Login from 'pix-certif/components/login';
 import ENV from 'pix-certif/config/environment';
 import { module, test } from 'qunit';
-import { reject, resolve } from 'rsvp';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -38,11 +37,10 @@ module('Integration | Component | login', function (hooks) {
 
   test('it should call authentication service with appropriate parameters', async function (assert) {
     // given
-    sessionStub.authenticate.callsFake(function (authenticator, email, password) {
+    sessionStub.authenticate.callsFake(async function (authenticator, email, password) {
       this.authenticator = authenticator;
       this.email = email;
       this.password = password;
-      return resolve();
     });
     const sessionServiceObserver = this.owner.lookup('service:session');
     const screen = await render(<template><Login /></template>);
@@ -73,7 +71,7 @@ module('Integration | Component | login', function (hooks) {
       },
     };
 
-    sessionStub.authenticate.callsFake(() => reject(invalidCredentialsErrorMessage));
+    sessionStub.authenticate.callsFake(() => Promise.reject(invalidCredentialsErrorMessage));
     const screen = await render(<template><Login /></template>);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
     await fillIn(screen.getByLabelText('Mot de passe'), 'Mauvais mot de passe');
@@ -87,11 +85,10 @@ module('Integration | Component | login', function (hooks) {
 
   test('should authenticate user with trimmed email', async function (assert) {
     // given
-    sessionStub.authenticate.callsFake(function (authenticator, email, password) {
+    sessionStub.authenticate.callsFake(async function (authenticator, email, password) {
       this.authenticator = authenticator;
       this.email = email;
       this.password = password;
-      return resolve();
     });
     const sessionServiceObserver = this.owner.lookup('service:session');
     const screen = await render(<template><Login /></template>);
@@ -116,7 +113,7 @@ module('Integration | Component | login', function (hooks) {
     };
     const currentDomainService = this.owner.lookup('service:current-domain');
     sinon.stub(currentDomainService, 'getExtension').returns('fr');
-    sessionStub.authenticate.callsFake(() => reject(errorResponse));
+    sessionStub.authenticate.callsFake(() => Promise.reject(errorResponse));
     const screen = await render(<template><Login /></template>);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
     await fillIn(screen.getByLabelText('Mot de passe'), 'Mauvais mot de passe');
@@ -157,7 +154,7 @@ module('Integration | Component | login', function (hooks) {
       },
     };
 
-    sessionStub.authenticate.callsFake(() => reject(notLinkedToOrganizationErrorMessage));
+    sessionStub.authenticate.callsFake(() => Promise.reject(notLinkedToOrganizationErrorMessage));
     const screen = await render(<template><Login /></template>);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
     await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');
@@ -184,7 +181,7 @@ module('Integration | Component | login', function (hooks) {
       },
     };
 
-    sessionStub.authenticate.callsFake(() => reject(gatewayTimeoutErrorMessage));
+    sessionStub.authenticate.callsFake(() => Promise.reject(gatewayTimeoutErrorMessage));
     const screen = await render(<template><Login /></template>);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
     await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');
@@ -203,7 +200,7 @@ module('Integration | Component | login', function (hooks) {
       errors: [{ status: '502', title: 'Bad Gateway', detail: 'Bad gateway occurred' }],
     };
 
-    sessionStub.authenticate.callsFake(() => reject(msgErrorNotLinkedCertification));
+    sessionStub.authenticate.callsFake(() => Promise.reject(msgErrorNotLinkedCertification));
     const screen = await render(<template><Login /></template>);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
     await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');

--- a/certif/tests/unit/adapters/certification-point-of-contact-test.js
+++ b/certif/tests/unit/adapters/certification-point-of-contact-test.js
@@ -1,6 +1,5 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Adapters | certification-point-of-contact', function (hooks) {
   setupTest(hooks);
@@ -9,7 +8,7 @@ module('Unit | Adapters | certification-point-of-contact', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:certification-point-of-contact');
-    const ajaxStub = () => resolve();
+    const ajaxStub = async () => {};
     adapter.ajax = ajaxStub;
   });
 

--- a/certif/tests/unit/adapters/division-test.js
+++ b/certif/tests/unit/adapters/division-test.js
@@ -1,6 +1,5 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Adapters | division', function (hooks) {
   setupTest(hooks);
@@ -10,7 +9,7 @@ module('Unit | Adapters | division', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:division');
-    const ajaxStub = () => resolve();
+    const ajaxStub = async () => {};
     adapter.ajax = ajaxStub;
   });
 

--- a/certif/tests/unit/adapters/session-for-supervising-test.js
+++ b/certif/tests/unit/adapters/session-for-supervising-test.js
@@ -1,6 +1,5 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Adapters | session-for-supervising', function (hooks) {
   setupTest(hooks);
@@ -9,7 +8,7 @@ module('Unit | Adapters | session-for-supervising', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:session-for-supervising');
-    const ajaxStub = () => resolve();
+    const ajaxStub = async () => {};
     adapter.ajax = ajaxStub;
   });
 

--- a/certif/tests/unit/adapters/student-test.js
+++ b/certif/tests/unit/adapters/student-test.js
@@ -1,6 +1,5 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Adapter | student', function (hooks) {
   setupTest(hooks);
@@ -9,7 +8,7 @@ module('Unit | Adapter | student', function (hooks) {
 
   hooks.beforeEach(function () {
     adapter = this.owner.lookup('adapter:student');
-    const ajaxStub = () => resolve();
+    const ajaxStub = async () => {};
     adapter.ajax = ajaxStub;
   });
 

--- a/certif/tests/unit/services/current-user-test.js
+++ b/certif/tests/unit/services/current-user-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 import sinon from 'sinon';
 
 module('Unit | Service | current-user', function (hooks) {
@@ -91,7 +90,7 @@ module('Unit | Service | current-user', function (hooks) {
       class SessionStub extends Service {
         isAuthenticated = true;
         data = { authenticated: { user_id: 123 } };
-        invalidate = () => resolve('invalidate');
+        invalidate = async () => 'invalidate';
       }
       this.owner.register('service:session', SessionStub);
       const currentUser = this.owner.lookup('service:currentUser');

--- a/certif/tests/unit/services/feature-toggles-test.js
+++ b/certif/tests/unit/services/feature-toggles-test.js
@@ -2,7 +2,6 @@ import Object from '@ember/object';
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Service | feature toggles', function (hooks) {
   setupTest(hooks);
@@ -12,7 +11,7 @@ module('Unit | Service | feature toggles', function (hooks) {
       // Given
       const featureToggles = Object.create({});
       const storeStub = Service.create({
-        queryRecord: () => resolve(featureToggles),
+        queryRecord: async () => featureToggles,
       });
       const featureToggleService = this.owner.lookup('service:featureToggles');
       featureToggleService.set('store', storeStub);

--- a/junior/eslint.config.mjs
+++ b/junior/eslint.config.mjs
@@ -55,7 +55,7 @@ export default [
     },
     rules: {
       'no-irregular-whitespace': 'off',
-      'no-restricted-imports': ['error', { paths: ['lodash'] }],
+      'no-restricted-imports': ['error', { paths: ['lodash', 'rsvp'] }],
     },
   },
   {

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import RSVP from 'rsvp';
 
 export default class ChallengeRoute extends Route {
   @service currentUser;
@@ -44,18 +43,19 @@ export default class ChallengeRoute extends Route {
       this.focusedCertificationChallengeWarningManager.reset();
     }
 
-    return RSVP.hash({
-      assessment,
-      challenge,
-      answer,
-      currentChallengeNumber,
-    }).catch((err) => {
+    try {
+      return {
+        assessment,
+        challenge,
+        answer,
+        currentChallengeNumber,
+      };
+    } catch (err) {
       const meta = 'errors' in err ? err.errors[0].meta : null;
       if (meta.field === 'authorization') {
         this.router.transitionTo('authenticated');
-        return;
       }
-    });
+    }
   }
 
   async afterModel({ assessment }) {

--- a/mon-pix/eslint.config.mjs
+++ b/mon-pix/eslint.config.mjs
@@ -69,6 +69,7 @@ export default [
       'no-restricted-imports': [
         'error',
         'lodash',
+        'rsvp',
         {
           name: '@ember/test-helpers',
           importNames: ['render', 'visit', 'find'],

--- a/mon-pix/tests/integration/components/feedback-panel-test.gjs
+++ b/mon-pix/tests/integration/components/feedback-panel-test.gjs
@@ -4,7 +4,6 @@ import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import FeedbackPanel from 'mon-pix/components/feedback-panel';
 import { module, test } from 'qunit';
-import { resolve } from 'rsvp';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { waitForDialog, waitForDialogClose } from '../../helpers/wait-for';
@@ -16,7 +15,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
     createRecord() {
       return Object.create({
         save() {
-          return resolve();
+          return Promise.resolve();
         },
       });
     }

--- a/mon-pix/tests/unit/services/competence-evaluation-test.js
+++ b/mon-pix/tests/unit/services/competence-evaluation-test.js
@@ -2,7 +2,6 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { reject } from 'rsvp';
 import sinon from 'sinon';
 
 module('Unit | Service | competence-evaluation', function (hooks) {
@@ -55,7 +54,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
         // given
         competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
         store = Service.create({
-          queryRecord: () => reject({ errors: [{ code: 'IMPROVE_COMPETENCE_EVALUATION_FORBIDDEN' }] }),
+          queryRecord: sinon.stub().rejects({ errors: [{ code: 'IMPROVE_COMPETENCE_EVALUATION_FORBIDDEN' }] }),
           findRecord: sinon.stub().resolves(),
         });
         router = EmberObject.create({ transitionTo: sinon.stub() });
@@ -80,7 +79,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
         // given
         competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
         store = Service.create({
-          queryRecord: () => reject(error),
+          queryRecord: sinon.stub().rejects(error),
           findRecord: sinon.stub().resolves(),
         });
         competenceEvaluationService.set('router', router);

--- a/orga/eslint.config.mjs
+++ b/orga/eslint.config.mjs
@@ -63,6 +63,7 @@ export default [
       'no-restricted-imports': [
         'error',
         {
+          paths: ['rsvp'],
           patterns: [
             {
               group: ['lodash', 'lodash/*', 'lodash-es', 'lodash-es/*', 'lodash.*'],


### PR DESCRIPTION
## ☀️ Problème

On utilise encore `RSVP` dans quelques fichiers alors que les `Promise` natives sont désormais suffisantes.
Cela introduit une librairie spécifique Ember qui ne nous apporte rien de plus que le javascript natif.


<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On migre tous les usages de `RSVP` vers l'usage de `Promise`.
On ajoute `rsvp` aux imports interdits dans les configurations `eslint` des applications front.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧴 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester
CI verte

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
