### PR TITLE
[BUMP] Mise à jour d'epreuves components

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.498.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.18.2",
+        "@1024pix/epreuves-components": "^4.21.1",
         "@1024pix/oppsy": "^1.0.2",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.18.2.tgz",
-      "integrity": "sha512-XRrUKPuNbMzo4WNDWxEveeUuUBEDZ7GcNkXwyIogiYWS+8/n16eV2Mr4Jhzq2M5BrLEByHqHuZSK0p81mUhjxw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.21.1.tgz",
+      "integrity": "sha512-jTVu+YSiY2kDXTn/hqJOtP5ufKTa/dXNRpf2E4eHU4Z6fvqn5S91eYEIs9fY4yNAb8SFUee3iuyGPL3vY1mDDQ==",
       "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "modulix:test": "npm run test:api:path -- 'tests/devcomp/unit/infrastructure/datasources/learning-content/module-datasource_test.js' 'tests/devcomp/unit/infrastructure/datasources/learning-content/validation/module-validation_test.js' 'tests/devcomp/unit/infrastructure/repositories/module-repository_test.js' && TEST_SETUP_MODE=unit npm run test:api:path -- 'tests/devcomp/acceptance/module-instantiation_test.js'"
   },
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.18.2",
+    "@1024pix/epreuves-components": "^4.21.1",
     "@1024pix/oppsy": "^1.0.2",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",

--- a/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
+++ b/api/src/devcomp/infrastructure/datasources/learning-content/modules/demo-epreuves-components.json
@@ -884,7 +884,30 @@
                     },
                     {
                       "direction": "outbound",
-                      "content": "Non."
+                      "content": "Non.</br> Trouves moi des photos depuis cette piece jointe",
+                      "attachmentName": "historik.rar"
+                    },
+                    {
+                      "direction": "inbound",
+                      "content": "Whoua !",
+                      "illustrations": [
+                        {
+                          "src": "https://images.unsplash.com/photo-1507666405895-422eee7d517f?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                          "alt": "un éléphant"
+                        },
+                        {
+                          "src": "https://images.unsplash.com/photo-1507666405895-422eee7d517f?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                          "alt": "un chat"
+                        },
+                        {
+                          "src": "https://images.unsplash.com/photo-1507666405895-422eee7d517f?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                          "alt": "un lion"
+                        }
+                      ]
+                    },
+                    {
+                      "direction": "outbound",
+                      "content": "ça sent la noisette"
                     }
                   ]
                 },

--- a/junior/package-lock.json
+++ b/junior/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.44",
-        "@1024pix/epreuves-components": "^4.18.2",
+        "@1024pix/epreuves-components": "^4.21.1",
         "@1024pix/eslint-plugin": "^3.0.4",
         "@1024pix/pix-ui": "^68.1.2",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.18.2.tgz",
-      "integrity": "sha512-XRrUKPuNbMzo4WNDWxEveeUuUBEDZ7GcNkXwyIogiYWS+8/n16eV2Mr4Jhzq2M5BrLEByHqHuZSK0p81mUhjxw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.21.1.tgz",
+      "integrity": "sha512-jTVu+YSiY2kDXTn/hqJOtP5ufKTa/dXNRpf2E4eHU4Z6fvqn5S91eYEIs9fY4yNAb8SFUee3iuyGPL3vY1mDDQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/junior/package.json
+++ b/junior/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.44",
-    "@1024pix/epreuves-components": "^4.18.2",
+    "@1024pix/epreuves-components": "^4.21.1",
     "@1024pix/eslint-plugin": "^3.0.4",
     "@1024pix/pix-ui": "^68.1.2",
     "@1024pix/stylelint-config": "^5.1.37",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.44",
-        "@1024pix/epreuves-components": "^4.18.2",
+        "@1024pix/epreuves-components": "^4.21.1",
         "@1024pix/eslint-plugin": "^3.0.4",
         "@1024pix/pix-ui": "^68.0.0",
         "@1024pix/stylelint-config": "^5.1.37",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.18.2.tgz",
-      "integrity": "sha512-XRrUKPuNbMzo4WNDWxEveeUuUBEDZ7GcNkXwyIogiYWS+8/n16eV2Mr4Jhzq2M5BrLEByHqHuZSK0p81mUhjxw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.21.1.tgz",
+      "integrity": "sha512-jTVu+YSiY2kDXTn/hqJOtP5ufKTa/dXNRpf2E4eHU4Z6fvqn5S91eYEIs9fY4yNAb8SFUee3iuyGPL3vY1mDDQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.44",
-    "@1024pix/epreuves-components": "^4.18.2",
+    "@1024pix/epreuves-components": "^4.21.1",
     "@1024pix/eslint-plugin": "^3.0.4",
     "@1024pix/pix-ui": "^68.0.0",
     "@1024pix/stylelint-config": "^5.1.37",


### PR DESCRIPTION
## ☀️ Problème

Une nouvelle version de pix-epreuves-component est disponible.

## ⛱️ Proposition

Mettre à jour le package avec la nouvel version.

## 🧴 Remarques
RAS

## 🏊 Pour tester

Se rendre sur la page de démo et verifier que les composants sont bien à jour
