### PR TITLE
[FEATURE] Ajouter un sélecteur de catégorie sur la fiche d'édition d'une organisation (PIX-23563)

### DIFF
--- a/admin/app/components/organizations/information-section-edit.gjs
+++ b/admin/app/components/organizations/information-section-edit.gjs
@@ -12,6 +12,7 @@ import Joi from 'joi';
 import lodashGet from 'lodash/get';
 import lodashSet from 'lodash/set';
 import { FormValidator } from 'pix-admin/utils/form-validator';
+import { isSearchValid } from 'pix-admin/utils/normalize-text';
 
 import Card from '../card';
 
@@ -28,6 +29,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @tracked administrationTeams = [];
   @tracked organizationLearnerTypes = [];
   @tracked countries = [];
+  @tracked structureCategories = [];
+  @tracked categoriesSearchQuery = '';
 
   noIdentityProviderOption = { label: this.intl.t('common.words.none'), value: 'None' };
   garIdentityProviderOption = { label: 'GAR', value: 'GAR' };
@@ -44,6 +47,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.administrationTeams = await this.store.findAll('administration-team');
     this.organizationLearnerTypes = await this.store.findAll('organization-learner-type');
     this.countries = await this.store.findAll('country');
+    this.structureCategories = await this.store.findAll('structure-category');
   }
 
   #initForm() {
@@ -66,6 +70,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
       organizationLearnerTypeId: this.args.organization.organizationLearnerTypeId
         ? `${this.args.organization.organizationLearnerTypeId}`
         : null,
+      categoryId: this.args.organization.categoryId ? `${this.args.organization.categoryId}` : null,
     };
   }
 
@@ -96,6 +101,21 @@ export default class OrganizationInformationSectionEditionMode extends Component
     return options;
   }
 
+  get categoriesOptions() {
+    const options = this.structureCategories.map((structureCategory) => ({
+      value: structureCategory.id,
+      label: structureCategory.label,
+    }));
+    return options;
+  }
+
+  get filteredCategoriesOptions() {
+    if (!this.categoriesSearchQuery) {
+      return this.categoriesOptions;
+    }
+    return this.categoriesOptions.filter((option) => isSearchValid(option.label, this.categoriesSearchQuery));
+  }
+
   get countriesOptions() {
     const options = this.countries.map((country) => ({
       value: country.code,
@@ -118,6 +138,11 @@ export default class OrganizationInformationSectionEditionMode extends Component
   @action
   updateFormValue(key, event) {
     this.updateValue(key, event.target.value);
+  }
+
+  @action
+  onSearchCategories(query) {
+    this.categoriesSearchQuery = query;
   }
 
   @action
@@ -153,6 +178,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
     const countryName = this.countries.find((country) => country.code === this.form.countryCode)?.name;
 
+    const categoryLabel = this.structureCategories.find((category) => category.id === this.form.categoryId)?.label;
+
     this.args.organization.set('name', this.form.name);
     this.args.organization.set('externalId', this.form.externalId);
     this.args.organization.set('provinceCode', this.form.provinceCode);
@@ -169,6 +196,8 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.args.organization.set('countryName', countryName ?? null);
     this.args.organization.set('organizationLearnerTypeId', this.form.organizationLearnerTypeId);
     this.args.organization.set('organizationLearnerTypeName', organizationLearnerTypeName);
+    this.args.organization.set('categoryId', this.form.categoryId);
+    this.args.organization.set('categoryLabel', categoryLabel);
 
     this.closeAndResetForm();
     return this.args.onSubmit();
@@ -276,6 +305,30 @@ export default class OrganizationInformationSectionEditionMode extends Component
               @isFullWidth={{true}}
               {{on "input" (fn this.updateFormValue "externalId")}}
             ><:label>{{t "components.organizations.information-section-view.external-id"}}</:label></PixInput>
+          </div>
+
+          <div class="organization-creation-form__input--full">
+            <PixSelect
+              required
+              @aria-required={{true}}
+              @texts={{hash
+                placeholder=(t "components.organizations.editing.category.selector.placeholder")
+                selectSearchLabel=(t "components.organizations.editing.category.selector.search-label")
+                searchPlaceholder=(t "components.organizations.editing.category.selector.search-placeholder")
+                requiredLabel=(t "common.forms.mandatory")
+              }}
+              @errorMessage={{if this.validator.errors.categoryId (t this.validator.errors.categoryId)}}
+              @validationStatus={{if this.validator.errors.categoryId "error"}}
+              @options={{this.filteredCategoriesOptions}}
+              @value={{this.form.categoryId}}
+              @onChange={{fn this.updateValue "categoryId"}}
+              @onSearch={{this.onSearchCategories}}
+              @hideDefaultOption={{true}}
+              @isSearchable={{true}}
+              @isFullWidth={{true}}
+            >
+              <:label>{{t "components.organizations.editing.category.selector.label"}}</:label>
+            </PixSelect>
           </div>
         </Card>
 
@@ -402,6 +455,10 @@ const ORGANIZATION_FORM_VALIDATION_SCHEMA = Joi.object({
   organizationLearnerTypeId: Joi.string().empty(['', null]).required().messages({
     'any.required': 'components.organizations.editing.organization-learner-type.selector.error-message',
     'string.empty': 'components.organizations.editing.organization-learner-type.selector.error-message',
+  }),
+  categoryId: Joi.string().empty(['', null]).required().messages({
+    'any.required': 'components.organizations.editing.category.selector.error-message',
+    'string.empty': 'components.organizations.editing.category.selector.error-message',
   }),
   identityProviderForCampaigns: Joi.string().empty(['', null]),
 });

--- a/admin/app/models/structure-category.js
+++ b/admin/app/models/structure-category.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@warp-drive/legacy/model';
+
+export default class StructureCategory extends Model {
+  @attr('string') label;
+}

--- a/admin/tests/acceptance/authenticated/organizations/information-management-test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management-test.js
@@ -36,6 +36,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
         countryCode: 99100,
         organizationLearnerTypeName: 'Student',
         organizationLearnerTypeId: 2,
+        categoryId: 1,
       });
       this.server.create('organization', { id: '1234', features: { PLACES_MANAGEMENT: { active: true } } });
 

--- a/admin/tests/integration/components/organizations/information-section-edit-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-edit-test.gjs
@@ -36,6 +36,13 @@ module('Integration | Component | organizations/information-section-edit', funct
         store.createRecord('organization-learner-type', { id: '789', name: 'Student' }),
         store.createRecord('organization-learner-type', { id: '987', name: 'Teacher' }),
       ]);
+
+    findAllStub
+      .withArgs('structure-category')
+      .resolves([
+        store.createRecord('structure-category', { id: '111', label: 'Catégorie 1' }),
+        store.createRecord('structure-category', { id: '222', label: 'Catégorie 2' }),
+      ]);
   });
 
   module('organization validation', function (hooks) {
@@ -297,6 +304,37 @@ module('Integration | Component | organizations/information-section-edit', funct
       // then
       assert.ok(organizationLearnerTypeErrorMessage);
     });
+
+    test("it should show error message if organization's category is empty", async function (assert) {
+      const organizationWithoutCategory = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+        countryCode: '99100',
+        organizationLearnerTypeId: 789,
+        categoryId: null,
+      });
+
+      // when
+      const screen = await render(
+        <template><InformationSectionEdit @organization={{organizationWithoutCategory}} /></template>,
+      );
+      await click(screen.getByRole('button', { name: t('common.actions.save') }));
+
+      const categoryIdErrorMessage = screen.getByText(
+        t('components.organizations.editing.category.selector.error-message'),
+      );
+
+      // then
+      assert.ok(categoryIdErrorMessage);
+    });
   });
 
   module('administration teams select', function () {
@@ -379,6 +417,105 @@ module('Integration | Component | organizations/information-section-edit', funct
             name: `${t('components.organizations.editing.administration-team.selector.label')} *`,
           }),
         ).getByText(t('components.organizations.editing.administration-team.selector.placeholder')),
+      );
+    });
+  });
+
+  module('categories select', function () {
+    test('it should display select with options loaded', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+      });
+
+      //when
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+      const categorySelectButton = screen.getByRole('button', {
+        name: `${t('components.organizations.editing.category.selector.label')} *`,
+      });
+      await click(categorySelectButton);
+      const listbox = await screen.findByRole('listbox');
+      const categorySelectContainer = categorySelectButton.closest('.pix-select');
+
+      //then
+      assert.ok(within(listbox).getByRole('option', { name: 'Catégorie 1' }));
+      assert.ok(within(listbox).getByRole('option', { name: 'Catégorie 2' }));
+
+      //when
+      await fillIn(
+        within(categorySelectContainer).getByLabelText(
+          t('components.organizations.editing.category.selector.search-label'),
+        ),
+        'categorie 1',
+      );
+
+      //then
+      assert.ok(within(listbox).getByRole('option', { name: 'Catégorie 1' }));
+      assert.notOk(within(listbox).queryByRole('option', { name: 'Catégorie 2' }));
+    });
+
+    test('it should display current category as pre-selected option if organization has one', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+        categoryId: 222,
+      });
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+      // then
+      assert.ok(
+        within(
+          screen.getByRole('button', {
+            name: `${t('components.organizations.editing.category.selector.label')} *`,
+          }),
+        ).getByText('Catégorie 2'),
+      );
+    });
+
+    test('it should display the placeholder if organization does not have a category', async function (assert) {
+      // given
+      const organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        isOrganizationSCO: true,
+        credit: 0,
+        documentationUrl: 'https://pix.fr/',
+        features: {},
+        administrationTeamId: 123,
+        categoryId: null,
+      });
+
+      //when
+      const screen = await render(<template><InformationSectionEdit @organization={{organization}} /></template>);
+
+      // then
+      assert.ok(
+        within(
+          screen.getByRole('button', {
+            name: `${t('components.organizations.editing.category.selector.label')} *`,
+          }),
+        ).getByText(t('components.organizations.editing.category.selector.placeholder')),
       );
     });
   });

--- a/admin/tests/integration/components/organizations/information-section-test.gjs
+++ b/admin/tests/integration/components/organizations/information-section-test.gjs
@@ -49,6 +49,13 @@ module('Integration | Component | organizations/information-section', function (
         store.createRecord('organization-learner-import-format', { id: '123', name: 'GENERIC' }),
         store.createRecord('organization-learner-import-format', { id: '456', name: 'ONDE' }),
       ]);
+
+    findAllStub
+      .withArgs('structure-category')
+      .resolves([
+        store.createRecord('structure-category', { id: '111', label: 'Catégorie 1' }),
+        store.createRecord('structure-category', { id: '222', label: 'Catégorie 2' }),
+      ]);
   });
 
   module('when editing organization', function () {
@@ -173,6 +180,15 @@ module('Integration | Component | organizations/information-section', function (
       const danemarkOption = await screen.findByRole('option', { name: 'Danemark (99101)' });
       await click(danemarkOption);
 
+      await click(
+        screen.getByRole('button', {
+          name: `${t('components.organizations.editing.category.selector.label')} *`,
+        }),
+      );
+      await screen.findByRole('listbox');
+      const categoryOption = await screen.findByRole('option', { name: 'Catégorie 1' });
+      await click(categoryOption);
+
       await fillByLabel(t('components.organizations.information-section-view.credits'), 50);
       await fillByLabel(t('components.organizations.information-section-view.documentation-link'), 'https://pix.fr/');
 
@@ -200,6 +216,9 @@ module('Integration | Component | organizations/information-section', function (
             .nextElementSibling,
         )
         .hasText('Équipe 2');
+      assert
+        .dom(screen.getByText(t('components.organizations.information-section-view.category')).nextElementSibling)
+        .hasText('Catégorie 1');
       assert
         .dom(screen.getByText(t('components.organizations.information-section-view.credits')).nextElementSibling)
         .hasText('50');

--- a/admin/tests/mirage/routes.js
+++ b/admin/tests/mirage/routes.js
@@ -716,6 +716,27 @@ export default function routes() {
     };
   });
 
+  this.get('/admin/structure-categories', async () => {
+    return {
+      data: [
+        {
+          type: 'structure-category',
+          id: '2',
+          attributes: {
+            label: 'Catégorie 2',
+          },
+        },
+        {
+          type: 'structure-category',
+          id: '1',
+          attributes: {
+            label: 'Catégorie 1',
+          },
+        },
+      ],
+    };
+  });
+
   this.get('/admin/oidc/identity-providers', () => {
     return {
       data: [

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1152,6 +1152,15 @@
             "placeholder": "Select attestations"
           }
         },
+        "category": {
+          "selector": {
+            "error-message": "Category is required",
+            "label": "Category",
+            "placeholder": "Choose a category",
+            "search-label": "Search",
+            "search-placeholder": "Search for a category"
+          }
+        },
         "country": {
           "selector": {
             "error-message": "Country is required",

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1160,6 +1160,15 @@
             "placeholder": "Sélectionner les attestations"
           }
         },
+        "category": {
+          "selector": {
+            "error-message": "La catégorie est requise",
+            "label": "Catégorie",
+            "placeholder": "Sélectionner une catégorie",
+            "search-label": "Rechercher",
+            "search-placeholder": "Rechercher une catégorie"
+          }
+        },
         "country": {
           "selector": {
             "error-message": "Le pays est requis",


### PR DESCRIPTION
## 💥 Problème

Le formulaire d'édition d'une organisation ne permettait pas de renseigner sa catégorie, alors que ce champ existe côté modèle organisation et doit pouvoir être géré au même titre que l'équipe en charge, le pays ou le public prescrit.

## 👩‍🚀 Proposition

Ajout d'un sélecteur "Catégorie" dans le formulaire d'édition d'organisation (`information-section-edit.gjs`) :

## 👁️ Remarques

La catégorie devient un champ obligatoire à l'édition, comme le sont déjà l'équipe en charge, le pays et le public prescrit.

## ♻️ Pour tester

- Lancer l'admin (`npm run dev:admin`, port 4202) et se connecter avec `superadmin@example.net` / `pix123`
- Aller sur une fiche organisation (`/organizations/:id`)
- Cliquer sur "Modifier" dans la section Informations
- Vérifier la présence du sélecteur "Catégorie", avec sa liste d'options chargée dynamiquement et recherchable
- Sélectionner une catégorie puis enregistrer → vérifier qu'elle est bien affichée après sauvegarde
- Enregistrer sans sélectionner de catégorie → vérifier l'affichage du message d'erreur "La catégorie est requise"
