### PR TITLE
[BUGFIX] Créer les jobs d'import après la sauvegarde finale de chaque étape du pipeline d'import de prescrits (PIX-24209)

### DIFF
--- a/api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js
@@ -42,9 +42,6 @@ const sendOrganizationLearnersFile = async function ({
     encoding = parser.getEncoding();
 
     filename = await importStorage.sendFile({ filepath: payload.path });
-    await validateGenericFileJobRepository.performAsync(
-      new ValidateGenericFileJob({ organizationImportId: organizationImport.id }),
-    );
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);
@@ -61,6 +58,10 @@ const sendOrganizationLearnersFile = async function ({
       if (filename) await importStorage.deleteFile({ filename });
     }
   }
+
+  await validateGenericFileJobRepository.performAsync(
+    new ValidateGenericFileJob({ organizationImportId: organizationImport.id }),
+  );
 };
 
 export { sendOrganizationLearnersFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js
@@ -23,13 +23,6 @@ const validateFregataFile = async function ({
     const { warnings } = parser.parse(parser.getFileEncoding());
 
     warningsData = warnings;
-
-    await importFromFregataJobRepository.performAsync(
-      new ImportFromFregataJob({
-        organizationImportId: organizationImport.id,
-        locale: i18n.getLocale(),
-      }),
-    );
   } catch (error) {
     if (error instanceof AggregateImportError) {
       errors.push(...error.meta);
@@ -44,6 +37,13 @@ const validateFregataFile = async function ({
     organizationImport.validate({ errors, warnings: warningsData });
     await organizationImportRepository.save(organizationImport);
   }
+
+  await importFromFregataJobRepository.performAsync(
+    new ImportFromFregataJob({
+      organizationImportId: organizationImport.id,
+      locale: i18n.getLocale(),
+    }),
+  );
 };
 
 export { validateFregataFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js
@@ -32,7 +32,6 @@ const validateGenericFile = async function ({
     });
 
     learnerSet.addLearners(learners);
-    await importFromGenericFileJobRepository.performAsync(new ImportFromGenericFileJob({ organizationImportId }));
   } catch (error) {
     if (Array.isArray(error)) {
       errors.push(...error);
@@ -46,6 +45,8 @@ const validateGenericFile = async function ({
     organizationImport.validate({ errors });
     await organizationImportRepository.save(organizationImport);
   }
+
+  await importFromGenericFileJobRepository.performAsync(new ImportFromGenericFileJob({ organizationImportId }));
 };
 
 export { validateGenericFile };

--- a/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js
+++ b/api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js
@@ -24,14 +24,6 @@ const validateSupFile = async function ({
     const { warnings } = parser.parse(parser.getFileEncoding());
 
     warningsData = warnings;
-
-    await importFromSupJobRepository.performAsync(
-      new ImportFromSupJob({
-        organizationImportId: organizationImport.id,
-        type,
-        locale: i18n.getLocale(),
-      }),
-    );
   } catch (error) {
     if (error instanceof AggregateImportError) {
       errors.push(...error.meta);
@@ -46,6 +38,14 @@ const validateSupFile = async function ({
     organizationImport.validate({ errors, warnings: warningsData });
     await organizationImportRepository.save(organizationImport);
   }
+
+  await importFromSupJobRepository.performAsync(
+    new ImportFromSupJob({
+      organizationImportId: organizationImport.id,
+      type,
+      locale: i18n.getLocale(),
+    }),
+  );
 };
 
 export { validateSupFile };

--- a/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/send-organization-learners-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/import-from-feature/send-organization-learners-file_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
     organizationLearnerImportFormatRepositoryStub,
     validateGenericFileJobRepositoryStub,
     commonCsvLearnerParserStub,
-    dependencieStub,
+    dependenciesStub,
     importStorageStub,
     organizationImportStub,
     importFormat,
@@ -53,7 +53,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
       .withArgs(new ValidateGenericFileJob({ organizationImportId }))
       .resolves();
 
-    dependencieStub = {
+    dependenciesStub = {
       createReadStream: sinon.stub(),
       getDataBuffer: sinon.stub(),
     };
@@ -93,8 +93,8 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
       // given
       organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).resolves(importFormat);
 
-      dependencieStub.createReadStream.withArgs(uploadedFilepath).returns(dataStream);
-      dependencieStub.getDataBuffer.withArgs(dataStream).resolves(dataBuffer);
+      dependenciesStub.createReadStream.withArgs(uploadedFilepath).returns(dataStream);
+      dependenciesStub.getDataBuffer.withArgs(dataStream).resolves(dataBuffer);
 
       GenericParser.buildParser.withArgs({ buffer: dataBuffer, importFormat }).returns(commonCsvLearnerParserStub);
 
@@ -111,7 +111,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
         validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
-        dependencies: dependencieStub,
+        dependencies: dependenciesStub,
       });
 
       // then
@@ -120,10 +120,13 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
         organizationImportSavedStub,
       );
       expect(importStorageStub.deleteFile.called, 'importStorageStub.delete').to.be.false;
+      expect(validateGenericFileJobRepositoryStub.performAsync.firstCall).calledAfter(
+        organizationImportRepositoryStub.save.secondCall,
+      );
     });
   });
 
-  context(' error cases', function () {
+  context('error cases', function () {
     it('should upload errors', async function () {
       // given
       organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).resolves(null);
@@ -137,7 +140,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
         validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
-        dependencies: dependencieStub,
+        dependencies: dependenciesStub,
       });
 
       // then
@@ -172,7 +175,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
           validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
-          dependencies: dependencieStub,
+          dependencies: dependenciesStub,
         });
 
         expect(
@@ -200,7 +203,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
           validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
-          dependencies: dependencieStub,
+          dependencies: dependenciesStub,
         });
 
         expect(
@@ -219,8 +222,8 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
         // given
         organizationLearnerImportFormatRepositoryStub.get.withArgs(organizationId).resolves(importFormat);
 
-        dependencieStub.createReadStream.withArgs(uploadedFilepath).returns(dataStream);
-        dependencieStub.getDataBuffer.withArgs(dataStream).resolves(dataBuffer);
+        dependenciesStub.createReadStream.withArgs(uploadedFilepath).returns(dataStream);
+        dependenciesStub.getDataBuffer.withArgs(dataStream).resolves(dataBuffer);
 
         GenericParser.buildParser.withArgs({ buffer: dataBuffer, importFormat }).returns(commonCsvLearnerParserStub);
 
@@ -240,7 +243,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
             validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
-            dependencies: dependencieStub,
+            dependencies: dependenciesStub,
           });
         } catch {
           // do something
@@ -264,7 +267,7 @@ describe('Unit | UseCase | sendOrganizationLearnersFile', function () {
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
             validateGenericFileJobRepository: validateGenericFileJobRepositoryStub,
-            dependencies: dependencieStub,
+            dependencies: dependenciesStub,
           });
         } catch {
           // do something

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-fregata-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-fregata-file_test.js
@@ -122,6 +122,9 @@ describe('Unit | UseCase | validateFregataFile', function () {
           organizationImportId,
         }),
       );
+      expect(importFromFregataJobRepositoryStub.performAsync.firstCall).calledAfter(
+        organizationImportRepositoryStub.save.firstCall,
+      );
     });
   });
 

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-generic-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-generic-file_test.js
@@ -14,7 +14,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
     importFromGenericFileJobRepositoryStub,
     commonCsvLearnerParserStub,
     importOrganizationLearnerSetStub,
-    dependencieStub,
+    dependenciesStub,
     importStorageStub,
     organizationImportStub,
     dataBuffer,
@@ -49,7 +49,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
       .withArgs(new ImportFromGenericFileJob({ organizationImportId }))
       .resolves();
 
-    dependencieStub = {
+    dependenciesStub = {
       createReadStream: sinon.stub(),
       getDataBuffer: sinon.stub(),
     };
@@ -91,7 +91,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
 
       importStorageStub.readFile.withArgs({ filename: s3Filepath }).resolves(dataStream);
 
-      dependencieStub.getDataBuffer.withArgs(dataStream).resolves(dataBuffer);
+      dependenciesStub.getDataBuffer.withArgs(dataStream).resolves(dataBuffer);
 
       GenericParser.buildParser.withArgs({ buffer: dataBuffer, importFormat }).returns(commonCsvLearnerParserStub);
 
@@ -110,7 +110,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
         organizationImportRepository: organizationImportRepositoryStub,
         organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
         importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
-        dependencies: dependencieStub,
+        dependencies: dependenciesStub,
       });
 
       // then
@@ -121,10 +121,13 @@ describe('Unit | UseCase | validateGenericFile', function () {
         'organizationImportRepository.save',
       ).to.be.true;
       expect(importStorageStub.deleteFile.called, 'importStorage.deleteFile').to.be.false;
+      expect(importFromGenericFileJobRepositoryStub.performAsync.firstCall).calledAfter(
+        organizationImportRepositoryStub.save.firstCall,
+      );
     });
   });
 
-  context(' error cases', function () {
+  context('error cases', function () {
     context('when there is an error occured', function () {
       it('should throw and delete file on storage', async function () {
         // given
@@ -140,7 +143,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
           organizationImportRepository: organizationImportRepositoryStub,
           organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
           importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
-          dependencies: dependencieStub,
+          dependencies: dependenciesStub,
         });
 
         expect(validateError).to.instanceOf(AggregateImportError);
@@ -167,7 +170,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
             importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
-            dependencies: dependencieStub,
+            dependencies: dependenciesStub,
           });
 
           expect(
@@ -190,7 +193,7 @@ describe('Unit | UseCase | validateGenericFile', function () {
             organizationImportRepository: organizationImportRepositoryStub,
             organizationLearnerImportFormatRepository: organizationLearnerImportFormatRepositoryStub,
             importFromGenericFileJobRepository: importFromGenericFileJobRepositoryStub,
-            dependencies: dependencieStub,
+            dependencies: dependenciesStub,
           });
 
           expect(

--- a/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-sup-file_test.js
+++ b/api/tests/prescription/learner-management/unit/domain/usecases/validate-learners-file/validate-sup-file_test.js
@@ -125,6 +125,9 @@ describe('Unit | UseCase | validateSupFile', function () {
           organizationImportId,
         }),
       );
+      expect(importFromSupJobRepositoryStub.performAsync.firstCall).calledAfter(
+        organizationImportRepositoryStub.save.firstCall,
+      );
     });
   });
 


### PR DESCRIPTION
## :question: Problème

Dans le pipeline d'import de prescrits, plusieurs jobs asynchrones étaient créés **avant** que le bloc `try/catch/finally` ait persisté l'état final de l'`organizationImport` (`organizationImport.upload(...)` / `organizationImport.validate(...)` puis `organizationImportRepository.save(...)`) :

- `ValidateGenericFileJob`, créé juste après l'upload du fichier générique, avant la sauvegarde de l'import (nom de fichier, encoding).
- `ImportFromGenericFileJob`, créé juste après le parsing du fichier générique, avant la sauvegarde du résultat de validation.
- `ImportFromSupJob`, créé juste après le parsing du fichier Sup, avant la sauvegarde du résultat de validation.
- `ImportFromFregataJob`, créé juste après le parsing du fichier Fregata, avant la sauvegarde du résultat de validation.

Dans chaque cas, le job pouvait ainsi démarrer avant que l'enregistrement `organizationImport` correspondant ne soit à jour en base, avec le risque de traiter un état incohérent ou obsolète.

## :bulb: Proposition

Déplacer la création des jobs après le bloc `try/catch/finally`, une fois que l'`organizationImport` a bien été mis à jour et sauvegardé, pour les 4 étapes du pipeline d'import :

- `api/src/prescription/learner-management/domain/usecases/import-from-feature/send-organization-learners-file.js` : `ValidateGenericFileJob` créé après l'upload et la sauvegarde finale.
- `api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-generic-file.js` : `ImportFromGenericFileJob` créé après la validation et la sauvegarde.
- `api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-sup-file.js` : `ImportFromSupJob` créé après la validation et la sauvegarde.
- `api/src/prescription/learner-management/domain/usecases/validate-learners-file/validate-fregata-file.js` : `ImportFromFregataJob` créé après la validation et la sauvegarde.

Les tests unitaires associés ont été mis à jour pour refléter ce nouvel ordre d'exécution.

## :test_tube: Pour tester

- Faire un import de fichier SCO_1D (ou autre format générique) et vérifier que le job de validation est bien créé après la sauvegarde de l'import.
- Faire un import de fichier Sup, puis un import de fichier Fregata, et vérifier que le job d'import associé est bien créé après la sauvegarde du résultat de validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
