### PR TITLE
[FEATURE] Ajouter du tracking pour l'affichage d'une mise en avant de CF (PIX-24010).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -122,7 +122,6 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
       {{#if @highlightedTraining}}
         <HighlightedCard
           @highlightedTraining={{@highlightedTraining}}
-          @onCardClick={{@onCardClick}}
           @onHighlightedCardButtonClick={{@onHighlightedCardButtonClick}}
         />
       {{/if}}

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/evaluation-results-hero-recommendation-engine/index.gjs
@@ -120,7 +120,11 @@ export default class EvaluationResultsHeroRecommendationEngine extends Component
         {{/unless}}
       </div>
       {{#if @highlightedTraining}}
-        <HighlightedCard @highlightedTraining={{@highlightedTraining}} @onCardClick={{@onCardClick}} />
+        <HighlightedCard
+          @highlightedTraining={{@highlightedTraining}}
+          @onCardClick={{@onCardClick}}
+          @onHighlightedCardButtonClick={{@onHighlightedCardButtonClick}}
+        />
       {{/if}}
       {{#if this.media.isMobile}}
         <ActionButtons

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card.gjs
@@ -15,7 +15,6 @@ import Card from '../training/card';
       <Card
         @isHighlighted={{true}}
         @training={{@highlightedTraining}}
-        @onCardClick={{@onCardClick}}
         @onHighlightedCardButtonClick={{@onHighlightedCardButtonClick}}
       />
     </div>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card.gjs
@@ -12,7 +12,12 @@ import Card from '../training/card';
     <div class="highlighted-card">
       <h2 class="highlighted-card__title">{{t "pages.skill-review.recommended-engine.highlighted-card.title"}}</h2>
       <p class="highlighted-card__subtitle">{{t "pages.skill-review.recommended-engine.highlighted-card.subtitle"}}</p>
-      <Card @isHighlighted={{true}} @training={{@highlightedTraining}} @onCardClick={{@onCardClick}} />
+      <Card
+        @isHighlighted={{true}}
+        @training={{@highlightedTraining}}
+        @onCardClick={{@onCardClick}}
+        @onHighlightedCardButtonClick={{@onHighlightedCardButtonClick}}
+      />
     </div>
   </div>
 </template>

--- a/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
+++ b/mon-pix/app/components/campaigns/assessment/results-recommendation-engine/training/card.gjs
@@ -45,6 +45,12 @@ export default class Card extends Component {
   }
 
   @action
+  showHighlightedCardModal() {
+    this.args.onHighlightedCardButtonClick({ trainingId: this.args.training.id });
+    this.modalIsOpen = true;
+  }
+
+  @action
   closeModal() {
     this.modalIsOpen = false;
   }
@@ -65,7 +71,7 @@ export default class Card extends Component {
             {{/if}}
           </ul>
           <PixButton
-            @triggerAction={{this.showModal}}
+            @triggerAction={{this.showHighlightedCardModal}}
             class="results-recommendation-engine-highlighted-training-card-description__button"
           >
             {{t "pages.skill-review.recommended-engine.highlighted-card.learn-more"}}

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -31,6 +31,12 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     });
   }
 
+  @action onHighlightedCardButtonClick({ trainingId }) {
+    this.pixMetrics.trackEvent('Moteur de reco - Clic sur la carte du contenu formatif mis en avant', {
+      trainingId,
+    });
+  }
+
   @action onModalButtonClick({ trainingId }) {
     this.pixMetrics.trackEvent('Moteur de reco - Clic sur le bouton "Découvrir le programme/module"', {
       trainingId,
@@ -138,6 +144,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         @highlightedTraining={{this.highlightedTraining}}
         @hasTrainings={{this.hasTrainings}}
         @onCardClick={{this.onCardClick}}
+        @onHighlightedCardButtonClick={{this.onHighlightedCardButtonClick}}
         @onSeeRecommendationsButtonClicked={{this.onSeeRecommendationsButtonClicked}}
         @questResults={{@model.questResults}}
       />

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -20,6 +20,7 @@ export default class EvaluationResultsRecommendationEngine extends Component {
     super(...args);
 
     this.trackTrainingsDisplayed(this.trainings);
+    this.trackHighlightedTrainingDisplayed(this.highlightedTraining);
   }
 
   @tracked _drawerRevealedByScroll = false;
@@ -60,6 +61,15 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         trainingId: training.id,
         position: index + 1,
       });
+    });
+  }
+
+  trackHighlightedTrainingDisplayed(highlightedTraining) {
+    if (!highlightedTraining) {
+      return;
+    }
+    this.pixMetrics.trackEvent('Moteur de reco - Mise en avant du contenu formatif sur la page de résultats', {
+      trainingId: highlightedTraining.id,
     });
   }
 

--- a/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
+++ b/mon-pix/app/components/routes/campaigns/assessment/evaluation-results-recommendation-engine.gjs
@@ -153,7 +153,6 @@ export default class EvaluationResultsRecommendationEngine extends Component {
         @campaignParticipationResult={{@model.campaignParticipationResult}}
         @highlightedTraining={{this.highlightedTraining}}
         @hasTrainings={{this.hasTrainings}}
-        @onCardClick={{this.onCardClick}}
         @onHighlightedCardButtonClick={{this.onHighlightedCardButtonClick}}
         @onSeeRecommendationsButtonClicked={{this.onSeeRecommendationsButtonClicked}}
         @questResults={{@model.questResults}}

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -179,6 +179,74 @@ module(
         });
       });
 
+      module('when campaign has a highlighted training', function () {
+        test('should send a tracking event on page load', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+            isHighlighted: true,
+          });
+
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          // when
+          await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+          // then
+          sinon.assert.calledWith(
+            pixMetrics.trackEvent,
+            'Moteur de reco - Mise en avant du contenu formatif sur la page de résultats',
+            { trainingId: training.id },
+          );
+          assert.ok(true);
+        });
+      });
+
+      module('when campaign has no highlighted training', function () {
+        test('should not send a tracking event on page load', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+          });
+
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          // when
+          await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+
+          // then
+          sinon.assert.neverCalledWith(
+            pixMetrics.trackEvent,
+            'Moteur de reco - Mise en avant du contenu formatif sur la page de résultats',
+          );
+          assert.ok(true);
+        });
+      });
+
       module('when clicking on the highlighted card button', function () {
         test('should send a tracking event', async function (assert) {
           // given

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -285,40 +285,6 @@ module(
           );
           assert.ok(true);
         });
-
-        test('should not send the "Clic sur la carte du contenu formatif" tracking event', async function (assert) {
-          // given
-          const training = store.createRecord('training', {
-            title: 'Super training',
-            duration: { days: 1, hours: 1, minutes: 1 },
-            isHighlighted: true,
-          });
-
-          const pixMetrics = this.owner.lookup('service:pix-metrics');
-          pixMetrics.trackEvent = sinon.stub();
-
-          const model = {
-            campaign,
-            campaignParticipationResult: {
-              campaignParticipationBadges: [Symbol('badges')],
-              competenceResults: [Symbol('competences')],
-              reload: () => {},
-            },
-            trainings: [training],
-          };
-
-          // when
-          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
-          await click(
-            screen.getByRole('button', {
-              name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more'),
-            }),
-          );
-
-          // then
-          sinon.assert.neverCalledWith(pixMetrics.trackEvent, 'Moteur de reco - Clic sur la carte du contenu formatif');
-          assert.ok(true);
-        });
       });
 
       module('tracking', function (hooks) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/evaluation-results-recommendation-engine-test.gjs
@@ -179,6 +179,80 @@ module(
         });
       });
 
+      module('when clicking on the highlighted card button', function () {
+        test('should send a tracking event', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+            isHighlighted: true,
+          });
+
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          // when
+          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          await click(
+            screen.getByRole('button', {
+              name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more'),
+            }),
+          );
+
+          // then
+          sinon.assert.calledWith(
+            pixMetrics.trackEvent,
+            'Moteur de reco - Clic sur la carte du contenu formatif mis en avant',
+            { trainingId: training.id },
+          );
+          assert.ok(true);
+        });
+
+        test('should not send the "Clic sur la carte du contenu formatif" tracking event', async function (assert) {
+          // given
+          const training = store.createRecord('training', {
+            title: 'Super training',
+            duration: { days: 1, hours: 1, minutes: 1 },
+            isHighlighted: true,
+          });
+
+          const pixMetrics = this.owner.lookup('service:pix-metrics');
+          pixMetrics.trackEvent = sinon.stub();
+
+          const model = {
+            campaign,
+            campaignParticipationResult: {
+              campaignParticipationBadges: [Symbol('badges')],
+              competenceResults: [Symbol('competences')],
+              reload: () => {},
+            },
+            trainings: [training],
+          };
+
+          // when
+          const screen = await render(<template><EvaluationResultsRecommendationEngine @model={{model}} /></template>);
+          await click(
+            screen.getByRole('button', {
+              name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more'),
+            }),
+          );
+
+          // then
+          sinon.assert.neverCalledWith(pixMetrics.trackEvent, 'Moteur de reco - Clic sur la carte du contenu formatif');
+          assert.ok(true);
+        });
+      });
+
       module('tracking', function (hooks) {
         hooks.afterEach(function () {
           delete window.IntersectionObserver;

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card-test.gjs
@@ -44,10 +44,17 @@ module(
         const store = this.owner.lookup('service:store');
         const training = store.createRecord('training', _buildTraining({}));
         const onCardClickStub = sinon.stub();
+        const onHighlightedCardButtonClickStub = sinon.stub();
 
         // when
         const screen = await render(
-          <template><HighlightedCard @highlightedTraining={{training}} @onCardClick={{onCardClickStub}} /></template>,
+          <template>
+            <HighlightedCard
+              @highlightedTraining={{training}}
+              @onCardClick={{onCardClickStub}}
+              @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
+            />
+          </template>,
         );
         await click(
           screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more') }),
@@ -55,6 +62,32 @@ module(
 
         // then
         assert.dom(await screen.findByRole('dialog', { name: training.title })).exists();
+      });
+
+      test('should call onHighlightedCardButtonClick function', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const training = store.createRecord('training', _buildTraining({}));
+        const onCardClickStub = sinon.stub();
+        const onHighlightedCardButtonClickStub = sinon.stub();
+
+        // when
+        const screen = await render(
+          <template>
+            <HighlightedCard
+              @highlightedTraining={{training}}
+              @onCardClick={{onCardClickStub}}
+              @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
+            />
+          </template>,
+        );
+        await click(
+          screen.getByRole('button', { name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more') }),
+        );
+
+        // then
+        sinon.assert.calledOnceWithExactly(onHighlightedCardButtonClickStub, { trainingId: training.id });
+        assert.ok(true);
       });
     });
 

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/highlighted-card/highlighted-card-test.gjs
@@ -43,7 +43,6 @@ module(
         // given
         const store = this.owner.lookup('service:store');
         const training = store.createRecord('training', _buildTraining({}));
-        const onCardClickStub = sinon.stub();
         const onHighlightedCardButtonClickStub = sinon.stub();
 
         // when
@@ -51,7 +50,6 @@ module(
           <template>
             <HighlightedCard
               @highlightedTraining={{training}}
-              @onCardClick={{onCardClickStub}}
               @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
             />
           </template>,
@@ -68,7 +66,6 @@ module(
         // given
         const store = this.owner.lookup('service:store');
         const training = store.createRecord('training', _buildTraining({}));
-        const onCardClickStub = sinon.stub();
         const onHighlightedCardButtonClickStub = sinon.stub();
 
         // when
@@ -76,7 +73,6 @@ module(
           <template>
             <HighlightedCard
               @highlightedTraining={{training}}
-              @onCardClick={{onCardClickStub}}
               @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
             />
           </template>,

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -36,6 +36,66 @@ module(
           assert.dom(screen.queryByRole('presentation')).doesNotExist();
         });
       });
+
+      module('when user clicks on the highlighted training card button', function () {
+        test('should not call onCardClick function', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord('training', _buildTraining({}));
+          const onCardClickStub = sinon.stub();
+          const onHighlightedCardButtonClickStub = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <TrainingCard
+                @isHighlighted={{true}}
+                @training={{training}}
+                @onCardClick={{onCardClickStub}}
+                @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
+              />
+            </template>,
+          );
+          await click(
+            screen.getByRole('button', {
+              name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more'),
+            }),
+          );
+
+          // then
+          sinon.assert.notCalled(onCardClickStub);
+          assert.ok(true);
+        });
+
+        test('should call onHighlightedCardButtonClick function', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const training = store.createRecord('training', _buildTraining({}));
+          const onCardClickStub = sinon.stub();
+          const onHighlightedCardButtonClickStub = sinon.stub();
+
+          // when
+          const screen = await render(
+            <template>
+              <TrainingCard
+                @isHighlighted={{true}}
+                @training={{training}}
+                @onCardClick={{onCardClickStub}}
+                @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
+              />
+            </template>,
+          );
+          await click(
+            screen.getByRole('button', {
+              name: t('pages.skill-review.recommended-engine.highlighted-card.learn-more'),
+            }),
+          );
+
+          // then
+          sinon.assert.calledOnceWithExactly(onHighlightedCardButtonClickStub, { trainingId: training.id });
+          assert.ok(true);
+        });
+      });
     });
 
     test('it renders with correct fields', async function (assert) {

--- a/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
+++ b/mon-pix/tests/integration/components/campaigns/assessment/results-recommendation-engine/training/card-test.gjs
@@ -71,7 +71,6 @@ module(
           // given
           const store = this.owner.lookup('service:store');
           const training = store.createRecord('training', _buildTraining({}));
-          const onCardClickStub = sinon.stub();
           const onHighlightedCardButtonClickStub = sinon.stub();
 
           // when
@@ -80,7 +79,6 @@ module(
               <TrainingCard
                 @isHighlighted={{true}}
                 @training={{training}}
-                @onCardClick={{onCardClickStub}}
                 @onHighlightedCardButtonClick={{onHighlightedCardButtonClickStub}}
               />
             </template>,


### PR DESCRIPTION
## ☀️ Problème
Actuellement, dans plausible, nous ne pouvons pas savoir si un utilisateur clique sur un CF mis en avant.

## ⛱️ Proposition
Ajouter deux évènements plausible:
- Un pour l'affichage d'un CF mis en avant sur la page de résultats.
- Un pour le clic sur le bouton du CF mis en avant (pour l'affichage de la modale). 

## 🧴 Remarques
N/A

## 🏊 Pour tester
- Aller sur la page de résultats de la campagne [EDUMULTIP](https://app-pr17455.review.pix.fr/campagnes/EDUMULTIP/) avec notre cher ami dave.
- Vérifier que les deux events remontent bien.
- Aller sur [une campagne sans CF mis en avant.](https://app-pr17455.review.pix.fr/campagnes/EVAL12345/)
- Vérifier qu'aucun des deux events ne remonte