### PR TITLE
[FEATURE] Restreindre l'attribution de la récompense de quête aux évaluations avec participation à une campagne (PIX-24210).

### DIFF
--- a/api/src/evaluation/application/assessments/assessment-controller.js
+++ b/api/src/evaluation/application/assessments/assessment-controller.js
@@ -53,11 +53,8 @@ async function completeAssessment(request) {
       });
     }
 
-    if (assessment.userId && isQuestEnabled) {
-      await questUsecases.rewardUser({ userId: assessment.userId });
-    }
-
     if (assessment.userId && assessment.isCampaignParticipationAvailable() && isQuestEnabled) {
+      await questUsecases.rewardUser({ userId: assessment.userId });
       await shareProfileRewardWithOrganization(assessment.campaignParticipationId, assessment.userId);
     }
 

--- a/api/tests/evaluation/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/evaluation/unit/application/assessments/assessment-controller_test.js
@@ -121,6 +121,40 @@ describe('Evaluation | Unit | Application | assessment-controller', function () 
     });
 
     context('quest rewards', function () {
+      it('should call the rewardUser use case if there is a userId and quest is enabled and a campaign participation available', async function () {
+        // given
+        const userId = 12;
+        const campaignParticipationId = 456;
+        const profileRewardId = 789;
+        assessment.userId = userId;
+        assessment.campaignParticipationId = campaignParticipationId;
+        assessment.isCampaignParticipationAvailable.returns(true);
+        featureToggles.get.resolves(true);
+        questUsecases.getQuestResultsForCampaignParticipation.resolves([{ profileRewardId }]);
+        evaluationUsecases.completeAssessment.resolves(assessment);
+
+        // when
+        await assessmentController.completeAssessment({ params: { id: assessmentId } });
+
+        // then
+        expect(questUsecases.rewardUser).to.have.been.calledWithExactly({
+          userId: 12,
+        });
+      });
+      it('should not call the rewardUser use case if there is no campaign participation available', async function () {
+        // given
+        featureToggles.get.resolves(true);
+        assessment.userId = 12;
+        assessment.isCampaignParticipationAvailable.returns(false);
+        evaluationUsecases.completeAssessment.resolves(assessment);
+
+        // when
+        await assessmentController.completeAssessment({ params: { id: assessmentId } });
+
+        // then
+        expect(questUsecases.rewardUser).to.not.have.been.called;
+      });
+
       it('should not call the rewardUser usecase if the questEnabled flag is false', async function () {
         // given
         featureToggles.get.resolves(false);
@@ -132,21 +166,6 @@ describe('Evaluation | Unit | Application | assessment-controller', function () 
 
         // then
         expect(questUsecases.rewardUser).to.have.not.been.called;
-      });
-
-      it('should call the rewardUser use case if there is a userId and quest is enabled', async function () {
-        // given
-        featureToggles.get.resolves(true);
-        assessment.userId = 12;
-        evaluationUsecases.completeAssessment.resolves(assessment);
-
-        // when
-        await assessmentController.completeAssessment({ params: { id: assessmentId } });
-
-        // then
-        expect(questUsecases.rewardUser).to.have.been.calledWithExactly({
-          userId: 12,
-        });
       });
 
       it('should not call the rewardUser use case if there is no userId', async function () {


### PR DESCRIPTION
## ☀️ Problème
`questUsecases.rewardUser` était appelé dès qu'un utilisateur terminait un assessment même en dehors de toute participation à une campagne. La récompense de quête (attestation) pouvait donc être attribuée à des évaluations qui n'étaient pas rattachées à une campagne.

## ⛱️ Proposition
On déplace l'appel à `rewardUser`  dans le bloc déjà conditionné par `assessment.isCampaignParticipationAvailable()`. La récompense de quête n'est donc attribuée que lorsque l'évaluation est dans le cadre d'une participation à une campagne. Les tests unitaires du contrôleur sont mis à jour en conséquence.

## 🧴 Remarques
RAS

## 🏊 Pour tester 
- Terminer une évaluation **sans** participation à une campagne → vérifier qu'aucune récompense de quête n'est attribuée à l'utilisateur.
- Terminer une évaluation **avec** une participation à une campagne → vérifier que la récompense de quête est bien attribuée.