### PR TITLE
[BUGFIX] Ne pas jeter d'erreur 500 lors de la concurrence de création d'invitation à un CDC (PIX-24219)

### DIFF
--- a/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
+++ b/api/src/team/infrastructure/repositories/certification-center-membership.repository.js
@@ -98,7 +98,16 @@ const countByUserId = async function (userId) {
 
 const create = async function ({ certificationCenterId, role, userId }) {
   const knexConn = DomainTransaction.getConnection();
-  await knexConn(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME).insert({ certificationCenterId, role, userId });
+  try {
+    await knexConn(CERTIFICATION_CENTER_MEMBERSHIP_TABLE_NAME).insert({ certificationCenterId, role, userId });
+  } catch (err) {
+    if (knexUtils.isUniqConstraintViolated(err)) {
+      throw new AlreadyExistingMembershipError(
+        `User is already member of certification center ${certificationCenterId}`,
+      );
+    }
+    throw err;
+  }
 };
 
 const findByCertificationCenterIdAndUserId = async function ({ certificationCenterId, userId }) {

--- a/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
+++ b/api/tests/team/integration/infrastructure/repositories/certification-center-membership.repository.test.js
@@ -110,6 +110,26 @@ describe('Integration | Team | Infrastructure | Repository | Certification Cente
         userId,
       });
     });
+
+    context('when a membership already exists for both user and certificationCenter', function () {
+      it('throws an AlreadyExistingMembershipError', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(certificationCenterMembershipRepository.create)({
+          certificationCenterId,
+          role: CERTIFICATION_CENTER_MEMBERSHIP_ROLES.MEMBER,
+          userId,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingMembershipError);
+      });
+    });
   });
 
   describe('#findByCertificationCenterIdAndUserId', function () {


### PR DESCRIPTION
## ☀️ Problème
On a eu deux erreurs 500 récemment sur la route `/api/organization-invitations/{id}/response`
`insert into "certification-center-memberships" ("certificationCenterId", "role", "userId") values ($1, $2, $3) - duplicate key value violates unique constraint "certification-center-memberships_userid_certificationcenterid_d"`

## ⛱️ Proposition
Faire en sorte de gerer ce cas d'erreur et ne pas faire crash l'API pour ce cas précis.

## 🧴 Remarques
L'ancienne méthode "save" gérait bien ce cas avec un try/catch, et la nouvelle méthode "create" n'avait pas ce garde fou. J'ai donc simplement reproduit le fonctionnement d'avant. 
On pourrait également faire un .onConflict().ignore() côté knex, mais la finalitée est la même.

## 🏊 Pour tester
Soyez créatifs pour tester en condition réelle :D 
Ou alors, en local, enlever le try/catch côté repo. Lancez le test associé, voir qu'il casse avec la même erreur.
