### PR TITLE
[TECH] Ajouter une contrainte NOT NULL sur les descriptions de la table combined_course_blueprints (PIX-24105)

### DIFF
--- a/api/db/migrations/20260910084810_add_not_null_constraint_to_descriptions_in_table_combined_course_blueprints.js
+++ b/api/db/migrations/20260910084810_add_not_null_constraint_to_descriptions_in_table_combined_course_blueprints.js
@@ -1,0 +1,37 @@
+// Make sure you properly test your migration, especially DDL (Data Definition Language)
+// ! If the target table is large, and the migration take more than 20 minutes, the deployment will fail !
+
+// You can design and test your migration to avoid this by following this guide
+// https://1024pix.atlassian.net/wiki/spaces/EDTDT/pages/3849323922/Cr+er+une+migration
+
+// If your migrations target :
+//
+// `answers`
+// `knowledge-elements`
+// `knowledge-element-snapshots`
+//
+// contact @team-captains, because automatic migrations are not active on `pix-datawarehouse-production`
+// this may prevent data replication to succeed the day after your migration is deployed on `pix-api-production`
+const TABLE_NAME = 'combined_course_blueprints';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.text('description').notNullable().alter();
+    table.text('prescriberDescription').notNullable().alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.text('description').nullable().alter();
+    table.text('prescriberDescription').nullable().alter();
+  });
+}

--- a/high-level-tests/e2e-playwright/helpers/db.ts
+++ b/high-level-tests/e2e-playwright/helpers/db.ts
@@ -512,7 +512,8 @@ export async function createCombinedCourseBlueprintInDB(name: string) {
     .insert({
       name,
       internalName: name,
-      description: null,
+      description: 'description',
+      prescriberDescription: 'prescriberDescription',
       illustration: null,
       createdAt: someDate,
       updatedAt: someDate,


### PR DESCRIPTION
## :question: Problème

Les colonnes `description` et `prescriberDescription` de la table `combined_course_blueprints` acceptent actuellement des valeurs `NULL`, alors que ces champs sont censés être toujours renseignés. Rien ne garantit l'intégrité de ces données au niveau de la base.

## :bulb: Proposition

- Ajouter une migration `20260910084810_add_not_null_constraint_to_descriptions_in_table_combined_course_blueprints.js` qui pose une contrainte `NOT NULL` sur les colonnes `description` et `prescriberDescription` de la table `combined_course_blueprints`.
- Le `down` de la migration rétablit les colonnes en `nullable`.

## :test_tube: Pour tester

- Lancer `npm run db:migrate` depuis `api/` et vérifier que la migration passe sans erreur.
- Vérifier en base que les colonnes `description` et `prescriberDescription` de `combined_course_blueprints` sont bien `NOT NULL`.
- Lancer `npm run db:rollback:latest` et vérifier que les colonnes redeviennent `nullable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf7pBWT9RioHpr6JxSKFxA
