### PR TITLE
[TECH] Répare les e2e de combined-course-blueprint

### DIFF
--- a/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
+++ b/high-level-tests/e2e-playwright/tests/pix-app/combined-course.test.ts
@@ -9,6 +9,8 @@ import {
 import { ReconciliationLoginPage } from '../../pages/pix-app/ReconciliationLoginPage.js';
 import { ReconciliationPage } from '../../pages/pix-app/ReconciliationPage.js';
 
+test.slow();
+
 test('pass a combined course as sco user and see the final result', async ({ page }) => {
   await createDataForCombinedCourse();
 


### PR DESCRIPTION
## 📚 Problème
On a un flaky sur les tests end-to-end. https://app.circleci.com/pipelines/gh/1024pix/pix/186733/workflows/d43fdbc3-7389-45e8-a214-0799dbc14fa4/jobs/2117793/tests

## 🎒 Proposition
On ajoute un test.slow() en amont du test 2e pour tripler le temps du timeout - en attendant de trouver mieux.

## 📐 Pour tester
CI au vert.
