### PR TITLE
[BUGFIX] Réparer un test E2E cassé

### DIFF
--- a/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/INDIVIDUAL_ENROLMENT.spec.ts
+++ b/high-level-tests/e2e-playwright/tests/recette-certif/enrolment/INDIVIDUAL_ENROLMENT.spec.ts
@@ -92,8 +92,8 @@ test(
       await expect(
         pixCertifProPage.getByText("Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau."),
       ).toBeVisible();
-      await pixCertifProPage.getByRole('button', { name: 'Fermer la notification' }).click();
       await pixCertifProPage.getByRole('button', { name: "Fermer la modale d'ajout de candidat" }).click();
+      await pixCertifProPage.getByRole('button', { name: 'Fermer la notification' }).click();
       const enrolledCandidatesSoFar = await sessionManagementPage.getEnrolledCandidatesData();
       expect(enrolledCandidatesSoFar).toMatchObject([
         {


### PR DESCRIPTION
## 📚 Problème

Avec les derniers changements PixUI, INDIVIDUAL_ENROLMENT casse
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/84a6119a-f2b0-444c-a4fb-a916884fee05" />
La modale d'ajout de candidat ne se ferme pas et le toast est en dessous donc non cliquable

## 🎒 Proposition

Échanger les actions "Fermer la notif" et "Fermer la modale"

## 🧑‍🏫 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 📐 Pour tester

Tests E2E verts :white_check_mark: 