### PR TITLE
[TECH] Utiliser un batchInsert pour mettre à jour les combinedCourseBlueprintShares (PIX-24221)

### DIFF
--- a/api/src/quest/infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js
+++ b/api/src/quest/infrastructure/repositories/combined-course-blueprints/combined-course-blueprint-repository.js
@@ -59,7 +59,7 @@ export async function save({ combinedCourseBlueprint }) {
 
   const doesCombinedCourseBlueprintExists = !!combinedCourseBlueprint.id;
   if (doesCombinedCourseBlueprintExists) {
-    await updateShares({ combinedCourseBlueprint, knexConn });
+    await _updateShares({ combinedCourseBlueprint, knexConn });
   }
 
   const quest = await questRepository.findById({ questId });
@@ -67,7 +67,7 @@ export async function save({ combinedCourseBlueprint }) {
   return _toDomain({ ...createdBlueprint[0], organizationIds: combinedCourseBlueprint.organizationIds }, quest);
 }
 
-async function updateShares({ combinedCourseBlueprint, knexConn }) {
+async function _updateShares({ combinedCourseBlueprint, knexConn }) {
   const currentCombinedCourseBlueprint = await findById({ id: combinedCourseBlueprint.id });
   if (!currentCombinedCourseBlueprint) {
     throw new NotFoundError(`No combined course blueprint found with id ${combinedCourseBlueprint.id}`);
@@ -91,12 +91,12 @@ async function updateShares({ combinedCourseBlueprint, knexConn }) {
   }
 
   if (organizationIdsToAdd.length > 0) {
-    for (const organizationId of organizationIdsToAdd) {
-      await knexConn('combined_course_blueprint_shares').insert({
-        organizationId,
-        combinedCourseBlueprintId: currentCombinedCourseBlueprint.id,
-      });
-    }
+    const combinedCourseBlueprintShares = organizationIdsToAdd.map((organizationId) => ({
+      organizationId,
+      combinedCourseBlueprintId: currentCombinedCourseBlueprint.id,
+    }));
+
+    await knexConn.batchInsert('combined_course_blueprint_shares', combinedCourseBlueprintShares);
   }
 }
 

--- a/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
+++ b/api/tests/quest/integration/infrastructure/repositories/combined-course-blueprint-repository_test.js
@@ -411,4 +411,38 @@ describe('Quest | Integration | Repository | combined-course-blueprint', functio
       expect(result.length).to.equal(0);
     });
   });
+
+  describe('#updateSharesCombinedCourseBlueprint', function () {
+    it('should update combined course blueprint share for a given organizationId', async function () {
+      // given
+      const organization1 = databaseBuilder.factory.buildOrganization();
+      const organization2 = databaseBuilder.factory.buildOrganization();
+      const organization3 = databaseBuilder.factory.buildOrganization();
+      const organization4 = databaseBuilder.factory.buildOrganization();
+
+      const combinedCourseBlueprintShare = databaseBuilder.factory.buildCombinedCourseBlueprintShare({
+        organizationId: organization1.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const combinedCourseBlueprint = await combinedCourseBluePrintRepository.findById({
+        id: combinedCourseBlueprintShare.combinedCourseBlueprintId,
+      });
+
+      const combinedCourseBlueprintToUpdate = domainBuilder.buildCombinedCourseBlueprint({
+        ...combinedCourseBlueprint,
+        organizationIds: [organization2.id, organization3.id],
+      });
+
+      // when
+      const result = await combinedCourseBluePrintRepository.save({
+        combinedCourseBlueprint: combinedCourseBlueprintToUpdate,
+      });
+
+      // then
+      expect(result.organizationIds).deep.equal([organization2.id, organization3.id]);
+      expect(result.organizationIds).not.contain(organization4.id);
+    });
+  });
 });


### PR DESCRIPTION
## 📚 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lors d'un update des combinedCourseBlueprintShares, la méthode save passe par une boucle créant de nombreuses requêtes SQL.

## 🎒 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Rationnalisation des requpêtes SQL par l'utilisation de la méthode batchInsert.

## 🧑‍🏫 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Ajout de tests sur la mise a jour des combinedCourseBlueprintShares

## 📐 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
