### PR TITLE
[TECH] Créer un package pix-types pour partager des types entre les applications

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@1024pix/epreuves-components": "^4.21.1",
         "@1024pix/oppsy": "^1.0.2",
+        "@1024pix/pix-types": "file:../packages/pix-types",
         "@aws-sdk/client-s3": "^3.121.0",
         "@aws-sdk/lib-storage": "^3.121.0",
         "@aws-sdk/s3-request-presigner": "^3.145.0",
@@ -127,6 +128,10 @@
         "node": "^24.18.0"
       }
     },
+    "../packages/pix-types": {
+      "name": "@1024pix/pix-types",
+      "version": "0.0.1"
+    },
     "node_modules/@1024pix/epreuves-components": {
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.21.1.tgz",
@@ -163,6 +168,10 @@
       "engines": {
         "node": "^16 || ^18 || ^20 || ^22 || ^24"
       }
+    },
+    "node_modules/@1024pix/pix-types": {
+      "resolved": "../packages/pix-types",
+      "link": true
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "11.9.3",

--- a/api/package.json
+++ b/api/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@1024pix/epreuves-components": "^4.21.1",
     "@1024pix/oppsy": "^1.0.2",
+    "@1024pix/pix-types": "file:../packages/pix-types",
     "@aws-sdk/client-s3": "^3.121.0",
     "@aws-sdk/lib-storage": "^3.121.0",
     "@aws-sdk/s3-request-presigner": "^3.145.0",

--- a/api/src/prescription/shared/domain/constants.js
+++ b/api/src/prescription/shared/domain/constants.js
@@ -1,13 +1,4 @@
-const CampaignParticipationStatuses = {
-  STARTED: 'STARTED',
-  SHARED: 'SHARED',
-};
-
-const CampaignTypes = {
-  ASSESSMENT: 'ASSESSMENT',
-  EXAM: 'EXAM',
-  PROFILES_COLLECTION: 'PROFILES_COLLECTION',
-};
+import { CampaignParticipationStatuses, CampaignTypes } from '@1024pix/pix-types';
 
 const CampaignExternalIdTypes = {
   STRING: 'STRING',

--- a/orga/app/utils/campaign-participation-statuses.ts
+++ b/orga/app/utils/campaign-participation-statuses.ts
@@ -1,1 +1,1 @@
-export type CampaignParticipationStatus = 'STARTED' | 'SHARED';
+export type { CampaignParticipationStatus } from '@1024pix/pix-types';

--- a/orga/app/utils/campaign-types.ts
+++ b/orga/app/utils/campaign-types.ts
@@ -1,1 +1,1 @@
-export type CampaignType = 'ASSESSMENT' | 'EXAM' | 'PROFILES_COLLECTION';
+export type { CampaignType } from '@1024pix/pix-types';

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.44",
         "@1024pix/eslint-plugin": "^3.0.4",
+        "@1024pix/pix-types": "file:../packages/pix-types",
         "@1024pix/pix-ui": "^68.1.2",
         "@1024pix/stylelint-config": "^5.1.37",
         "@babel/eslint-parser": "^7.28.6",
@@ -107,6 +108,11 @@
       "engines": {
         "node": "^24.18.0"
       }
+    },
+    "../packages/pix-types": {
+      "name": "@1024pix/pix-types",
+      "version": "0.0.1",
+      "dev": true
     },
     "node_modules/@1024pix/ember-testing-library": {
       "version": "3.0.44",
@@ -279,6 +285,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@1024pix/pix-types": {
+      "resolved": "../packages/pix-types",
+      "link": true
     },
     "node_modules/@1024pix/pix-ui": {
       "version": "68.1.2",

--- a/orga/package.json
+++ b/orga/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.44",
     "@1024pix/eslint-plugin": "^3.0.4",
+    "@1024pix/pix-types": "file:../packages/pix-types",
     "@1024pix/pix-ui": "^68.1.2",
     "@1024pix/stylelint-config": "^5.1.37",
     "@babel/eslint-parser": "^7.28.6",

--- a/packages/pix-types/index.d.ts
+++ b/packages/pix-types/index.d.ts
@@ -1,0 +1,15 @@
+export declare const CampaignParticipationStatuses: {
+  readonly STARTED: 'STARTED';
+  readonly SHARED: 'SHARED';
+};
+
+export declare const CampaignTypes: {
+  readonly ASSESSMENT: 'ASSESSMENT';
+  readonly EXAM: 'EXAM';
+  readonly PROFILES_COLLECTION: 'PROFILES_COLLECTION';
+};
+
+export type CampaignParticipationStatus =
+  (typeof CampaignParticipationStatuses)[keyof typeof CampaignParticipationStatuses];
+
+export type CampaignType = (typeof CampaignTypes)[keyof typeof CampaignTypes];

--- a/packages/pix-types/index.js
+++ b/packages/pix-types/index.js
@@ -1,0 +1,10 @@
+export const CampaignParticipationStatuses = Object.freeze({
+  STARTED: 'STARTED',
+  SHARED: 'SHARED',
+});
+
+export const CampaignTypes = Object.freeze({
+  ASSESSMENT: 'ASSESSMENT',
+  EXAM: 'EXAM',
+  PROFILES_COLLECTION: 'PROFILES_COLLECTION',
+});

--- a/packages/pix-types/package.json
+++ b/packages/pix-types/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@1024pix/pix-types",
+  "version": "0.0.1",
+  "description": "Types et constantes partagés entre l'API et les fronts Pix",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}


### PR DESCRIPTION
## 📚 Problème

On essaie de se diriger tout doucement vers l'adoption de Typescript sur notre codebase.

## 🎒 Proposition

Pour nous aider et éviter de redéfinir des types partagés par tous, on crée un package interne au monorepo accessible par toutes les apps.
Pour ce premier exemple, on y exporte `CampaignParticipationStatus` et `CampaignType` comme premier cas d'usage.

## 🧑‍🏫 Remarques

- Pourquoi du .js + .d.ts ? Pour l'instant nous n'avons pas de build `tsc` et Node ne `type-strip` pas les fichiers des modules. 

- La version du package `pix-types` est décorative

## 📐 Pour tester

🟩